### PR TITLE
docs: GitBook wiring + OpenAPI draft

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,4 @@
+root: ./docs/
+structure:
+  readme: overview.md
+  summary: SUMMARY.md

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,28 @@
+# Summary
+
+- [Overview](overview.md)
+- [Setup](setup.md)
+
+## Product
+- [PRD Breakdown](prd.md)
+- [Decisions](decisions.md)
+- [Roadmap](roadmap.md)
+
+## Design
+- [Design Language](design.md)
+- [Pages, Screens & Microinteractions](pages.md)
+
+## System
+- [Architecture](architecture.md)
+- [Data Model](data-model.md)
+- [API Surface](api.md)
+- [Canonical Line Items & Ratios](line-items.md)
+- [Tax Engine](tax-engine.md)
+- [OpenAPI Draft](api/openapi.yaml)
+- [Engineering Contracts](engineering.md)
+- [Deployment](deployment.md)
+
+## Flows
+- [Authentication](flows/auth.md)
+- [Statement Import](flows/import.md)
+- [Bank Linking](flows/bank-link.md)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,32 @@
+openapi: 3.1.0
+info:
+  title: Expendit API
+  version: 0.1.0-draft
+  description: >-
+    Draft contract for /api/v1 (docs/api.md is the narrative source). Auth:
+    Firebase ID tokens (Google-only). Org-scoped authorization
+    (engineering.md §2); errors use the ecosystem envelope.
+servers:
+  - url: https://api.expendit.cuesoft.io
+  - url: http://localhost:8080
+security: [{ firebase: [] }]
+tags: [{ name: ledger }, { name: imports }, { name: banking }, { name: company }, { name: taxes }, { name: rights }]
+paths:
+  /api/v1/expenses: { get: { tags: [ledger], summary: List expenses (filters, cursor), responses: { "200": { description: Page } } }, post: { tags: [ledger], summary: Create, responses: { "201": { description: Expense } } } }
+  /api/v1/incomes: { get: { tags: [ledger], summary: List incomes, responses: { "200": { description: Page } } } }
+  /api/v1/import/upload: { post: { tags: [imports], summary: "Upload CSV/PDF/receipt (async; Idempotency-Key)", responses: { "202": { description: "{job_id}" }, "413": { description: file_too_large }, "422": { description: flows/import.md taxonomy } } } }
+  /api/v1/import/{jobId}: { get: { tags: [imports], summary: Job + staged transactions, responses: { "200": { description: Job } } } }
+  /api/v1/import/{jobId}/confirm: { post: { tags: [imports], summary: Commit staged rows (atomic, idempotent), responses: { "200": { description: Result } } } }
+  /api/v1/bank-links: { post: { tags: [banking], summary: Init Mono link, responses: { "201": { description: Connect config } } }, get: { tags: [banking], summary: List links, responses: { "200": { description: Links } } } }
+  /api/v1/bank-links/{id}/sync: { post: { tags: [banking], summary: Manual sync (rate-limited), responses: { "202": { description: Job } } } }
+  /api/v1/statements: { post: { tags: [company], summary: Upload financial statement, responses: { "202": { description: Mapping staged } } } }
+  /api/v1/statements/{id}/confirm: { post: { tags: [company], summary: Confirm mapping (identity-checked), responses: { "200": { description: Statement }, "422": { description: mapping_identity_violation } } } }
+  /api/v1/ratios: { get: { tags: [company], summary: Ratio report for period, responses: { "200": { description: Ratios + traces } } } }
+  /api/v1/tax/estimates: { get: { tags: [taxes], summary: Current estimates (rule-set versioned), responses: { "200": { description: Estimates } } } }
+  /api/v1/tax/filings: { post: { tags: [taxes], summary: Start filing draft, responses: { "201": { description: Draft } } } }
+  /api/v1/reports: { post: { tags: [rights], summary: Generate downloadable report, responses: { "201": { description: Artifact } } } }
+  /api/v1/account/export: { post: { tags: [rights], summary: Full-history export (owner), responses: { "202": { description: Archive job } } } }
+  /api/v1/account/purge: { post: { tags: [rights], summary: Request purge (grace window), responses: { "202": { description: Scheduled } } } }
+components:
+  securitySchemes:
+    firebase: { type: http, scheme: bearer, bearerFormat: "Firebase ID token (google.com provider only)" }


### PR DESCRIPTION
Completes X-2 plumbing: `.gitbook.yaml` (root: docs/, summary nav) + `docs/SUMMARY.md` for the GitBook space (created via API: org **Cuesoft**), and `docs/api/openapi.yaml` — the draft /v1 contract derived from docs/api.md, ready for Scalar rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)