### PR TITLE
docs: PRD breakdown — product, architecture, data model, API, roadmap

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -101,3 +101,20 @@ Server-side emission to Upstat: `upload_success` (job completed),
 Shared with apparule's api.md §4 for ecosystem parity: versioned `/api/v1`,
 error envelope `{"error": {"code", "message"}}`, cursor pagination,
 idempotency keys on upload/purge/report creation.
+
+---
+
+## 5. Expansion surface (2026-07-16) **[Proposed]** — deltas, `/api/v1`
+
+| Group | Endpoints |
+| --- | --- |
+| Orgs | `POST /orgs` · `GET /orgs` · member CRUD (`role: owner|admin|member`) · org-scoped auth context header |
+| Bank links | `POST /bank-links` (provider session init) · provider webhook `/webhooks/bank` · `GET /bank-links` · `POST /bank-links/{id}/sync` · `PATCH` (pause/auto-confirm) · `DELETE ?purge=bool` |
+| Company statements | `POST /statements` (upload) · `GET /statements/{id}/mapping` (staged line items) · `PATCH /statements/{id}/mapping` (fix canonical keys) · `POST /statements/{id}/confirm` |
+| Ratios | `POST /ratios/compute {period}` · `GET /ratios?period` · `GET /ratios/{key}/trace` |
+| Taxes | `GET /tax/profile` · `PUT /tax/profile` · `GET /tax/estimates` · `POST /tax/filings` (wizard draft) · `POST /tax/filings/{id}/generate` · `POST /tax/filings/{id}/submit` (v2, provider-gated) · `GET /tax/filings` |
+
+Bank-synced transactions enter the existing import pipeline as jobs
+(`source: bank_sync`) — one staged-review path for every ingress. Statement
+mapping mirrors import review (staged → human confirm) with the
+`canonical_key` closed vocabulary.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,103 @@
+# Expendit — API Surface
+
+> Current surface verified against `internal/router/*.go`. Markers: **[Current]**,
+> **[PRD]**, **[Proposed]**.
+
+## 1. Current surface **[Current]** (api/common, :8080)
+
+All routes JSON unless noted; protected routes require `Authorization: Bearer <JWT>`
+and scope data to the token's `uid` claim.
+
+### Auth & users
+
+| Method & path | Auth | Notes |
+| --- | --- | --- |
+| `POST /users/signup`, `POST /signup` | public | duplicate registration paths (legacy alias) — consolidate at v1 **[Proposed]** |
+| `POST /users/signin`, `POST /login` | public, rate-limited | issues JWT |
+| `POST /auth/google` | public | Google sign-in |
+| `POST /users/forgot-password` | public, rate-limited | reset email |
+| `PATCH /users/reset-password` | public, rate-limited | token-based reset |
+| `POST /logout` | protected | |
+| `GET /users` | protected (admin) | password/refresh-token never serialized |
+| `GET /users/:user_id` | protected | |
+| `PUT /users/change-password` | protected | identity from JWT |
+| `PUT /users/:id` | protected | cannot change `user_type` |
+
+### Ledger
+
+| Group | Routes |
+| --- | --- |
+| `/expense` (protected) | `GET ""`, `GET /:id`, `GET /search`, `GET /user/:userID`, `POST /create`, `PUT /:id`, `DELETE /:id`, `GET /expenses/month/:userID`, `GET /month-expense/:userID` |
+| `/income` (protected) | `GET ""`, `GET /:id`, `GET /search`, `POST /create`, `PUT /:id`, `DELETE /:id`, `GET /incomes/monthly/:userID`, `GET /incomes/month/:userID` |
+| `/category` (protected) | `GET ""`, `GET /:id`, `GET /search`, `POST /create`, `PUT /:id`, `DELETE /:id` |
+
+(Path `:userID` segments are legacy — handlers enforce the JWT `uid`; v1
+removes them from paths. **[Proposed]**)
+
+### Import (EXP-002/003 core)
+
+| Method & path | Purpose |
+| --- | --- |
+| `POST /import/upload` | multipart file (CSV/tabular, PDF, receipt image) → creates job, parses, stages, categorizes, detects duplicates/anomalies, summarizes (synchronous today) |
+| `GET /import/:jobId` | job + staged transactions |
+| `PUT /import/transaction/:id/category` | user correction |
+| `POST /import/:jobId/confirm` | commit staged rows to ledger |
+| `DELETE /import/:jobId` | discard job + staging |
+
+### Reports
+
+| Method & path | Purpose |
+| --- | --- |
+| `GET /report/monthly/:userID` | income-vs-expense by month (bar chart data) |
+| `GET /report/chart/category/:userID` | totals by category |
+| `GET /report/chart/category/expenses/:userID` | expense breakdown by category |
+
+## 2. Target surface **[Proposed]** — deltas only, under `/api/v1`
+
+The v1 exercise is mostly *consolidation* (one signup path, JWT-scoped paths
+without `:userID`, error envelope, pagination) plus these new capabilities:
+
+### Downloadable reports (EXP-004) & data rights (USR-001/002)
+
+| Method & path | Purpose |
+| --- | --- |
+| `POST /api/v1/reports` | `{kind: monthly_summary\|cash_movement, period, format: pdf\|csv}` → artifact (stream or signed URL) |
+| `GET /api/v1/reports` | past artifacts (TTL'd) |
+| `POST /api/v1/account/export` | full-history export (`full_export`, CSV/JSON archive) — USR-001 |
+| `POST /api/v1/account/purge` | request full deletion (grace window) — USR-002 |
+| `DELETE /api/v1/account/purge` | cancel within grace |
+| `GET /api/v1/consent` · `POST /api/v1/consent` | ToS/privacy/AI-processing acceptance records |
+
+### Import hardening
+
+| Change | Why |
+| --- | --- |
+| `POST /import/upload` → `202 {job_id}`; processing moves to a worker | Synchronous AI budget (≤120 s) inside the request doesn't scale (architecture.md §4.2) |
+| `GET /import/:jobId` becomes the polling/streaming surface | Status field already models `processing/completed/failed` |
+| Explicit upload limits (size, MIME) with typed errors | Predictable failure surface |
+
+### Events (ECO-ANALYTICS)
+
+Server-side emission to Upstat: `upload_success` (job completed),
+`report_generation` (artifact created). Counters + coarse dimensions only
+(file_type, kind) — never amounts, descriptions, or categories.
+
+## 3. Gap analysis — requirement → current → needed
+
+| Requirement | Current | Gap |
+| --- | --- | --- |
+| EXP-001 preview landing | Landing exists, no example-report section | Web-only: demo-data preview section |
+| EXP-002 uploads | CSV/PDF/receipt-image implemented | Async processing, limits (hardening) |
+| EXP-003 AI categorization | Engine + correction + anomalies implemented | Anomaly UX outside import; correction feedback loop |
+| EXP-004 downloadable summaries | JSON aggregates only | `POST /api/v1/reports` + artifact rendering |
+| EXP-005 privacy hub | Nothing | Web page + D3 clause + AI-processing disclosure |
+| USR-001 export-all | Nothing | `account/export` |
+| USR-002 delete-all | Per-item deletes only | `account/purge` with grace |
+| ECO-AUTH | Local JWT auth (solid) | D1 integration when contract exists |
+| ECO-ANALYTICS | Nothing | D2 + two server-side events |
+
+## 4. Conventions **[Proposed]**
+
+Shared with apparule's api.md §4 for ecosystem parity: versioned `/api/v1`,
+error envelope `{"error": {"code", "message"}}`, cursor pagination,
+idempotency keys on upload/purge/report creation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,207 @@
+# Expendit — System Architecture
+
+> Companion to [prd.md](prd.md). Markers: **[Current]**, **[PRD]**, **[Proposed]**.
+
+## 1. Context — current state **[Current]**
+
+```mermaid
+flowchart LR
+    subgraph Users
+        U[Individual / SME user]
+    end
+
+    subgraph expendit.cuesoft.io
+        LAND[Landing page<br/>hero, features, how-it-works]
+        DASH[Dashboard suite<br/>expense, income, categories,<br/>history, import, reports, settings]
+    end
+
+    subgraph Backend — api/common Go/Gin :8080
+        AUTH[Auth: signup/signin/Google,<br/>reset + rate limiting]
+        LEDGER[Expenses / Incomes / Categories<br/>CRUD + search + monthly aggregates]
+        IMPORT[Import pipeline]
+        REPORT[Report aggregations]
+    end
+
+    subgraph Data & providers
+        MG[(MongoDB)]
+        RD[(Redis<br/>rate-limit counters)]
+        AI[Groq → Gemini<br/>extraction, categorization, narrative]
+    end
+
+    U --> LAND
+    U --> DASH
+    DASH -->|JWT bearer| AUTH
+    DASH --> LEDGER
+    DASH --> IMPORT
+    DASH --> REPORT
+    AUTH --> MG
+    AUTH --> RD
+    LEDGER --> MG
+    IMPORT --> MG
+    IMPORT --> AI
+    REPORT --> MG
+```
+
+The intelligence core is already here; what the PRD adds is drawn in §2.
+
+## 2. Context — target additions **[PRD + Proposed]**
+
+```mermaid
+flowchart LR
+    subgraph New surfaces
+        PREV[Example-report preview<br/>on landing, demo data only]
+        PRIV[Privacy hub page]
+        EXPORTS[Downloadable reports<br/>PDF / CSV]
+        RIGHTS[Export-all / delete-all<br/>account data rights]
+    end
+
+    subgraph Ecosystem — external
+        ACC[account.cuesoft.io]
+        UP[Upstat events]
+        CL[clients.cuesoft.io]
+        PH[privacy.cuesoft.io]
+    end
+
+    PREV --- PRIV
+    EXPORTS --- RIGHTS
+    PRIV -->|clause link| PH
+    RIGHTS -->|USR-001/002| API[api/common]
+    EXPORTS --> API
+    API -->|Upload Success,<br/>Report Generation| UP
+    API -->|verify sessions when D1 lands| ACC
+    DASHX[Dashboard] -.->|support| CL
+```
+
+## 3. Service breakdown
+
+### 3.1 api/common — the whole backend **[Current]**
+
+| Area | Packages / files | Behaviour |
+| --- | --- | --- |
+| Auth | `handler/user_controller.go`, `middleware/{auth,rate_limit}` | JWT (HS256, signing-method-guarded), login + password-flow rate limits, Google auth, logout, change/forgot/reset password |
+| Ledger | `handler/{expense,income,category}_controller.go` | Per-user CRUD + search; monthly aggregates (`/expense/expenses/month/:userID`, `/income/incomes/monthly/:userID`, …); identity enforced from JWT `uid` (not path params) |
+| Import | `service/{import_service,csv_parser,pdf_parser,ai_enhancer,categorization_engine,duplicate_detector,anomaly_engine,summary_generator}.go` | See §4 |
+| Reports | `handler/report_controller.go` | Mongo aggregations: monthly income-vs-expense (bar), by-category, category-expenses |
+
+### 3.2 web — Next.js dashboard + landing **[Current]**
+
+Routes: `/` (marketing sections), `/signin`, `/signup`, `/forgot-password[/new-password]`,
+`/dashboard`, `/expense`, `/income`, `/categories`, `/history`, `/import`,
+`/reports`, `/settings`, `/change-password`. Target adds: landing preview
+section (EXP-001), `/privacy` (EXP-005), report-download UI (EXP-004),
+data-rights controls in `/settings` (USR-001/002). **[Proposed placement]**
+
+## 4. The import pipeline (core asset) **[Current]**
+
+### 4.1 Flow
+
+```mermaid
+flowchart TD
+    UP[POST /import/upload<br/>multipart file] --> DET{detectFileType<br/>extension + magic bytes}
+    DET -->|csv / xlsx / txt| CSV[ParseCSV — tabular parser]
+    DET -->|pdf| PDFT[ExtractPDFText]
+    PDFT -->|text ok| AIX[AI extraction, chunked<br/>120s budget]
+    AIX -->|0 rows| RGX[Regex PDF fallback parser]
+    DET -->|jpg png webp heic| VIS[AI vision extraction<br/>requires GROQ/GEMINI key]
+    CSV --> STAGE
+    AIX --> STAGE
+    RGX --> STAGE
+    VIS --> STAGE
+    STAGE[Staged ImportedTransactions] --> DUP[Duplicate detector]
+    DUP --> CAT[Categorization engine<br/>+ AI enhancer]
+    CAT --> ANOM[Anomaly engine<br/>large txn, spike, abnormal category, duplicate charge]
+    ANOM --> SUM[Summary generator<br/>totals, net cash flow, by-category,<br/>monthly trends + AI narrative]
+    SUM --> JOB[(ImportJob: processing→completed/failed)]
+    JOB --> REVIEW[User review:<br/>correct categories per txn]
+    REVIEW --> CONFIRM[Confirm → ledger writes]
+    REVIEW --> DISCARD[Discard → job + staging removed]
+```
+
+AI provider selection: `GROQ_API_KEY` → `GEMINI_API_KEY` → none (CSV/PDF regex
+still work; image uploads error with guidance).
+
+### 4.2 Known architectural debts **[Current → Proposed fixes]**
+
+| Debt | Consequence | Proposed fix |
+| --- | --- | --- |
+| `ProcessImport` runs synchronously inside the upload request (AI budget alone up to 120s) | Slow requests, gateway timeouts on big statements, no horizontal isolation | Async job worker: upload returns `202 + jobId` immediately; worker consumes a Redis-backed queue; the `ImportJob.status` field already models this — Phase 2 roadmap |
+| Raw file bytes are parsed in-memory and not persisted | Re-processing impossible; but privacy-friendly | Keep no-persistence as the *default* (privacy-first) and document it in the privacy hub; optional debug retention behind explicit consent **[Proposed]** |
+| PDF text sampled into logs (`[pdf] sample: …`) | **Financial data in logs** — conflicts with §7 privacy stance | Remove/behind debug flag before privacy hub ships (roadmap P1 item) |
+| Anomalies live only on the job | Not visible after leaving import screen | Anomaly feed/badges in dashboard (EXP-003 UX) |
+
+## 5. Core sequences
+
+### 5.1 Statement import — current **[Current]**
+
+```mermaid
+sequenceDiagram
+    actor U as User
+    participant W as web /import
+    participant A as api/common
+    participant AI as Groq/Gemini
+    participant M as MongoDB
+
+    U->>W: choose file (CSV/PDF/receipt)
+    W->>A: POST /import/upload (multipart, JWT)
+    A->>M: create ImportJob (processing)
+    A->>AI: extract / categorize / narrate
+    AI-->>A: transactions + labels + summary
+    A->>M: staged transactions, anomalies, summary
+    A-->>W: job result (synchronous today)
+    U->>W: review, fix categories
+    W->>A: PUT /import/transaction/:id/category
+    U->>W: confirm
+    W->>A: POST /import/:jobId/confirm
+    A->>M: write expenses/incomes to ledger
+```
+
+### 5.2 Downloadable report — target (EXP-004) **[Proposed]**
+
+```mermaid
+sequenceDiagram
+    actor U as User
+    participant W as web /reports
+    participant A as api/common
+    participant M as MongoDB
+
+    U->>W: pick period + report type, "Download"
+    W->>A: POST /api/v1/reports (period, format: pdf|csv)
+    A->>M: aggregate (reuses report pipelines)
+    A->>A: render artifact (CSV writer / PDF template)
+    A-->>W: signed/streamed download
+    A--)UP: event: Report Generation (counter only)
+```
+
+### 5.3 Delete-all data right — target (USR-002) **[Proposed]**
+
+```mermaid
+sequenceDiagram
+    actor U as User
+    participant W as web /settings
+    participant A as api/common
+    participant M as MongoDB
+
+    U->>W: "Delete my financial history"
+    W-->>U: consequences + type-to-confirm
+    W->>A: POST /api/v1/account/purge
+    A->>M: mark purge_requested (grace window, e.g. 7 days)
+    Note over A,M: reversible during grace; then hard-delete<br/>expenses, incomes, categories, imports, jobs
+    A-->>W: scheduled + effective date
+```
+
+## 6. Deployment view **[Current]**
+
+- Compose: mongo, redis, api-common :8080, web :3000 (healthcheck-gated).
+- Helm: standard-form chart (api-common, web; `envFrom` secret hook; values
+  document the external MongoDB/Redis requirement).
+- Terraform: cluster-agnostic helm release.
+- Target additions: worker deployment for async imports (same image,
+  worker command) **[Proposed]**, no new stateful services.
+
+## 7. Cross-repo dependencies
+
+| ID | Dependency | Blocks |
+| --- | --- | --- |
+| D1 | `account.cuesoft.io` contract | ECO-AUTH migration (local JWT is the interim) |
+| D2 | Upstat event-ingestion API | ECO-ANALYTICS events |
+| D3 | Expendit clause on `privacy.cuesoft.io` | EXP-005 copy |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -3,6 +3,11 @@
 > Companion to [prd.md](prd.md) / [architecture.md](architecture.md).
 > Markers: **[Current]**, **[PRD]**, **[Proposed]**.
 
+> **X-5 alignment (2026-07-16):** cloud system of record is **Aiven
+> Postgres**; the Mongo entities below describe the *current* code and the
+> self-host default until the Mongo→Postgres migration executes with E-4.
+> Entity shapes are store-agnostic.
+
 ## 1. Current entities **[Current]** (MongoDB)
 
 ```mermaid

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,145 @@
+# Expendit — Data Model
+
+> Companion to [prd.md](prd.md) / [architecture.md](architecture.md).
+> Markers: **[Current]**, **[PRD]**, **[Proposed]**.
+
+## 1. Current entities **[Current]** (MongoDB)
+
+```mermaid
+erDiagram
+    USER ||--o{ EXPENSE : owns
+    USER ||--o{ INCOME : owns
+    USER ||--o{ CATEGORY : owns
+    USER ||--o{ IMPORT_JOB : runs
+    IMPORT_JOB ||--o{ IMPORTED_TRANSACTION : stages
+
+    USER {
+        objectid _id PK
+        string user_id
+        string first_name
+        string last_name
+        string email
+        string password "bcrypt; json:- (never serialized)"
+        string user_type "ADMIN | USER"
+        string refresh_token "json:-"
+        datetime created_at
+    }
+    EXPENSE {
+        objectid _id PK
+        string userid
+        string name
+        float amount
+        string category
+        datetime date
+    }
+    INCOME {
+        objectid _id PK
+        string userid
+        string name
+        float amount
+        string category
+        datetime date
+    }
+    CATEGORY {
+        objectid _id PK
+        string userid
+        string name
+        string type "expense | income"
+    }
+    IMPORT_JOB {
+        objectid _id PK
+        string userid
+        string status "processing | completed | failed"
+        string file_name
+        string file_type "csv | pdf | image"
+        int total_parsed
+        int duplicates_found
+        int imported
+        json summary "totals, net, by_category, monthly_trends"
+        string ai_summary "LLM narrative"
+        json anomalies "typed list"
+        datetime created_at
+        datetime completed_at
+    }
+    IMPORTED_TRANSACTION {
+        objectid _id PK
+        objectid job_id FK
+        string userid
+        string description
+        float amount
+        string direction "income | expense"
+        string category "AI-assigned, user-correctable"
+        bool is_duplicate
+        datetime txn_date
+    }
+```
+
+Notes:
+
+- Field names above are representative of the Go structs in
+  `internal/model/`; `password`/`refresh_token` are excluded from all JSON
+  responses (`json:"-"`).
+- Anomaly vocabulary **[Current]**: `large_transaction`, `spending_spike`,
+  `abnormal_category`, `duplicate_charge`.
+- Raw uploaded file bytes are **not persisted** — parsed in-memory only.
+  This is a privacy feature to keep, and to document (prd.md §8.3).
+
+## 2. Target additions **[Proposed]**
+
+```mermaid
+erDiagram
+    USER ||--o{ REPORT_ARTIFACT : downloads
+    USER ||--o| PURGE_REQUEST : "may file"
+    USER ||--o{ CONSENT_RECORD : signs
+
+    REPORT_ARTIFACT {
+        objectid _id PK
+        string userid
+        string kind "monthly_summary | cash_movement | full_export"
+        string format "pdf | csv | json"
+        string period "e.g. 2026-06"
+        string object_key "or streamed; TTL"
+        datetime created_at
+    }
+    PURGE_REQUEST {
+        objectid _id PK
+        string userid
+        string status "pending | cancelled | executed"
+        datetime requested_at
+        datetime effective_at "end of grace window"
+    }
+    CONSENT_RECORD {
+        objectid _id PK
+        string userid
+        string document "tos | privacy | ai_processing"
+        string version
+        datetime accepted_at
+    }
+```
+
+- `REPORT_ARTIFACT` backs EXP-004 (downloadables) and USR-001 (full export is
+  just `kind: full_export`).
+- `PURGE_REQUEST` backs USR-002 with a grace window (architecture.md §5.3).
+- `CONSENT_RECORD` mirrors apparule's model for ecosystem parity; the
+  `ai_processing` document records acceptance of third-party AI extraction
+  (prd.md §6, open question 1).
+
+## 3. Identity mapping for D1 (account.cuesoft.io) **[Proposed]**
+
+When the central account service lands, `USER` gains a nullable
+`account_subject` column; login via D1 links-or-creates the local user row.
+Local credentials remain valid through a deprecation window, then password
+fields are dropped. This keeps every owned collection (`userid` scoping)
+untouched during migration.
+
+## 4. Data classification & handling **[PRD §5/§7]**
+
+| Class | Data | Rules |
+| --- | --- | --- |
+| High-sensitivity | Transactions (all), import staging, summaries, AI narratives, uploaded file bytes (in flight) | Never in logs (the current `[pdf] sample:` log line must go — architecture.md §4.2); TLS in transit; third-party AI processing disclosed; raw files not at rest |
+| Sensitive | User identity, consent, purge requests | Standard PII handling; consent/purge rows immutable audit records |
+| Operational | Job status/counters, event counters to Upstat | Safe for logs/metrics; Upstat events are **counters only, never amounts or descriptions** |
+
+Retention defaults **[Proposed, to ratify]**: ledger data until user deletion
+(USR-002); import jobs + staging 90 days after confirm/discard; report
+artifacts 30 days (regenerable); raw uploads never at rest.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -143,3 +143,69 @@ untouched during migration.
 Retention defaults **[Proposed, to ratify]**: ledger data until user deletion
 (USR-002); import jobs + staging 90 days after confirm/discard; report
 artifacts 30 days (regenerable); raw uploads never at rest.
+
+---
+
+## 5. Expansion entities (2026-07-16) **[Proposed]**
+
+```mermaid
+erDiagram
+    USER ||--o{ ORG_MEMBER : "belongs to"
+    ORG ||--o{ ORG_MEMBER : has
+    ORG ||--o{ BANK_LINK : links
+    BANK_LINK ||--o{ BANK_SYNC : "runs"
+    ORG ||--o{ FIN_STATEMENT : uploads
+    FIN_STATEMENT ||--o{ LINE_ITEM : "normalized into"
+    ORG ||--o{ RATIO_REPORT : computes
+    ORG ||--o{ TAX_PROFILE : configures
+    TAX_PROFILE ||--o{ TAX_ESTIMATE : produces
+    TAX_PROFILE ||--o{ TAX_FILING : files
+
+    ORG { objectid _id PK
+        string name
+        string kind "personal | company"
+        string currency
+        string country }
+    BANK_LINK { objectid _id PK
+        objectid org_id FK
+        string provider "mono|okra|plaid — to ratify"
+        string institution
+        string masked_account
+        string status "active|reauth_required|paused"
+        datetime last_synced_at }
+    FIN_STATEMENT { objectid _id PK
+        objectid org_id FK
+        string kind "balance_sheet|income_statement|cash_flow"
+        string period "e.g. 2026-Q2 / FY2025"
+        string source_file_type
+        string mapping_status "staged|confirmed" }
+    LINE_ITEM { objectid _id PK
+        objectid statement_id FK
+        string canonical_key "current_assets|inventory|total_debt|revenue|cogs|net_income|..."
+        string source_label "as it appeared in the upload"
+        float amount }
+    RATIO_REPORT { objectid _id PK
+        objectid org_id FK
+        string period
+        json ratios "key → {value, formula, inputs[line_item ids], benchmark_band}"
+        datetime computed_at }
+    TAX_FILING { objectid _id PK
+        objectid org_id FK
+        string kind "pit|cit|vat"
+        string period
+        string status "draft|generated|submitted|accepted"
+        json computed_fields "each with input trace"
+        string artifact_key "generated forms"
+        datetime filed_at }
+```
+
+Notes: existing per-user collections become org-scoped (`org_id`) with a
+personal org auto-created per user (migration: `userid` → personal org). The
+`canonical_key` vocabulary is the closed mapping target for AI-suggested
+line mapping (pages.md B6) — same schema-as-boundary pattern as elsewhere.
+Ratio formulas persist **with their inputs** so every gauge is auditable
+(MI-8 trace). Tax computed fields carry input traces for the wizard's
+"how we got this" expanders; filings are immutable once submitted.
+Bank credentials are never stored — only provider tokens, encrypted, with
+provider-side revocation honored (BNK-002 unlink offers keep-or-purge for
+already-imported transactions).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -119,3 +119,11 @@ until a real customer needs it.
   `sandbox-e306a` (per-product prefixes `expendit/<env>/…`) for capture
   media, exports, and artifacts. Self-host compose keeps its bundled
   stores. ☑
+- **X-6 Environments & deploy gating (RATIFIED 2026-07-16, deliberate
+  deviation from the cueprise norm)**: `stg` = **sandbox** and is the ONLY
+  environment — no production deployment exists for these products. Secrets
+  live in Doppler `<project>/stg`. Because these repos are **open source**,
+  merge-to-main must NOT deploy: main-merge runs build+test only. **Deploys
+  happen exclusively on tag creation (`v*`)**, treated as production-grade:
+  a GitHub tag ruleset restricts `v*` creation to owner-level access, and the
+  deploy workflow additionally runs in a protected GitHub environment. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,72 @@
+# Expendit — Decision Sheet
+
+> Ratify by checking a box; each decision flips its **[Proposed]** tags to
+> **[Decided]** and unblocks the listed phases. Status: ☐ open · ☑ ratified.
+
+## E-1 · Bank aggregator — gates Phase 3 (Bank linking)
+
+| Option | For | Against |
+| --- | --- | --- |
+| **(a) Mono (NG-first) + Plaid added later for international** ⭐ | The surviving credible NG aggregator (Okra wound down in 2025); direct fit for the core market; Plaid layers on cleanly behind the same `BANK_LINK.provider` field | Two integrations over time |
+| (b) Plaid only | One global provider | NG institution coverage is the whole point of v1 |
+| (c) Build direct bank integrations | No middleman | Not remotely worth it at this stage |
+
+**Also ratify with it:** consent UX = provider-hosted flow (their widget), we
+store only provider tokens (encrypted) + masked metadata; sync cadence default
+**daily + manual refresh**.
+
+☐ Ratified: option ___
+
+## E-2 · Tax jurisdiction & filing path — gates Phase 5 (Tax center)
+
+**Recommendation ⭐: Nigeria-first.** v1 computes **PIT (personal), CIT
+(company estimate), VAT summary** from the categorized ledger + mapped
+statements, and generates **filing-ready documents** (guided handoff). Direct
+e-filing (TAX-003) only lands where a credible API/partner exists — evaluated
+after v1 ships. Other jurisdictions = explicit later scope, config-driven via
+the tax-profile model.
+
+☐ Ratified (jurisdiction: ___)
+
+## E-3 · AI processing of financial data — gates the privacy hub copy (Phase 0)
+
+| Option | For | Against |
+| --- | --- | --- |
+| **(a) Keep Groq→Gemini with explicit disclosure + `ai_processing` consent; self-hosted model as a roadmap item for cloud** ⭐ | Works today; honest; consent recorded per user | Financial data transits third parties (disclosed) |
+| (b) Self-hosted extraction model before launch | Strongest privacy story | Big ML lift now; blocks everything on it |
+| (c) Drop AI features | — | Guts EXP-003 |
+
+☐ Ratified: option ___
+
+## E-4 · Org model migration — gates Phase 4 (Company financials)
+
+**Recommendation ⭐:** introduce `ORG` with **auto-created personal org per
+user** (migration maps `userid` scoping → personal org); company orgs with
+owner/admin/member roles. One-way, reversible-by-backup migration executed at
+the start of Phase 4, not before (personal features don't need it).
+
+☐ Ratified
+
+## E-5 · Retention defaults — published in the privacy hub (Phase 0)
+
+**Recommendation ⭐:** raw uploads **never at rest** (parse in-memory, keep
+the current behavior) · import jobs + staging **90 days** after
+confirm/discard · report artifacts **30 days** (regenerable) · ledger data
+until user deletion · purge grace window **7 days**.
+
+☐ Ratified (or adjust: ___)
+
+## E-6 · Currency handling
+
+**Recommendation ⭐:** v1 = **single currency per org** (₦ default, set at org
+creation); no FX conversion. Multi-currency consolidation stays a non-goal
+until a real customer needs it.
+
+☐ Ratified
+
+## Cross-cutting
+
+- **X-1 account.cuesoft.io**: OIDC target; local JWT interim; migration per
+  data-model.md §3. ☐
+- **X-2 Docs platform**: GitBook space per product, Git-synced; Scalar API
+  refs. ☐

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -104,3 +104,18 @@ until a real customer needs it.
   consumer-API keys to third-party AI vendors in cloud deployments — data
   stays inside GCP, which strengthens every privacy disclosure. Self-host
   fallback: bring-your-own Gemini/Groq key via env (existing code path). ☑
+- **X-5 Data plane (RATIFIED 2026-07-16, per-product DB decided by delegation)**:
+  **Aiven Postgres** as the system of record — financial aggregation, audit
+  trails, ratio/tax traces, and org joins are SQL-shaped. Mongo→Postgres
+  migration is scheduled WITH the E-4 org migration (one migration, not two);
+  self-host compose keeps Mongo until then, then switches to a Postgres
+  container.
+  **Shared Redis**: the sandbox **Aiven Redis** instance, tenancy by
+  **`REDIS_DB` index** (the irealty pattern: discrete `REDIS_HOST/PORT/
+  USERNAME/PASSWORD/TLS/DB` vars; e.g. irealty prd=0, stg/dev=1) — indices
+  per product/config assigned in Doppler by the owner. **Doppler is the env
+  source of truth**: project `expendit` with `dev / dev_personal / stg / prd`
+  configs (already created). **Object storage**: the **default Cloud Storage bucket** in
+  `sandbox-e306a` (per-product prefixes `expendit/<env>/…`) for capture
+  media, exports, and artifacts. Self-host compose keeps its bundled
+  stores. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -77,7 +77,12 @@ until a real customer needs it.
   sign-in/sign-up screens **in-app** (own UI per its design system,
   Firebase Auth underneath: Google sign-in + email/password flows). The
   central facade fronts the same Firebase project later without contract
-  changes; in-app screens then become optional, not obsolete. Environment/secrets live in **Doppler**
+  changes; in-app screens then become optional, not obsolete. **HARDENED
+  2026-07-16: Google sign-in is the ONLY method — no username/password
+  signup or login, product-wide.** Email/Password provider disabled at
+  the Firebase project; backends reject non-Google-provider tokens
+  (`provider-not-allowed`); UI ships exactly one auth CTA. Full contract:
+  [flows/auth.md](flows/auth.md). Environment/secrets live in **Doppler**
   (`cueprise/cuesoft_stg`; see also the `cuesoft-iac` project) — CLI token
   currently expired (`doppler login` to refresh); config names to be mirrored
   into docs once readable. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -80,3 +80,9 @@ until a real customer needs it.
   into docs once readable. ☑
 - **X-2 Docs platform**: GitBook space per product, Git-synced; Scalar API
   refs. ☑
+- **X-3 Cloud deployment target (RATIFIED, directive)**: all backend
+  services run on **Google Cloud Run** (per-service containers — the same
+  `cuesoft/<repo>-<service>` images), following the cueprise pattern
+  (IaC precedent in `cuesoft-iac`); frontends deploy to **Firebase App
+  Hosting**. Helm + terraform in `deploy/` remain the **self-host** path —
+  cloud and self-host share images, not manifests. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -40,7 +40,10 @@ the tax-profile model.
 | (b) Self-hosted extraction model before launch | Strongest privacy story | Big ML lift now; blocks everything on it |
 | (c) Drop AI features | — | Guts EXP-003 |
 
-☑ Ratified: option (a) Groq→Gemini + disclosure/consent
+☑ Ratified: option (a) — **revised by X-4 (2026-07-16): cloud uses Vertex AI
+(Gemini, ADC) instead of consumer Groq/Gemini APIs; financial data stays in
+GCP. Disclosure + `ai_processing` consent still apply; Groq/Gemini env keys
+remain the self-host fallback.**
 
 ## E-4 · Org model migration — gates Phase 4 (Company financials)
 
@@ -94,3 +97,10 @@ until a real customer needs it.
   (IaC precedent in `cuesoft-iac`); frontends deploy to **Firebase App
   Hosting**. Helm + terraform in `deploy/` remain the **self-host** path —
   cloud and self-host share images, not manifests. ☑
+- **X-4 AI platform (RATIFIED, directive 2026-07-16)**: AI features use
+  **Vertex AI** (Gemini via `{region}-aiplatform.googleapis.com`, ADC from the
+  service account — the `cuesoft-iac/functions/cueprise-gemini-proxy` pattern;
+  reference model `gemini-2.5-flash-lite`, region `us-central1`). No
+  consumer-API keys to third-party AI vendors in cloud deployments — data
+  stays inside GCP, which strengthens every privacy disclosure. Self-host
+  fallback: bring-your-own Gemini/Groq key via env (existing code path). ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -73,8 +73,11 @@ until a real customer needs it.
 - **X-1 account.cuesoft.io / identity (RATIFIED)**: interim + sandbox identity
   is **Firebase Authentication on GCP project `sandbox-e306a`** ("sandbox") —
   Google sign-in + email flows come from Firebase; services verify Firebase ID
-  tokens (OIDC-compatible). The `account.cuesoft.io` facade fronts this later
-  without contract changes. Environment/secrets live in **Doppler**
+  tokens (OIDC-compatible). `account.cuesoft.io` **is not built yet** — each app replicates the
+  sign-in/sign-up screens **in-app** (own UI per its design system,
+  Firebase Auth underneath: Google sign-in + email/password flows). The
+  central facade fronts the same Firebase project later without contract
+  changes; in-app screens then become optional, not obsolete. Environment/secrets live in **Doppler**
   (`cueprise/cuesoft_stg`; see also the `cuesoft-iac` project) — CLI token
   currently expired (`doppler login` to refresh); config names to be mirrored
   into docs once readable. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3,6 +3,10 @@
 > Ratify by checking a box; each decision flips its **[Proposed]** tags to
 > **[Decided]** and unblocks the listed phases. Status: ☐ open · ☑ ratified.
 
+> **RATIFIED 2026-07-16** — all recommendations approved wholesale ("decisions
+> look solid"). Where other docs still carry **[Proposed]** on these topics,
+> this sheet governs; tags flip to **[Decided]** as docs are next touched.
+
 ## E-1 · Bank aggregator — gates Phase 3 (Bank linking)
 
 | Option | For | Against |
@@ -15,7 +19,7 @@
 store only provider tokens (encrypted) + masked metadata; sync cadence default
 **daily + manual refresh**.
 
-☐ Ratified: option ___
+☑ Ratified: option (a) Mono NG-first, Plaid later
 
 ## E-2 · Tax jurisdiction & filing path — gates Phase 5 (Tax center)
 
@@ -26,7 +30,7 @@ e-filing (TAX-003) only lands where a credible API/partner exists — evaluated
 after v1 ships. Other jurisdictions = explicit later scope, config-driven via
 the tax-profile model.
 
-☐ Ratified (jurisdiction: ___)
+☑ Ratified (jurisdiction: Nigeria)
 
 ## E-3 · AI processing of financial data — gates the privacy hub copy (Phase 0)
 
@@ -36,7 +40,7 @@ the tax-profile model.
 | (b) Self-hosted extraction model before launch | Strongest privacy story | Big ML lift now; blocks everything on it |
 | (c) Drop AI features | — | Guts EXP-003 |
 
-☐ Ratified: option ___
+☑ Ratified: option (a) Groq→Gemini + disclosure/consent
 
 ## E-4 · Org model migration — gates Phase 4 (Company financials)
 
@@ -45,7 +49,7 @@ user** (migration maps `userid` scoping → personal org); company orgs with
 owner/admin/member roles. One-way, reversible-by-backup migration executed at
 the start of Phase 4, not before (personal features don't need it).
 
-☐ Ratified
+☑ Ratified
 
 ## E-5 · Retention defaults — published in the privacy hub (Phase 0)
 
@@ -54,7 +58,7 @@ the current behavior) · import jobs + staging **90 days** after
 confirm/discard · report artifacts **30 days** (regenerable) · ledger data
 until user deletion · purge grace window **7 days**.
 
-☐ Ratified (or adjust: ___)
+☑ Ratified as recommended
 
 ## E-6 · Currency handling
 
@@ -62,11 +66,17 @@ until user deletion · purge grace window **7 days**.
 creation); no FX conversion. Multi-currency consolidation stays a non-goal
 until a real customer needs it.
 
-☐ Ratified
+☑ Ratified
 
 ## Cross-cutting
 
-- **X-1 account.cuesoft.io**: OIDC target; local JWT interim; migration per
-  data-model.md §3. ☐
+- **X-1 account.cuesoft.io / identity (RATIFIED)**: interim + sandbox identity
+  is **Firebase Authentication on GCP project `sandbox-e306a`** ("sandbox") —
+  Google sign-in + email flows come from Firebase; services verify Firebase ID
+  tokens (OIDC-compatible). The `account.cuesoft.io` facade fronts this later
+  without contract changes. Environment/secrets live in **Doppler**
+  (`cueprise/cuesoft_stg`; see also the `cuesoft-iac` project) — CLI token
+  currently expired (`doppler login` to refresh); config names to be mirrored
+  into docs once readable. ☑
 - **X-2 Docs platform**: GitBook space per product, Git-synced; Scalar API
-  refs. ☐
+  refs. ☑

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,52 @@
+# Deployment — Cloud Contract
+
+> Implements decision X-3. Cloud deploys follow the proven cueprise/getpp
+> patterns (workflows verified 2026-07-16); provisioning goes through the
+> **cuesoft-iac** Pulumi ecosystem — never ad-hoc gcloud. Self-hosting via
+> `deploy/` (compose/helm/terraform) is unchanged and shares only images.
+
+## 1. Topology
+
+| Surface | Runs on | Provisioned by |
+| --- | --- | --- |
+| `api/common` (Go) | Cloud Run | cuesoft-iac stack `expendit` |
+| `web` (Next.js) | **Firebase App Hosting** | App Hosting backend |
+
+## 2. Provisioning (cuesoft-iac)
+
+- **Pulumi, bun runtime**; state in `gs://cuesoft-iac-pulumi-state-bucket`;
+  per-product stack (`Pulumi.<product>.yaml`) added alongside existing ones
+  (getpp, swaves, …).
+- Cloud Run services instantiate the shared module
+  `common/modules/gcp/cloud-run-service.ts`; the GitHub→GCP deploy identity
+  uses **Workload Identity Federation** (`common/helpers/wif.ts`) — no
+  service-account keys in GitHub.
+- Secrets/env flow from **Doppler** (`cueprise/cuesoft_stg` pattern) into
+  Cloud Run env; the repo's `.env.example` files document the variable
+  names, Doppler owns values.
+
+## 3. CI/CD (GitHub Actions, cueprise/getpp pattern)
+
+| Workflow | Trigger | Does |
+| --- | --- | --- |
+| `build-and-test.yml` | PRs | build + tests per service |
+| `build-push-and-release-staging.yml` | push to `main` | matrix over services: buildx (GHA cache) → push `cuesoft/expendit-<service>` (tags: `latest` + `sha`) → Cloud Run deploy **by image digest** via WIF |
+| `build-push-and-release-production.yml` | GitHub Release | same, pinned to the release commit; frontend rollout via `firebase-tools apphosting:rollouts:create --git-commit` |
+
+Two hard-won rules inherited from cueprise, non-negotiable:
+
+1. **Deploy by digest, never by tag** — Cloud Run pulls Docker Hub images
+   through the `mirror.gcr.io` cache, which has served stale manifests for
+   tags; the staging workflow threads `steps.build.outputs.digest` into the
+   deploy step.
+2. **WIF only** (`google-github-actions/auth@v3` with
+   `workload_identity_provider` + `service_account`) — no JSON keys.
+
+GitHub environments (`Staging <Project>`, `Production`) gate the deploy
+jobs and carry the URLs.
+
+## 4. Not in this phase
+
+Writing these workflows + the Pulumi stack is **implementation work**, out of
+scope for the docs phase — this document is the contract they'll be built
+against. Docker Hub repos already exist for every image name above.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -29,9 +29,14 @@
 
 | Workflow | Trigger | Does |
 | --- | --- | --- |
-| `build-and-test.yml` | PRs | build + tests per service |
-| `build-push-and-release-staging.yml` | push to `main` | matrix over services: buildx (GHA cache) → push `cuesoft/expendit-<service>` (tags: `latest` + `sha`) → Cloud Run deploy **by image digest** via WIF |
-| `build-push-and-release-production.yml` | GitHub Release | same, pinned to the release commit; frontend rollout via `firebase-tools apphosting:rollouts:create --git-commit` |
+| `build-and-test.yml` | PRs **and** push to `main` | build + tests per service — **no deploy, no image push** (X-6: open-source repos; merges must be inert) |
+| `release.yml` | **tag `v*` created** | matrix over services: buildx (GHA cache) → push `cuesoft/expendit-<service>` (tags: `latest`, `sha`, version) → Cloud Run deploy **by image digest** via WIF → App Hosting rollout pinned to the tag commit |
+
+**Gating (X-6):** `stg` (sandbox) is the only environment and is treated as
+production. Two independent gates: (1) a GitHub **tag ruleset** restricts
+creating `v*` tags to owner-level access; (2) the deploy job runs in a
+protected GitHub **environment** (`Sandbox`) with required reviewers. A merged
+PR never reaches the sandbox on its own.
 
 Two hard-won rules inherited from cueprise, non-negotiable:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -111,3 +111,14 @@
 | Home (public) | full marketing page (needs Brex-style redesign) | pages.md Part A |
 | Dashboard | full suite on MUI-era components | progressive restyle to this system, pages.md Part B |
 | Mobile | — | later phase; ledger + receipt-capture first (pages.md Part C sketch) — ecosystem parity **[Directive]** |
+
+## 7. Figma Style Guide (source of truth for tokens)
+
+The design system lives in the product's Figma file on a dedicated **Style
+Guide** page, backed by a variable collection **`expendit/tokens`** with
+**Light** and **Dark** modes. Every color token in §2 exists as a Figma
+variable (scopes: frame/shape/text fills + strokes) so designs bind to tokens,
+never raw hexes; the Style Guide page renders swatches (both modes), the type
+scale, and status/accent samples. Token changes happen in Figma first, then
+sync back into this document — the two must never diverge. Type styles and
+component samples are the next Style Guide iteration.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,113 @@
+# Expendit — Design Language
+
+> Reference feel: **brex.com** — editorial financial-grade polish: confident
+> typography, dark hero surfaces, precise data UI, keyboard-first workflows.
+> Markers: **[Directive]** = user-stated direction (2026-07-16), **[Proposed]**
+> = ratifiable decision. Pages/screens in [pages.md](pages.md) reference the
+> microinteractions here as `MI-n`.
+
+## 1. Design principles
+
+1. **Numbers are the product** — tabular numerals everywhere, right-aligned
+   money columns, consistent decimal precision; charts austere, never
+   decorative.
+2. **Editorial confidence** — Brex's trick: marketing surfaces read like a
+   finance magazine (huge serif-adjacent display type, generous whitespace,
+   dark sections), while the app is dense, quiet, and fast.
+3. **Keyboard-first ops** — the dashboard behaves like a tool: ⌘K palette,
+   row-level shortcuts, inline edit. Mouse optional for the power path.
+4. **Trust through disclosure** — sensitive states (bank links, AI processing,
+   tax filings) always show *what's happening and why*, inline, not in a help
+   center.
+
+## 2. Foundations
+
+### Color **[Proposed]**
+
+| Token | Light | Dark | Use |
+| --- | --- | --- | --- |
+| `bg` | #FFFFFF | #0C0C0E | canvas |
+| `bg-editorial` | #0C0C0E | #0C0C0E | hero/dark marketing sections (both themes) |
+| `bg-elev` | #F7F7F8 | #17171A | cards, table headers |
+| `border` | #E5E5E7 | #26262B | hairlines |
+| `text` | #111113 | #F5F5F6 | primary |
+| `text-2` | #6E6E76 | #A0A0A8 | secondary |
+| `accent` | #F46A1F | #F46A1F | the Expendit orange (Brex-adjacent): primary CTAs, active nav, focus rings |
+| `income` | #1B7F4B | #34C77B | inflows, positive deltas |
+| `expense` | #C6373C | #FF6B6E | outflows, negative deltas |
+| `warn` | #B26A00 | #FFB020 | anomalies, tax deadlines |
+| `info` | #2456D6 | #7DA2FF | AI/insight chips |
+| Afrocentric pattern | 4% opacity line motif | — | dark editorial sections only |
+
+### Type
+
+- Display (marketing + dashboard page titles): editorial grotesk/serif from
+  brand pass — interim `Söhne/Inter Display`-class. Hero sizes 56–88px,
+  tight leading (Brex scale).
+- UI/data: `Inter`; base 14, tables 13; **tabular figures always on for
+  numeric columns**; money format `₦1,240,300.50` / `$…` with currency from
+  org settings.
+- Mono (`JetBrains Mono`): account numbers, statement IDs, code on home page.
+
+### Layout
+
+- Marketing: 12-col, max 1200px; alternating light/dark full-bleed sections.
+- Dashboard: left nav 240px (collapsible to 64px icon rail) · content
+  max 1440px · right inspector panel (400px) slides in for detail views —
+  tables never navigate away for a single record. **[Proposed]**
+- Density toggle (comfortable/compact) on all tables.
+- Radii 6px; shadows only on overlays; hairline-first like apparule.
+
+## 3. Component inventory
+
+| Component | Anatomy | Notes |
+| --- | --- | --- |
+| `MoneyCell` | amount + direction color + currency | never colored for zero |
+| `TxnTable` | virtualized rows: date · description · category chip · amount · anomaly badge · source icon (csv/pdf/receipt/bank) | row hover reveals actions (edit category, split, exclude); inline category edit |
+| `CategoryChip` | color-dot + label; AI-assigned ones carry a subtle ✨ until confirmed | click → combobox |
+| `AnomalyBadge` | type icon + severity tint | click → inspector explanation |
+| `StatCard` | label · big tabular number · delta chip · sparkline | dashboard header row |
+| `RatioGauge` | semicircle gauge + value + benchmark band | company ratios (pages.md B6) |
+| `UploadDropzone` | drag target + file-type icons + progress ring per file | statement/records upload |
+| `LinkAccountCard` | bank logo · masked account · sync status dot · last-synced | bank linking |
+| `WizardShell` | left step rail + content + sticky summary right | imports, tax filing |
+| `Inspector` | right slide-in panel, ESC closes | record detail everywhere |
+| `CommandPalette` | ⌘K: navigate, actions ("upload statement", "new category"), recent records | Brex signature **[Proposed]** |
+| `Toast/Banner` | toasts transient; banners persistent (bank re-auth needed, tax deadline) | |
+
+## 4. Microinteraction catalog
+
+| ID | Interaction | Spec |
+| --- | --- | --- |
+| MI-1 | **⌘K palette** | opens 120ms fade+4px rise; fuzzy match; ↑↓ + enter; recent-first; actions show their shortcut hints |
+| MI-2 | **Upload lifecycle** | dropzone border animates to `accent` on drag-over; per-file progress ring; on parse start the ring morphs to an indeterminate AI-sparkle sweep; complete → ✓ pop + row count ("214 transactions found") |
+| MI-3 | **Staged-review commit** | confirm button shows count ("Import 209 / discard 5 duplicates"); on commit, staged rows cascade-collapse into the ledger toast (240ms stagger ≤10 rows, then batch) |
+| MI-4 | **Inline category edit** | click chip → combobox in-cell; enter commits with 80ms chip color crossfade; AI ✨ mark clears on human confirm; `e` on focused row opens it |
+| MI-5 | **Anomaly pulse** | new anomalies pulse twice on first render, then rest; count in nav badge |
+| MI-6 | **Row hover** | 60ms bg tint + action icons fade-in right-aligned; no layout shift (icons absolutely positioned) |
+| MI-7 | **Number tick** | stat cards animate value changes with 300ms count-up (once per data refresh, not on scroll) |
+| MI-8 | **Ratio gauge** | needle eases to value 600ms cubic; benchmark band fades in after; hover shows formula tooltip ("Current ratio = current assets ÷ current liabilities") |
+| MI-9 | **Bank link flow** | provider modal (Mono/Plaid-style) inside `WizardShell`; status stepper: connect → consent → syncing (progress with live txn counter) → done; sync dot breathes while syncing |
+| MI-10 | **Tax wizard** | step rail fills; each computed field shows a "how we got this" expander (line-item trace); final filing CTA requires typed confirmation of the period; success: stamped-✓ animation + receipt download |
+| MI-11 | **Inspector slide** | 280ms ease-out; deep-linkable (`?record=`); ESC/overlay-click closes; edits save optimistically with field-level spinners |
+| MI-12 | **Skeletons** | tables load header + 8 shimmer rows; charts load axis-first then series draw-in 400ms |
+| MI-13 | **Deadline banners** | tax deadlines surface T-30/T-7/T-1 with escalating tint (info→warn); dismiss snoozes to next threshold |
+| MI-14 | **Export** | report download button → inline progress → file-drop bounce on completion; artifact row appears in Reports history with NEW tag 24h |
+| MI-15 | **Danger flows** | delete-all/purge: type-to-confirm + 5s countdown-armed button (design.md of record for USR-002) |
+| MI-16 | **Empty states** | every table/chart: one-line + primary action ("Upload your first statement"); demo-data toggle on dashboard empty state (synthetic, clearly badged) |
+
+## 5. Accessibility & motion
+
+- `prefers-reduced-motion`: count-ups render final values; gauges jump-cut.
+- All money deltas encode direction with icon + sign, never color alone.
+- Tables: full keyboard nav (↑↓ rows, enter opens inspector, `e` edit
+  category); focus rings `accent` 2px.
+- Charts ship data-table toggles (screen-reader + export parity).
+
+## 6. Platform parity map
+
+| Surface | Now | Target |
+| --- | --- | --- |
+| Home (public) | full marketing page (needs Brex-style redesign) | pages.md Part A |
+| Dashboard | full suite on MUI-era components | progressive restyle to this system, pages.md Part B |
+| Mobile | — | later phase; ledger + receipt-capture first (pages.md Part C sketch) — ecosystem parity **[Directive]** |

--- a/docs/design.md
+++ b/docs/design.md
@@ -115,8 +115,7 @@
 ## 7. Figma Style Guide (source of truth for tokens)
 
 The design system lives in the product's Figma file on a dedicated **Style
-Guide** page, backed by a variable collection **`expendit/tokens`** with
-**Light** and **Dark** modes. Every color token in §2 exists as a Figma
+Guide** page, backed by a variable collection **`expendit/tokens`**. The file's plan allows a single variable mode, so themes are expressed as **`light/` and `dark/` variable groups** (same token names in each) rather than modes — migrate to true modes if the plan changes. Every color token in §2 exists as a Figma
 variable (scopes: frame/shape/text fills + strokes) so designs bind to tokens,
 never raw hexes; the Style Guide page renders swatches (both modes), the type
 scale, and status/accent samples. Token changes happen in Figma first, then

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -1,0 +1,79 @@
+# Expendit — Engineering Contracts
+
+> Error catalog, authorization matrix, rate limits, testing strategy, logging
+> rules. Ecosystem conventions shared with apparule/upstat (envelope, code
+> discipline, never-log gating — see apparule engineering.md §1 for the
+> envelope definition).
+
+## 1. Error catalog (product families)
+
+Shared envelope + HTTP families per the ecosystem standard. Expendit-specific
+codes live in their flow specs: import (flows/import.md §3 — `file_too_large`,
+`unsupported_type`, `no_transactions_found`, `password_protected_pdf`,
+`ai_unavailable`, `job_already_confirmed`), bank-link (flows/bank-link.md —
+`already_linked`, `link_expired`, `reauth_required`), tax
+(`ruleset_unsigned`, `period_incomplete`, `mapping_unconfirmed`), statements
+(`mapping_identity_violation`, `unmapped_threshold_exceeded` —
+line-items.md §4), rights (`purge_pending`, `grace_expired`).
+
+## 2. Authorization matrix (org model, E-4)
+
+Roles: **member** (read + own uploads), **admin** (member + manage data),
+**owner** (admin + destructive/legal). Personal orgs: the user is owner.
+
+| Resource / action | member | admin | owner |
+| --- | --- | --- | --- |
+| Ledger read, reports read | ✓ | ✓ | ✓ |
+| Upload imports, correct categories, confirm/discard own jobs | ✓ | ✓ | ✓ |
+| Confirm/discard any job; bulk re-categorize; manage categories | — | ✓ | ✓ |
+| Bank links: create/sync | — | ✓ | ✓ |
+| Bank links: unlink (+purge choice) | — | — | ✓ |
+| Statements upload + mapping | — | ✓ | ✓ |
+| Ratio reports | ✓ read | ✓ | ✓ |
+| Tax estimates read | ✓ | ✓ | ✓ |
+| Tax filing generate/**submit** | — | generate | ✓ submit |
+| Org members manage | — | — | ✓ |
+| Export-all (USR-001) | — | — | ✓ |
+| Purge (USR-002) | — | — | ✓ (type-to-confirm + grace) |
+| Consent records | self | self | self |
+
+Middleware resolves `{user, org, role}` once; handlers declare capability.
+Cross-org access is `404 not_found`, never `403` (no existence leaks).
+
+## 3. Rate limits
+
+| Surface | Limit |
+| --- | --- |
+| Import uploads | 10/hr per org, 30/day |
+| Manual bank sync | 1/10min per link (flows/bank-link.md) |
+| Report generation | 12/hr per org |
+| Export-all | 2/day per org |
+| Tax filing generation | 6/hr per org |
+| Auth | Firebase-managed; Redis limiter retired from auth routes only |
+
+## 4. Testing strategy
+
+| Layer | Scope | Non-negotiables |
+| --- | --- | --- |
+| Unit | parsers, engines, tax math | **tax golden tests** per rule set at band edges (tax-engine.md §6); line-item derivation + identity cross-check fixtures; duplicate-detector similarity table |
+| Contract | error catalog | every documented code producible |
+| Integration (compose) | import pipeline end-to-end | fixture files per failure-taxonomy row; idempotent upload/confirm under retry storms |
+| Migration tests | Mongo→Postgres (with E-4) | row-count + checksum parity harness; org auto-create mapping |
+| E2E smoke (release tag) | signin → upload → review → confirm → report download | against sandbox in release.yml |
+| Privacy invariants | logs + responses | grep-gate: no transaction descriptions/amounts in logs; bank tokens absent everywhere |
+
+## 5. Logging & observability
+
+Ecosystem conventions (request-id line, account/org ids only). Product
+**never-log list** (CI grep-gated): transaction descriptions & amounts,
+statement/receipt text (the retired `[pdf] sample:` class), bank provider
+tokens, generated tax documents' contents, AI prompts containing user data
+(log token counts + latency, not payloads).
+
+## 6. Acceptance
+
+- [ ] Tax golden suite green on both rule sets before any filing UI ships
+- [ ] Authz matrix tests per row incl. cross-org 404 behaviour
+- [ ] Migration parity harness exists before E-4 executes
+- [ ] Never-log grep gate in build-and-test.yml
+- [ ] Fixture library covers every import failure-taxonomy row

--- a/docs/flows/auth.md
+++ b/docs/flows/auth.md
@@ -1,0 +1,60 @@
+# Flow: Authentication (Google-only, Firebase-backed)
+
+> Implements decision X-1 as hardened 2026-07-16: **Google sign-in only** —
+> no username/password, product-wide. Firebase Auth on `sandbox-e306a`.
+> Replaces the entire local credential system (signup/signin/forgot/reset/
+> change-password in `user_controller.go` + their rate limiters and email
+> templates) after the migration window.
+
+## 1. Hard rule & enforcement
+
+Same three layers as the ecosystem standard (apparule flows/auth.md §1):
+provider disabled in Firebase console; backend rejects
+`sign_in_provider ≠ google.com` (`403 provider-not-allowed`); single
+"Continue with Google" CTA. `/signup`, `/forgot-password` routes retire —
+`/signin` remains as the one auth screen.
+
+## 2. Session model
+
+Ecosystem standard (apparule §2): Firebase SDK session, bearer ID tokens,
+silent-refresh-retry-once, upsert `USER` by `firebase_uid`. Firebase
+throttling replaces the Redis auth rate limiters; Redis limits remain for
+non-auth routes.
+
+## 3. Migration of legacy password users
+
+```mermaid
+flowchart TD
+    G[Google sign-in] --> V{USER row with this email?}
+    V -->|none| NEW[create USER w/ firebase_uid]
+    V -->|exists, no firebase_uid| ATTACH[attach firebase_uid<br/>password fields → legacy]
+    V -->|has firebase_uid| OK[signed in]
+```
+
+- Google-asserted emails are verified by definition → link-by-email is safe
+  (no unverified-email branch needed).
+- **Window**: legacy `/users/signin` works 60 days with a "switch to Google"
+  banner; then `410 migrate-to-firebase`; password/reset/change-password
+  endpoints + email templates deleted; password fields dropped (data-model §3).
+- **The stranded-user edge**: a legacy account whose email has no Google
+  account (corporate/non-Gmail without Google Workspace). Policy: they sign
+  in with *any* Google account and request an email change via support
+  (`clients.cuesoft.io`), which re-links history after identity check —
+  documented in the migration banner. Expected to be rare; measured by
+  `auth_migration_stranded` (support-ticket count).
+
+## 4. Post-auth gates
+
+Consent on first protected action: `tos`, `privacy`, **`ai_processing`**
+(declining disables AI-dependent paths only — E-3). Org scoping per E-4
+unchanged.
+
+## 5. Instrumentation & acceptance
+
+Events: `auth_signin_completed`, `auth_migration_completed` — counters only.
+
+- [ ] Legacy user links on first Google sign-in; history intact
+- [ ] Day-61: legacy endpoints 410; password columns dropped; templates gone
+- [ ] Non-Google-provider tokens rejected (crafted-token test)
+- [ ] `/signup` + `/forgot-password` routes removed; redirects to `/signin`
+- [ ] Rate-limiter middleware removed from auth routes only

--- a/docs/flows/bank-link.md
+++ b/docs/flows/bank-link.md
@@ -1,0 +1,86 @@
+# Flow: Bank Account Linking (Mono)
+
+> Implements E-1 (Mono NG-first). Covers link, sync, re-auth, pause, unlink —
+> the full `BANK_LINK` lifecycle (data-model.md §5). Preconditions: authed +
+> verified email; org context resolved.
+
+## 1. Linking
+
+```mermaid
+sequenceDiagram
+    actor U as User
+    participant W as web /accounts
+    participant A as api/common
+    participant M as Mono (widget + API)
+
+    U->>W: "Link account"
+    W->>A: POST /bank-links (org) → {mono_connect_config}
+    W->>U: Mono Connect widget (provider-hosted consent)
+    U->>M: select bank, authenticate, consent
+    M-->>W: success code
+    W->>A: PUT /bank-links/{id}/exchange {code}
+    A->>M: exchange for account id/token (stored encrypted)
+    A-->>W: link active {institution, masked_account}
+    A->>A: enqueue initial sync (last 6 months [Decided default])
+    Note over W: LinkAccountCard appears, sync dot breathing (MI-9)
+```
+
+Edge cases at link time:
+
+| Case | Behaviour |
+| --- | --- |
+| Widget closed mid-flow | no link row persisted beyond `pending`; pending rows purged after 1h |
+| Same account linked twice (same org) | `409 already-linked` → "This account is already connected" |
+| Same account, different org | allowed (personal + company can both see their own view) |
+| Bank not supported by Mono | widget handles; our empty-state lists "supported banks" link |
+| Exchange fails (code expired) | `422 link-expired` → restart widget |
+
+## 2. Syncing
+
+- Schedule: daily per link + manual "Sync now" (rate-limited 1/10min per link).
+- Each sync = one import job (`source: bank_sync`, flows/import.md §5):
+  fetch since last cursor → stage → duplicate-detect → categorize → anomaly →
+  review (or auto-confirm when enabled).
+- Cursor semantics: Mono transaction cursor persisted per link; a failed sync
+  never advances the cursor (at-least-once, duplicates handled by staging).
+
+| Sync failure | Behaviour |
+| --- | --- |
+| `reauth_required` (consent lapsed/bank revoked) | link status flips; persistent banner "Reconnect ×××1234" → widget re-auth flow; syncs paused |
+| Mono 5xx / rate-limit | exponential backoff, next scheduled run; after 3 consecutive failures → status `degraded` + banner |
+| Partial page fetch | job processes what arrived; cursor advances only past processed transactions |
+
+## 3. Pause / unlink
+
+- **Pause**: stops scheduled syncs; manual sync disabled; card shows paused
+  state. Resume re-enables from the stored cursor.
+- **Unlink** (`DELETE /bank-links/{id}?purge=`): confirm dialog with the
+  keep-or-purge choice (BNK-002):
+  - `purge=false` (default): provider token revoked + deleted; imported
+    transactions **stay** in the ledger (they're the user's records).
+  - `purge=true`: additionally hard-deletes all transactions originating
+    from this link (`source_link_id`) + their staged rows — MI-15 danger
+    treatment (type-to-confirm), irreversible.
+- Provider-side revocation (user revokes at their bank) surfaces as
+  `reauth_required` → user chooses reconnect or unlink.
+
+## 4. Security invariants
+
+- Bank credentials never touch our servers (widget is provider-hosted).
+- Mono tokens encrypted at rest (KMS/env key via Doppler); never logged;
+  never serialized in any API response.
+- Webhooks (`/webhooks/bank`) signature-verified; unverified → 401 + alert,
+  never processed (same rule as payments in apparule).
+- All bank-link mutations audit-logged (who, when, what — no payloads).
+
+## 5. Instrumentation & acceptance
+
+Events: `bank_link_created{institution?}` — institution only if we ratify it
+as a permitted dim; default counters only. `bank_sync_completed`,
+`bank_reauth_required`.
+
+- [ ] Link → initial 6-month backfill lands in staged review
+- [ ] Re-auth banner appears on revocation; reconnect resumes from cursor
+- [ ] Unlink keep vs purge both proven (purge removes exactly the link's rows)
+- [ ] Failed syncs never advance cursors; no transaction loss under retry
+- [ ] Tokens absent from logs, responses, and error messages (grep-proven)

--- a/docs/flows/import.md
+++ b/docs/flows/import.md
@@ -1,0 +1,77 @@
+# Flow: Statement / Receipt Import
+
+> The staged-review pipeline (architecture.md §4) from the user's side, with
+> every edge case. Target shape is the **async** model (202 + polling,
+> roadmap P2); differences from today's synchronous behaviour are marked.
+> Preconditions: authed; `ai_processing` consent for PDF-AI/receipt paths
+> (flows/auth.md §4).
+
+## 1. Happy path
+
+```mermaid
+flowchart TD
+    UP[/imports: drop file MI-2/] --> VAL{client checks}
+    VAL -->|type/size fail| E0[inline error, no upload]
+    VAL --> POST[POST /import/upload → 202 job_id]
+    POST --> POLL[GET /import/:jobId — processing]
+    POLL --> DONE{completed?}
+    DONE -->|failed| FAIL[job error state + guidance]
+    DONE -->|completed| REVIEW[staged review table]
+    REVIEW --> FIX[fix categories MI-4, un-flag false duplicates]
+    FIX --> CONFIRM[confirm → ledger MI-3]
+    REVIEW --> DISCARD[discard → job + staging purged]
+```
+
+## 2. Contracts per step
+
+| Step | Contract |
+| --- | --- |
+| Client checks | CSV/XLSX/TXT/PDF/JPG/PNG/WEBP/HEIC; ≤ 15 MB **[Decided default]**; images client-compressed ≤ 2048px |
+| Upload | multipart + `Idempotency-Key` (UUID per file selection) — retries never double-import; same key returns the same `job_id` |
+| Processing | async worker; job status `processing → completed \| failed`; poll every 2s with backoff, or SSE later; UI shows the MI-2 AI-sparkle stage |
+| Staged review | duplicates pre-flagged (`is_duplicate`) and excluded from the confirm count by default — user can re-include (false positives happen with recurring identical payments); AI categories carry the ✨ mark until touched |
+| Confirm | `POST /import/:jobId/confirm` idempotent (second call → 200 no-op); writes ledger rows atomically — partial confirm is impossible: all-or-error |
+| Discard | purges staging + job summary immediately |
+
+## 3. Failure taxonomy
+
+| Code | Cause | UX |
+| --- | --- | --- |
+| `413 file-too-large` | > limit | inline, no upload |
+| `415 unsupported-type` | magic-bytes check fails | "Upload a CSV, PDF, or receipt image" |
+| `422 no-transactions-found` | parsed 0 rows (CSV headers unrecognized / PDF text empty / image not a receipt) | job completed-empty state: guidance per file type + "try a CSV export from your bank" |
+| `422 password-protected-pdf` | encrypted PDF | "Remove the password and re-upload" |
+| `503 ai-unavailable` | Groq+Gemini both down/keyless, file type needs AI (image; PDF after regex fallback fails) | "AI processing is temporarily unavailable" + retry later; CSV path unaffected |
+| `409 job-already-confirmed` | double confirm race | treat as success (idempotent) |
+| worker crash mid-job | job auto-marked `failed` by timeout reaper (10 min) | "Something went wrong — nothing was imported" + retry (new job) |
+
+Partial AI extraction (some pages parse, some don't): job completes with
+`warnings: ["3 of 12 pages could not be parsed"]` — surfaced as a banner on
+the review table, never silent.
+
+## 4. Duplicate semantics
+
+- Detector compares staged rows against **ledger + other staged jobs** on
+  (date ±1d, amount exact, normalized description similarity).
+- Re-uploading the same statement month → most rows flagged; confirm imports
+  only the unflagged remainder — the "overlapping statements" case just works.
+- Confirmed duplicates are the user's explicit choice (re-included manually).
+
+## 5. Bank-sync convergence
+
+Bank-synced batches (flows/bank-link.md) enter this same pipeline as jobs
+with `source: bank_sync`; per-account **auto-confirm** (opt-in, after ≥3
+manually-confirmed clean syncs **[Decided default]**) skips review for
+duplicate-free jobs only — any anomaly or duplicate forces review.
+
+## 6. Instrumentation & acceptance
+
+Events: `upload_success{file_type}` (job completed), `import_confirmed`,
+`import_discarded` — counters + file_type only (ECO-ANALYTICS constraint).
+
+- [ ] Retry-storm on upload yields exactly one job
+- [ ] Confirm is atomic + idempotent under double-click and race
+- [ ] Every taxonomy row renders its distinct UX (fixture files per case)
+- [ ] Statement re-upload imports only the non-duplicate remainder
+- [ ] AI-down leaves CSV imports fully functional
+- [ ] No transaction contents in logs (the `[pdf] sample:` class of leak, gone)

--- a/docs/line-items.md
+++ b/docs/line-items.md
@@ -1,0 +1,96 @@
+# Expendit — Canonical Line-Item Vocabulary
+
+> The closed mapping target for company financial statements (pages.md B6,
+> data-model.md §5 `LINE_ITEM.canonical_key`). AI-suggested mappings and human
+> corrections must both land on these keys — free-form keys are rejected, the
+> same schema-as-boundary pattern used across the ecosystem. **[Proposed —
+> ratify; extending the vocabulary is a docs PR, not a code change]**
+
+## 1. Balance sheet
+
+| Key | Statement label examples | Used by ratios |
+| --- | --- | --- |
+| `cash_and_equivalents` | Cash, bank balances, treasury bills < 90d | cash ratio |
+| `receivables` | Trade debtors, accounts receivable | quick ratio, receivables days |
+| `inventory` | Stock, finished goods, WIP | quick ratio (excluded), inventory turnover |
+| `current_assets_other` | Prepayments, other current assets | current ratio |
+| `current_assets` *(derived if absent)* | Total current assets | current/quick/cash ratios |
+| `ppe` | Property, plant & equipment (net) | asset turnover |
+| `intangibles` | Goodwill, software, licenses | — |
+| `noncurrent_assets_other` | Investments, deferred tax assets | — |
+| `total_assets` *(derived if absent)* | Total assets | debt ratio, ROA, asset turnover |
+| `payables` | Trade creditors, accounts payable | current ratio |
+| `short_term_debt` | Overdrafts, current portion of loans | current ratio, total debt |
+| `current_liabilities_other` | Accruals, taxes payable | current ratio |
+| `current_liabilities` *(derived)* | Total current liabilities | current/quick/cash ratios |
+| `long_term_debt` | Loans, bonds, lease liabilities > 1y | debt-to-equity, total debt |
+| `noncurrent_liabilities_other` | Deferred tax, provisions | — |
+| `total_liabilities` *(derived)* | Total liabilities | debt ratio |
+| `share_capital` | Issued capital, share premium | equity |
+| `retained_earnings` | Accumulated profits/losses | equity |
+| `equity` *(derived)* | Total shareholders' equity | debt-to-equity, ROE |
+
+## 2. Income statement
+
+| Key | Examples | Used by ratios |
+| --- | --- | --- |
+| `revenue` | Turnover, sales, fees earned | margins, turnovers |
+| `cogs` | Cost of sales/goods sold | gross margin, inventory turnover |
+| `gross_profit` *(derived)* | | gross margin |
+| `opex` | Admin + selling + distribution expenses | operating margin |
+| `depreciation_amortization` | D&A (if separate) | interest coverage (EBITDA variant) |
+| `operating_profit` *(derived)* | EBIT, operating income | operating margin, interest coverage |
+| `interest_expense` | Finance costs | interest coverage |
+| `interest_income` | Investment/interest income | — |
+| `tax_expense` | Income tax | net margin, CIT cross-check |
+| `net_income` *(derived)* | Profit after tax | net margin, ROA, ROE |
+
+## 3. Cash-flow statement
+
+| Key | Examples |
+| --- | --- |
+| `cfo` | Net cash from operating activities |
+| `cfi` | Net cash from investing activities |
+| `cff` | Net cash from financing activities |
+| `capex` | Purchase of PP&E |
+| `net_change_in_cash` *(derived)* | |
+
+## 4. Derivation & validation rules
+
+- *(derived)* keys are computed when absent (`current_assets = cash +
+  receivables + inventory + other`) and **cross-checked when present** — a
+  reported total that differs from the component sum by >1% flags a
+  `mapping_warning` on the statement (shown in the B6 review step).
+- Every mapped statement must satisfy the accounting identity
+  `total_assets ≈ total_liabilities + equity` (±1%) before `confirmed`.
+- Amounts are stored in org currency, sign-normalized (assets/revenue
+  positive; expenses/liabilities positive magnitudes with the key carrying
+  semantics — no negative-by-convention ambiguity).
+- Unmapped source rows can be parked as `unmapped` (excluded from ratios,
+  listed in the review step) — but statements with >20% unmapped value by
+  magnitude cannot be confirmed.
+
+## 5. Ratio formulas (the auditable registry)
+
+| Ratio | Formula (canonical keys) |
+| --- | --- |
+| Current ratio | `current_assets / current_liabilities` |
+| Quick ratio | `(current_assets - inventory) / current_liabilities` |
+| Cash ratio | `cash_and_equivalents / current_liabilities` |
+| Debt-to-equity | `(short_term_debt + long_term_debt) / equity` |
+| Debt ratio | `total_liabilities / total_assets` |
+| Interest coverage | `operating_profit / interest_expense` |
+| Gross margin | `gross_profit / revenue` |
+| Operating margin | `operating_profit / revenue` |
+| Net margin | `net_income / revenue` |
+| ROA | `net_income / total_assets` |
+| ROE | `net_income / equity` |
+| Asset turnover | `revenue / total_assets` |
+| Inventory turnover | `cogs / inventory` |
+| Receivables days | `receivables / revenue × 365` |
+
+Each computed `RATIO_REPORT` row persists the formula string + the exact
+`LINE_ITEM` ids used (data-model.md §5), which is what the MI-8 "how we got
+this" trace renders. Period-average denominators (e.g. average inventory)
+are a **[Later]** refinement — v1 uses period-end values, disclosed in the
+trace.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -54,3 +54,4 @@ service is `api/common`; a future one would be `api/<function>`. See the
 - [decisions.md](decisions.md) — the open-decision register: ratify to unblock phases
 - [deployment.md](deployment.md) — Cloud Run + App Hosting contract (cuesoft-iac provisioning, CI/CD pattern)
 - flows/ — feature flow specs with edge cases: [auth](flows/auth.md), [import](flows/import.md), [bank-link](flows/bank-link.md)
+- [tax-engine.md](tax-engine.md) — NG PIT/CIT/VAT computation contract (versioned rule sets, trace requirements)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -55,3 +55,4 @@ service is `api/common`; a future one would be `api/<function>`. See the
 - [deployment.md](deployment.md) — Cloud Run + App Hosting contract (cuesoft-iac provisioning, CI/CD pattern)
 - flows/ — feature flow specs with edge cases: [auth](flows/auth.md), [import](flows/import.md), [bank-link](flows/bank-link.md)
 - [tax-engine.md](tax-engine.md) — NG PIT/CIT/VAT computation contract (versioned rule sets, trace requirements)
+- [engineering.md](engineering.md) — error catalog, authz matrix, rate limits, testing strategy, logging rules

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -52,3 +52,5 @@ service is `api/common`; a future one would be `api/<function>`. See the
 - [design.md](design.md) + [pages.md](pages.md) — design language, screens, microinteractions
 - [line-items.md](line-items.md) — canonical statement vocabulary + ratio formula registry
 - [decisions.md](decisions.md) — the open-decision register: ratify to unblock phases
+- [deployment.md](deployment.md) — Cloud Run + App Hosting contract (cuesoft-iac provisioning, CI/CD pattern)
+- flows/ — feature flow specs with edge cases: [auth](flows/auth.md), [import](flows/import.md), [bank-link](flows/bank-link.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -41,3 +41,11 @@ responsibilities. To run the stack locally, see [setup.md](setup.md).
 Backend services are named by **function**, never by language: the current
 service is `api/common`; a future one would be `api/<function>`. See the
 [repository structure](../README.md#repository-structure) in the README.
+
+## Product & design documentation
+
+- [prd.md](prd.md) — product requirements breakdown (requirements vs current state, user rights, open questions)
+- [architecture.md](architecture.md) — system design, import-pipeline deep dive, target sequences
+- [data-model.md](data-model.md) — current + target entities, identity migration, data classification
+- [api.md](api.md) — full current surface and v1 deltas with gap analysis
+- [roadmap.md](roadmap.md) — phased plan with dependencies

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -51,3 +51,4 @@ service is `api/common`; a future one would be `api/<function>`. See the
 - [roadmap.md](roadmap.md) — phased plan with dependencies
 - [design.md](design.md) + [pages.md](pages.md) — design language, screens, microinteractions
 - [line-items.md](line-items.md) — canonical statement vocabulary + ratio formula registry
+- [decisions.md](decisions.md) — the open-decision register: ratify to unblock phases

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -49,3 +49,5 @@ service is `api/common`; a future one would be `api/<function>`. See the
 - [data-model.md](data-model.md) — current + target entities, identity migration, data classification
 - [api.md](api.md) — full current surface and v1 deltas with gap analysis
 - [roadmap.md](roadmap.md) — phased plan with dependencies
+- [design.md](design.md) + [pages.md](pages.md) — design language, screens, microinteractions
+- [line-items.md](line-items.md) — canonical statement vocabulary + ratio formula registry

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -1,0 +1,134 @@
+# Expendit — Pages, Screens & Features
+
+> Component-level surface inventory referencing [design.md](design.md)
+> (`MI-n`). Part A public home page, Part B dashboard, Part C mobile sketch.
+> The 2026-07-16 expansion **[Directive]**: bank-account linking, company
+> financial-records analysis (solvency/profitability ratios), tax calculation
+> **and filing**.
+
+## Part A — Public home page (expendit.cuesoft.io)
+
+Shared CueLABS open-source-site pattern: product presentation → developer
+setup → Discord + GitHub + preview links → **Try Cloud** / **Self Host** CTAs
+**[Directive]**. Brex-style editorial execution (design.md §1.2).
+
+| # | Section | Content & components | Interactions |
+| --- | --- | --- | --- |
+| A1 | Nav | logo · Product · Solutions (Individuals/SMEs/Companies) · Docs (GitBook) · Community · GitHub badge · Sign in · **Try Cloud** | sticky; dark-on-light after hero scroll |
+| A2 | Hero (dark editorial) | display-type H1 "Financial intelligence for modern growth"; sub; dual CTA **Try Cloud** / **Self Host**; hero visual: dashboard in device frame with animated categorization chips | chips animate once; pauses reduced-motion |
+| A3 | Logos/social proof strip | placeholder for case-study logos (PRD §6) | |
+| A4 | Product pillars | 3 editorial cards: **Statements → intelligence** (upload/link), **Company financials** (ratios), **Taxes** (calculate + file) | card hover: 2px lift + accent underline draw |
+| A5 | Interactive preview (EXP-001) | embedded read-only demo report: synthetic txn table + category donut + cash-flow line; "This is demo data" badge | tabs switch datasets (freelancer/SME/company); MI-7 count-ups |
+| A6 | AI section | how categorization/anomalies work + privacy note inline (AI providers disclosed) | |
+| A7 | Security & privacy | encryption, retention, delete-all rights; links: security policy + privacy hub (D3) | |
+| A8 | Open source | `docker compose up` snippet + copy; architecture mini-diagram; GitHub/CONTRIBUTING | copy ✓ morph |
+| A9 | Community | Discord card + roadmap link | |
+| A10 | Cloud vs Self-host | comparison table; per-column CTAs | |
+| A11 | Footer | standard + "View Security Policy" CTA (PRD §6) | |
+
+Events → Upstat (D2): `page_view`, `try_cloud_click`, `self_host_click`,
+`github_click`, `demo_interact`.
+
+## Part B — Dashboard (app)
+
+Left nav groups **[Proposed]**: Overview · Transactions · Imports · Accounts
+(bank links) · Reports · **Company** (statements, ratios) · **Taxes** ·
+Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
+(personal ↔ company orgs, data-model.md §5).
+
+### B1 `/dashboard` — Overview
+- StatCard row: net cash flow, income, expenses, runway (company orgs) (MI-7).
+- Cash-flow chart (12mo), category donut, anomaly feed (MI-5), latest
+  transactions table (5 rows → Transactions).
+- Empty state: MI-16 with demo-data toggle.
+
+### B2 `/transactions` — Ledger
+- Full `TxnTable` (virtualized): filters (date range, category, source,
+  direction, amount range, anomaly-only), saved filter views, search.
+- Inline category edit (MI-4), row inspector (MI-11) with split-transaction
+  and exclude-from-reports controls **[Proposed]**.
+- Bulk select → bulk re-categorize / export selection.
+
+### B3 `/imports` — Import hub
+- UploadDropzone (CSV/PDF/receipt image) (MI-2) + import-job history table
+  (status, counts, anomalies found).
+- Job detail: staged-review table (AI categories ✨, duplicates pre-flagged),
+  per-row category fix (MI-4), then confirm/discard (MI-3).
+- Async model (202 + polling) per architecture.md §4.2.
+
+### B4 `/accounts` — Linked bank accounts **[Directive — new]**
+- `LinkAccountCard` grid + "Link account" CTA → provider flow (MI-9).
+- Aggregator: **Mono/Okra for NG banks, Plaid/TrueLayer international —
+  decision to ratify** (architecture.md §8).
+- Per-account: sync schedule, last sync, imported-txn count, pause/unlink
+  (unlink offers keep-or-purge history choice).
+- Synced transactions land in the same staged-review pipeline as uploads
+  (single ingestion path **[Proposed]**), auto-confirm option per account
+  once trust is established.
+- Re-auth banners when a link expires (design.md banners).
+
+### B5 `/reports` — Reports & downloads (EXP-004)
+- Generate: monthly summary / cash-movement / category deep-dive; period
+  picker; format PDF/CSV.
+- Artifact history table (TTL'd) with download (MI-14).
+- Scheduled reports (monthly email) **[Proposed, later]**.
+
+### B6 `/company` — Company financials **[Directive — new]**
+- **Statements**: upload balance sheet / income statement / cash-flow
+  (CSV/XLSX/PDF via the same dropzone); mapped into a normalized line-item
+  model (data-model.md §5) with a mapping-review step (like staged txns:
+  AI-suggested line mapping, human confirm) (MI-2/3 reused).
+- **Ratios** (`/company/ratios`): RatioGauge grid (MI-8), grouped:
+  - *Liquidity*: current ratio, quick ratio, cash ratio
+  - *Solvency*: debt-to-equity, debt ratio, interest coverage
+  - *Profitability*: gross/operating/net margin, ROA, ROE
+  - *Efficiency*: asset turnover, inventory turnover, receivables days
+  - Each gauge: value, period delta, benchmark band, "how we got this"
+    formula trace (MI-8 tooltip → inspector with line items).
+- Trend view: ratio time-series across periods; export to report artifact.
+- Requires ≥1 mapped statement period; empty state explains inputs needed.
+
+### B7 `/taxes` — Tax center **[Directive — new]**
+- Overview: jurisdiction profile (org settings), tax calendar with deadline
+  banners (MI-13), estimated liabilities StatCards.
+- **Calculators** (v1 scope **[Proposed — jurisdiction to ratify, NG-first]**):
+  - Personal income tax (PIT) from categorized income
+  - Company income tax (CIT) estimate from company statements
+  - VAT summary from ledger (output vs input VAT)
+- **Filing wizard** (`/taxes/file`): WizardShell (MI-10): period → data review
+  (traceable computed fields) → generated filing forms → submission:
+  - v1: produce filing-ready documents + guided handoff (download/export)
+  - v2: direct e-filing via jurisdiction APIs/partners where they exist
+    **[Proposed staging — "file the taxes" acceptance met in v2]**
+- Filing history: immutable records with stamped receipts.
+
+### B8 `/categories`, B9 `/settings`
+- Categories: CRUD + color/dot, merge tool, AI-training note.
+- Settings: org members/roles (company orgs), data & privacy (export-all
+  USR-001, purge USR-002 with MI-15), AI-processing consent, bank-link
+  permissions, notifications, theme/density.
+
+## Part C — Mobile app (later phase; parity direction **[Directive]**)
+
+Sketch for the parity roadmap — not scheduled before dashboard/web work:
+tabs Home (stat cards + anomalies) · Transactions (list + inline category) ·
+**Capture** (receipt camera → import pipeline) · Reports (view/download) ·
+Settings. Receipt capture is the mobile-native win (camera → MI-2 lifecycle).
+
+## Feature register delta (extends prd.md)
+
+| ID | Feature | Priority | Surfaces |
+| --- | --- | --- | --- |
+| BNK-001 | Bank account linking via aggregator, synced into staged review | Must | B4 |
+| BNK-002 | Sync scheduling, re-auth, unlink with data choice | Must | B4 |
+| CMP-001 | Company org type + financial-statement upload & line-item mapping | Must | B6 |
+| CMP-002 | Ratio engine (liquidity/solvency/profitability/efficiency) with formula traces | Must | B6 |
+| CMP-003 | Ratio trends + benchmark bands | Should | B6 |
+| TAX-001 | Tax profile + calendar + estimates (NG-first) | Must | B7 |
+| TAX-002 | Filing wizard producing filing-ready documents | Must | B7 |
+| TAX-003 | Direct e-filing integrations | Later | B7 |
+| PLT-001 | ⌘K palette, inspector pattern, saved views | Should | all |
+| PLT-002 | Mobile app (receipt capture first) | Later | Part C |
+
+Cross-refs: entities → data-model.md §5; API → api.md §5; phases →
+roadmap.md revision.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -110,3 +110,31 @@ downloadable artifacts) and *ecosystem integration*, not building the engine.
    delete-on-confirm for raw files, retain derived transactions **[Proposed]**.
 4. **Figma designs** — Home canvas empty; the implemented landing becomes the
    de-facto design until a Figma pass exists.
+
+---
+
+## 9. Scope expansion (2026-07-16) **[Directive]**
+
+Look and feel: **brex.com** ([design.md](design.md)). Three new capability
+pillars, page-level breakdowns in [pages.md](pages.md):
+
+1. **Bank account linking** (BNK-001/002) — users either upload statements
+   *or link accounts*; synced transactions flow through the same staged-review
+   pipeline. Aggregator choice (Mono/Okra NG-first vs Plaid/TrueLayer) to
+   ratify.
+2. **Company financial records** (CMP-001…003) — company orgs upload balance
+   sheets / income statements / cash-flow statements; a normalized line-item
+   model feeds a ratio engine: liquidity (current/quick/cash), solvency
+   (debt-to-equity, debt ratio, interest coverage), profitability
+   (margins/ROA/ROE), efficiency (turnovers) — every ratio with a formula
+   trace back to line items.
+3. **Taxes** (TAX-001…003) — calculate PIT/CIT/VAT (jurisdiction profile,
+   NG-first **[Proposed]**) and **file**: v1 generates filing-ready documents
+   with guided handoff; v2 adds direct e-filing where APIs/partners exist.
+
+Platform structure **[Directive]**: public home page (shared open-source-site
+pattern: Discord, GitHub, preview link, Try Cloud / Self Host CTAs) + dashboard
++ eventual mobile parity (receipt capture first). Docs on GitBook (Git-synced
+from `docs/`); API reference via Scalar. New open questions: aggregator
+selection + data-access consent UX; tax jurisdiction scope + filing partner;
+org/member model for companies (roles, approvals).

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,112 @@
+# Expendit — Product Requirements Breakdown
+
+> Source: "Expendit Product Requirement Document" (provided 2026-07-15) combined
+> with the repository state on `main`. The linked
+> [Figma file](https://www.figma.com/design/P2lGfKFLJPS9k9kTKlii1n/Expendit)
+> currently contains an empty "Home" canvas — the implemented landing page and
+> the PRD component table are the working references until designs land.
+>
+> Markers: **[PRD]** = stated requirement, **[Current]** = verified repository
+> fact, **[Proposed]** = design decision introduced here for ratification.
+
+## 1. Product definition
+
+Expendit is a financial-analysis and expense-intelligence product: it turns raw
+financial data — bank statements, receipts, CSV exports — into structured,
+categorized, anomaly-checked reports of spending and cash movement, for
+individuals, SMEs, and operational teams. **[PRD]**
+
+`expendit.cuesoft.io` is both the landing page and the application entry point.
+**[PRD §1.1]** Unlike apparule (whose web property fronts a mostly-unbuilt
+platform), Expendit's core intelligence loop **already exists in this repo**:
+upload → parse (CSV/PDF/receipt image) → AI categorization → duplicate &
+anomaly detection → reviewable staging → confirm into the ledger. The PRD phase
+is therefore mostly about *completing the trust surface* (privacy, data rights,
+downloadable artifacts) and *ecosystem integration*, not building the engine.
+
+## 2. Personas and jobs-to-be-done
+
+| Persona | Job-to-be-done | Primary surface |
+| --- | --- | --- |
+| Individual users | Automated tracking/categorizing of monthly spending | Dashboard, import hub |
+| SMEs | Lightweight expense management without ERP overhead | Dashboard, reports, exports |
+| Operational teams | Cash-position analysis and financial reporting | Reports, downloadable summaries |
+| Cuesoft partners | Product incubation, internal financial auditing | Whole stack |
+
+## 3. Functional requirements
+
+### 3.1 Stated requirements, mapped against current state
+
+| ID | Requirement | Priority | Current state **[Current]** | Gap |
+| --- | --- | --- | --- | --- |
+| EXP-001 | Report Preview Landing — visitors see example insights/charts without authenticating | Must | Landing page exists (hero, services, features, how-it-works, open-source, contact sections) | Add an *example report/chart preview* section with demo data; must never use real personal bank data **[PRD §5]** |
+| EXP-002 | Universal File Upload — bank statements (PDF) + CSVs | Must | **Implemented**: `POST /import/upload` accepts CSV/tabular, PDF (text-extraction → AI → regex fallback), and receipt images (JPG/PNG/WEBP/HEIC via AI vision) | Hardening: size limits, async processing (see architecture.md §4.2), clearer failure surfaces |
+| EXP-003 | AI Categorization — grouping, user correction, anomaly alerts | Should | **Implemented**: categorization engine + Groq→Gemini enhancer; per-transaction category correction endpoint; 4 anomaly types (large transaction, spending spike, abnormal category, duplicate charge) persisted per job | Alert *UX* (surfacing anomalies beyond the import screen); correction feedback loop into the engine **[Proposed]** |
+| EXP-004 | Summary Reports — downloadable financial summaries & cash-movement reports | Must | Summaries computed (totals, net cash flow, by-category, monthly trends, AI narrative) but only served as JSON; 3 chart aggregation endpoints | **Downloadable artifact generation (PDF/CSV) is missing** — the main Must-gap |
+| EXP-005 | Privacy Hub — disclosure on retention, storage, deletion rights | Must | Nothing | New page + `privacy.cuesoft.io` clause link; pairs with USR-001/002 below |
+
+### 3.2 Ecosystem requirements
+
+| ID | Requirement | Notes |
+| --- | --- | --- |
+| ECO-AUTH | Identity via `account.cuesoft.io` | Same external dependency as the other products (D1). Current: own JWT auth (signup/signin/Google/reset, rate-limited) — a solid interim. |
+| ECO-SUPPORT | Disputes/technical issues route to `clients.cuesoft.io` | Link-out from dashboard/settings. |
+| ECO-ANALYTICS | "Upload Success" and "Report Generation" events via Upstat | Depends on Upstat event API (D2). Events must be **privacy-compliant**: counters only, never financial payloads. **[PRD §4.2]** |
+
+### 3.3 Derived user-rights requirements **[PRD §7 made explicit]**
+
+| ID | Requirement |
+| --- | --- |
+| USR-001 | Visible route to **export the user's entire financial history** (machine-readable, at minimum CSV/JSON archive) at any time |
+| USR-002 | Visible route to **delete the entire financial history** (account-level purge with confirmation + grace semantics **[Proposed]**) |
+| USR-003 | Data-retention disclosure consistent with actual storage behaviour (see data-model.md §4) |
+
+## 4. Non-goals (initial release)
+
+- **Direct bank/SMS integration** — explicitly staged *after* file-based
+  uploads. **[PRD §5]** Roadmap Phase 3.
+- Building the ecosystem services themselves (account/clients/privacy hubs).
+- Multi-currency consolidation, budgeting/forecasting features (not in PRD).
+- Double-entry accounting semantics — Expendit is intelligence, not bookkeeping.
+
+## 5. Brand & content requirements
+
+- Aesthetic: trustworthy, analytical, privacy-sensitive; data-rich dashboards,
+  interactive charts, transaction previews. **[PRD §2]**
+- Afrocentric geometric patterns, enterprise polish (ecosystem alignment). **[PRD §2]**
+- Messaging: "privacy-first financial intelligence" over generic expense
+  tracking. **[PRD §6]**
+- CTAs: "Open Expendit", "Upload Statement", "View Security Policy". **[PRD §6]**
+- Case studies: retail SMEs, freelancers, individual cash-flow optimization. **[PRD §6]**
+
+## 6. Compliance & safety requirements
+
+| Concern | Requirement |
+| --- | --- |
+| Data classification | All financial data is **high-sensitivity** **[PRD §5]**; classification table in data-model.md §4 |
+| Demo data | Landing previews and demos must use synthetic data only **[PRD §5]** |
+| Privacy clause | Adhere to the Expendit-specific clause in `privacy.cuesoft.io` **[PRD §7]** (content dependency D3) |
+| User control | USR-001/002 above — export + full deletion, visibly reachable **[PRD §7]** |
+| AI processing disclosure | Statements/receipts are sent to third-party AI providers (Groq/Gemini) for extraction & categorization **[Current fact that §7 disclosure must cover — Proposed to make explicit in the privacy hub]** |
+
+## 7. Success metrics
+
+| Metric | Source | Requirement |
+| --- | --- | --- |
+| Upload Success | Upstat event on completed import job | ECO-ANALYTICS **[PRD]** |
+| Report Generation | Upstat event on report/export creation | ECO-ANALYTICS **[PRD]** |
+| Import → confirm conversion | api/common (jobs confirmed ÷ jobs created) | **[Proposed]** — measures trust in AI staging |
+| Correction rate per import | api/common | **[Proposed]** — categorization quality signal |
+
+## 8. Open questions
+
+1. **AI provider disclosure & data residency** — statements are processed by
+   Groq/Gemini today. Does the privacy commitment allow this by default, or is
+   an opt-in / self-hosted-model path required for the cloud offering?
+2. **`account.cuesoft.io` migration** — current users hold Expendit-local
+   credentials; migration/coexistence strategy needed when D1 lands.
+3. **Retention default** — uploaded source files (statements/receipts): stored
+   how long after a job is confirmed/discarded? data-model.md proposes
+   delete-on-confirm for raw files, retain derived transactions **[Proposed]**.
+4. **Figma designs** — Home canvas empty; the implemented landing becomes the
+   de-facto design until a Figma pass exists.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,71 @@
+# Expendit — Roadmap
+
+> Ordered plan from the gap analysis (api.md §3). Expendit's engine exists;
+> the phases complete the trust surface, then scale the pipeline, then expand
+> acquisition channels. Each phase is independently shippable.
+
+## Phase 0 — Landing preview + privacy hub (the two web Musts)
+
+| Item | Requirement | Notes |
+| --- | --- | --- |
+| Example-report preview section on `/` with synthetic data | EXP-001 | Reuses existing chart components; a small committed demo dataset — never real personal bank data (PRD §5) |
+| `/privacy` page: retention, storage, deletion rights, **third-party AI processing disclosure** | EXP-005 | Links to Expendit clause on privacy.cuesoft.io (D3); content mirrors data-model.md §4 |
+| Remove financial data from logs (`[pdf] sample:` line) | EXP-005 credibility | Small code change but scheduled here because the privacy hub's claims must be true the day it ships |
+| CTAs aligned to PRD ("Open Expendit", "Upload Statement", "View Security Policy") | PRD §6 | Copy/design pass |
+
+**Exit criteria:** a visitor understands the product and its privacy posture
+without signing in; no financial payloads in server logs.
+
+## Phase 1 — Downloadable reports + data rights (remaining Musts)
+
+| Item | Requirement |
+| --- | --- |
+| Report artifact generation: monthly summary + cash-movement, PDF/CSV | EXP-004 |
+| Reports UI: generate/download, artifact history (TTL) | EXP-004 |
+| Full-history export (CSV/JSON archive) reachable from settings | USR-001 |
+| Account purge with grace window + confirmations | USR-002 |
+| Consent records (ToS/privacy/AI-processing) | PRD §7 |
+
+**Exit criteria:** every §7 user right is a working button; EXP-004 acceptance
+met (downloadable summaries + cash movement).
+
+## Phase 2 — Pipeline hardening & intelligence UX
+
+| Item | Requirement / driver |
+| --- | --- |
+| Async import worker (202 + job polling; Redis-backed queue) | EXP-002 scale — the 120 s synchronous AI budget can't live inside requests |
+| Upload limits + typed errors | EXP-002 hardening |
+| Anomaly surfacing beyond import: dashboard feed/badges | EXP-003 "alerts" |
+| Correction feedback loop (corrections inform future categorization) | EXP-003 quality |
+| Import→confirm conversion + correction-rate metrics | prd.md §7 metrics |
+
+**Exit criteria:** a 50 MB statement imports without request timeouts;
+anomalies visible on the dashboard; categorization measurably improves from
+corrections.
+
+## Phase 3 — Ecosystem + acquisition channels
+
+| Item | Requirement | Notes |
+| --- | --- | --- |
+| Upstat events: `upload_success`, `report_generation` | ECO-ANALYTICS | **Blocked by D2**; ship behind the same no-op client wrapper pattern as apparule |
+| `account.cuesoft.io` sign-in + user linking (migration per data-model.md §3) | ECO-AUTH | **Blocked by D1** |
+| Support routing to clients.cuesoft.io | ECO-SUPPORT | Link-outs |
+| Direct bank/SMS ingestion research spike | PRD §5 roadmap | Explicitly post-file-upload; regional aggregator landscape (e.g. Mono/Okra-class providers) is its own investigation |
+
+**Exit criteria:** ecosystem events flowing; central identity live with
+migration path proven; bank-integration decision documented.
+
+## Dependencies
+
+| ID | Dependency | Blocks |
+| --- | --- | --- |
+| D1 | `account.cuesoft.io` contract | Phase 3 identity |
+| D2 | Upstat event-ingestion API | Phase 3 events |
+| D3 | Expendit clause on privacy.cuesoft.io | Phase 0 privacy hub copy |
+
+## Sequencing rationale
+
+Phases 0–1 close every **Must** with the least engineering (the engine already
+exists) and make the privacy story real before growth work; Phase 2 pays the
+scaling debt in the pipeline the PRD's traffic assumes; Phase 3 waits on
+external contracts (D1/D2) and the deliberately-deferred bank integration.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -69,3 +69,26 @@ Phases 0–1 close every **Must** with the least engineering (the engine already
 exists) and make the privacy story real before growth work; Phase 2 pays the
 scaling debt in the pipeline the PRD's traffic assumes; Phase 3 waits on
 external contracts (D1/D2) and the deliberately-deferred bank integration.
+
+---
+
+## Revision — scope expansion (2026-07-16)
+
+Phases 0–2 stand as written (trust surface → downloadables/rights → pipeline
+hardening). The expansion appends:
+
+- **Phase 3 (revised) — Bank linking**: aggregator decision (NG-first
+  Mono/Okra vs Plaid), link/sync/re-auth flows into the shared staged-review
+  pipeline (BNK-001/002). Upstat events + account.cuesoft.io items move here
+  unchanged.
+- **Phase 4 — Company financials**: org model migration (personal org
+  auto-create), statement upload + line-item mapping review, ratio engine +
+  trends (CMP-001…003).
+- **Phase 5 — Tax center**: profile/calendar/estimates (TAX-001), filing
+  wizard generating filing-ready documents (TAX-002); direct e-filing (TAX-003)
+  behind jurisdiction/partner availability.
+- **Phase 6 — Mobile parity** (receipt capture first) + Brex-system dashboard
+  restyle completes (design.md rolls out progressively from Phase 3).
+
+Gates: aggregator + tax-jurisdiction decisions are Phase 3/5 entry criteria;
+company features require the org migration to ship first.

--- a/docs/tax-engine.md
+++ b/docs/tax-engine.md
@@ -1,0 +1,113 @@
+# Expendit — Tax Engine Contract (Nigeria)
+
+> Implements E-2 (Nigeria-first) at the computation level. **Governing design
+> rule: tax rules are versioned data, not code** — the engine executes rule
+> sets selected by tax period, so law changes are config releases with
+> effective dates, and every computed field carries its rule-set version in
+> its trace (pages.md B7 "how we got this").
+>
+> ⚠️ **Professional review gate:** the tables below encode the rules as
+> understood at writing (incl. the Nigeria Tax Act 2025 regime effective
+> 2026-01-01). A licensed tax practitioner must sign off each rule set
+> before the filing wizard leaves "estimate" labeling. This is a launch
+> checklist item, not a formality.
+
+## 1. Rule-set mechanism
+
+```
+TAX_RULESET {
+  id: "ng-pit-2026" | "ng-pit-legacy" | "ng-cit-2026" | "ng-vat-2026" | …
+  jurisdiction: "NG"
+  kind: pit | cit | vat
+  effective_from / effective_to
+  params: { bands: […], reliefs: {…}, rates: {…} }
+  signoff: { by, date, reference }   // professional review gate
+}
+```
+
+Period → rule-set resolution is by the period's start date. FY2025 personal
+filings resolve `ng-pit-legacy`; 2026 onward resolve `ng-pit-2026`.
+
+## 2. PIT (personal income tax)
+
+### 2.1 `ng-pit-2026` (Nigeria Tax Act 2025, from 2026-01-01)
+
+Chargeable income = gross income − allowed deductions − **rent relief**
+(20% of annual rent, capped ₦500,000, where rent is user-supplied with a
+prompt). The legacy Consolidated Relief Allowance is abolished in this
+regime.
+
+| Band (annual, ₦) | Rate |
+| --- | --- |
+| first 800,000 | 0% |
+| next 2,200,000 (to 3m) | 15% |
+| next 9,000,000 (to 12m) | 18% |
+| next 13,000,000 (to 25m) | 21% |
+| next 25,000,000 (to 50m) | 23% |
+| above 50,000,000 | 25% |
+
+### 2.2 `ng-pit-legacy` (pre-2026 periods)
+
+CRA = max(₦200,000, 1% of gross) + 20% of gross; bands
+7/11/15/19/21/24% over 300k/300k/500k/500k/1.6m/above-3.2m; minimum tax 1%
+of gross where computed tax is lower (with low-income exemption).
+
+### 2.3 Inputs from the ledger
+
+Gross income = sum of `income` transactions in period, **excluding**
+categories flagged non-taxable (capital transfers between own accounts,
+loan principal received, gifts — a per-category `tax_treatment` attribute:
+`taxable_income | exempt | ignore`, user-reviewable in Categories). Every
+figure in the wizard traces to the transaction list behind it.
+
+## 3. CIT (companies)
+
+### `ng-cit-2026`
+
+| Classification | Test | Rate |
+| --- | --- | --- |
+| Small company | turnover ≤ ₦100m AND fixed assets ≤ ₦250m | 0% |
+| Other | — | 30% + **4% development levy** on assessable profits (consolidates the former education tax etc.) |
+
+Inputs come from the mapped statements (line-items.md): assessable profit
+starts from `net_income` with an adjustments worksheet (disallowables:
+depreciation add-back vs capital allowances — **v1 exposes the worksheet
+with editable adjustment lines rather than pretending to compute capital
+allowances**; each line requires a label and traces into the filing).
+Classification inputs (`revenue`, `ppe`+`intangibles`) come from mapped
+line items; borderline (±10%) classification prompts review.
+
+`ng-cit-legacy`: 0/20/30% by the 25m/100m turnover thresholds + TET 3%.
+
+## 4. VAT
+
+`ng-vat-2026`: rate **7.5%**; output VAT from `vatable` income categories,
+input VAT from `vatable` expense categories (per-category `vat_treatment`:
+`vatable | zero_rated | exempt`); net position = output − recoverable input;
+monthly period with filing due the **21st** of the following month (drives
+the MI-13 deadline banners). Registration-threshold guidance (turnover ≥
+₦25m) surfaces as a banner for below-threshold orgs, not a block.
+
+Zero-rated/exempt category defaults (basic food, medical, educational
+materials, exports — expanded under the 2025 Act) ship as the rule set's
+category-mapping suggestions; the user's category → treatment mapping is
+theirs to confirm.
+
+## 5. Estimation vs filing
+
+| Mode | Behaviour |
+| --- | --- |
+| **Estimate** (always available) | computed from whatever data exists; banner lists gaps ("3 months of statements missing") |
+| **Filing draft** (TAX-002) | requires: full-period data, confirmed category treatments, signed-off rule set; generates filing-ready documents (PIT self-assessment pack, CIT computation + capital-allowance worksheet, VAT return schedule) with the full trace appendix |
+| Direct e-filing (TAX-003) | later; per-channel integration decisions |
+
+Every generated figure stores `{value, ruleset_id, inputs: [transaction/line-item ids], formula}` — the immutable trace that makes an audit answerable.
+
+## 6. Acceptance
+
+- [ ] Same ledger + different periods resolves different rule sets correctly
+- [ ] PIT-2026 golden tests: 0 tax at ≤800k; spot values at band edges (3m, 12m, 25m, 50m)
+- [ ] Rent relief caps at 500k; absent rent input → relief 0 with prompt
+- [ ] CIT small-company test uses mapped line items; borderline prompts review
+- [ ] VAT net position reconciles to category-filtered transaction sums
+- [ ] No filing document generates from an unsigned rule set


### PR DESCRIPTION
PRD documentation phase for expendit. Docs only — no code.

**Headline finding:** EXP-002/003 are already substantially implemented (CSV/tabular + PDF + receipt-image import via Groq→Gemini, categorization engine, duplicate detector, 4 anomaly types, summaries + AI narrative). The real gaps are the trust surface and scale:

- **prd.md** — requirements mapped against verified current state; derived user-rights requirements (export-all/delete-all); AI-processing disclosure flagged; open questions (AI data residency, D1 migration, retention defaults).
- **architecture.md** — context diagrams, import-pipeline deep dive (mermaid), architectural debts (synchronous 120s AI budget in-request, financial data in logs) with proposed fixes, target sequences for downloads + purge flow.
- **data-model.md** — current Mongo entities (ER), target additions (report artifacts, purge requests, consent), D1 identity-migration plan, classification + retention defaults.
- **api.md** — complete current route inventory, v1 deltas, requirement→gap table.
- **roadmap.md** — 4 phases: privacy/preview Musts → downloadable reports + data rights → pipeline hardening + anomaly UX → ecosystem (D1/D2) + bank-integration spike.

Intended for iteration — comment inline and I'll revise on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)