### PR TITLE
docs: link the published GitBook site

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Run `make help` to see all available targets. For a detailed walkthrough, see
 [docs/setup.md](./docs/setup.md).
 
 ## Documentation
+- [Hosted docs](https://cuesoft.gitbook.io/expendit) — the full documentation site (auto-synced from `docs/`)
 
 Full documentation lives in the [`docs/`](./docs) folder:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -43,6 +43,8 @@ service is `api/common`; a future one would be `api/<function>`. See the
 [repository structure](../README.md#repository-structure) in the README.
 
 ## Product & design documentation
+> Published site: **https://cuesoft.gitbook.io/expendit** (Git-synced from this folder on every merge to main).
+
 
 - [prd.md](prd.md) — product requirements breakdown (requirements vs current state, user rights, open questions)
 - [architecture.md](architecture.md) — system design, import-pipeline deep dive, target sequences


### PR DESCRIPTION
Adds https://cuesoft.gitbook.io/expendit (live, Git-synced) to README + docs overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)