### PR TITLE
fix: correct docker port mapping, CORS credentials conflict and replace hardcoded frontend URL in password reset email with env var

### DIFF
--- a/api/common/middleware/corsMiddleware.go
+++ b/api/common/middleware/corsMiddleware.go
@@ -1,14 +1,15 @@
 package middleware
 
-
 import (
-	// "net/http"
 	"github.com/gin-gonic/gin"
 )
 
 func CORSMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+		origin := c.Request.Header.Get("Origin")
+		if origin != "" {
+			c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
+		}
 		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With, X-UserID")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT, DELETE, PATCH")

--- a/api/common/utils/mail.go
+++ b/api/common/utils/mail.go
@@ -12,13 +12,14 @@ var EMAIL_FROM string = os.Getenv("EMAIL_FROM")
 var SMTP_Host string = os.Getenv("SMTP_Host")
 var SMTP_User string = os.Getenv("SMTP_User")
 var SMTP_Password string = os.Getenv("SMTP_Password")
+var FRONTEND_URL string = os.Getenv("FRONTEND_URL")
 
 func SendResetPasswordEmail(toEmail, resetToken string) error {
 	m := gomail.NewMessage()
 	m.SetHeader("From", EMAIL_FROM)
 	m.SetHeader("To", toEmail)
 	m.SetHeader("Subject", "Reset Password")
-	m.SetBody("text/html", "Click the following link to reset your password: <a href=\"http://localhost:3000/forgotpassword/new_password/?resetToken="+resetToken+"\">Reset Password</a>")
+	m.SetBody("text/html", "Click the following link to reset your password: <a href=\""+FRONTEND_URL+"/forgotpassword/new_password/?resetToken="+resetToken+"\">Reset Password</a>")
 
 	d := gomail.NewDialer(SMTP_Host, 2525, SMTP_User, SMTP_Password)
 

--- a/api/common/utils/mail.go
+++ b/api/common/utils/mail.go
@@ -4,6 +4,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"gopkg.in/gomail.v2"
 )
@@ -14,6 +15,13 @@ var SMTP_User string = os.Getenv("SMTP_User")
 var SMTP_Password string = os.Getenv("SMTP_Password")
 var FRONTEND_URL string = os.Getenv("FRONTEND_URL")
 
+func getSMTPPort() int {
+	if p, err := strconv.Atoi(os.Getenv("SMTP_Port")); err == nil {
+		return p
+	}
+	return 587
+}
+
 func SendResetPasswordEmail(toEmail, resetToken string) error {
 	m := gomail.NewMessage()
 	m.SetHeader("From", EMAIL_FROM)
@@ -21,7 +29,7 @@ func SendResetPasswordEmail(toEmail, resetToken string) error {
 	m.SetHeader("Subject", "Reset Password")
 	m.SetBody("text/html", "Click the following link to reset your password: <a href=\""+FRONTEND_URL+"/forgotpassword/new_password/?resetToken="+resetToken+"\">Reset Password</a>")
 
-	d := gomail.NewDialer(SMTP_Host, 2525, SMTP_User, SMTP_Password)
+	d := gomail.NewDialer(SMTP_Host, getSMTPPort(), SMTP_User, SMTP_Password)
 
 	if err := d.DialAndSend(m); err != nil {
 		fmt.Println("Error sending email:", err)

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
   expendit-backend:
     build: ./api/common
     ports:
-      - "9000:8080"
+      - "9000:9000"
     env_file:
       - ./api/common/.env
     depends_on:


### PR DESCRIPTION
closes #156 
The backend container was mapped to port 8080 in compose.yaml but the app
listens on port 9000, causing all requests to return 502. Additionally, the
CORS middleware was setting Access-Control-Allow-Origin: * alongside
Access-Control-Allow-Credentials: true, a combination browsers reject when
requests include Authorization headers. Port mapping corrected to 9000:9000
and CORS updated to reflect the request origin instead of using a wildcard.
also replace hardcoded frontend URL in password reset email with env var.