### PR TITLE
fix JWT duplicate issue

### DIFF
--- a/api/common/helpers/tokenHelper.go
+++ b/api/common/helpers/tokenHelper.go
@@ -27,7 +27,7 @@ type SignedDetails struct{
 
 var userCollection *mongo.Collection = database.OpenCollection(database.Client, "user")
 
-var SECRET_KEY string = os.Getenv("SECRET_KEY")
+var SECRET_KEY string = os.Getenv("JWT_SECRET")
 
 
 func GenerateAllTokens(email string, firstName string,lastName string, userType string, uid string )(signedToken string, signedRefreshToken string, err error){

--- a/api/common/utils/encode.go
+++ b/api/common/utils/encode.go
@@ -10,7 +10,7 @@ import (
 )
 
 
-var SECRET_KEY string = os.Getenv("SECRET_KEY")
+var SECRET_KEY string = os.Getenv("JWT_SECRET")
 
 
 // Define a secret key for JWT


### PR DESCRIPTION
closes #154 

Remove the SECRET_KEY / JWT_SECRET split where two different env vars were
being used across the codebase to sign and validate JWT tokens. Standardise
all JWT signing to read from a single env var, eliminating the risk
of tokens signed by one helper being rejected by another.