### PR TITLE
docs: X-9 OpenTelemetry ecosystem standard

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -143,3 +143,19 @@ until a real customer needs it.
   **Browser gRPC-Web + Envoy is a sunset path**: no new surface uses it
   (U-5); at monitors-v2 (OBS-006) the dashboard goes fully HTTP and Envoy
   retires from the cloud topology. apparule/expendit never adopt gRPC. ☑
+- **X-9 Telemetry standard (RATIFIED, directive 2026-07-16)**: **OpenTelemetry
+  everywhere** — traces, custom metrics, and logs from every service via OTel
+  SDKs (Go: otel-go + slog bridge; Python: opentelemetry-python + logging
+  handler; Next: @opentelemetry/sdk-node), W3C `traceparent` propagation
+  across HTTP and gRPC. **Export: direct OTLP from the SDK in v1** (batch
+  processors; collector sidecar on Cloud Run is the documented upgrade path
+  for tail sampling/fan-out). **Receiver: upstat's OTLP ingest gateway**
+  (OBS-001; gRPC 4317 + HTTP 4318, `Upstat-Ingest-Key` via
+  OTEL_EXPORTER_OTLP_HEADERS) — sibling products are its first-party
+  customers. Until OBS-001 ships, services instrument NOW with export
+  env-gated (unset OTEL_EXPORTER_OTLP_ENDPOINT = no-op). Logs dual-emit:
+  JSON stdout stays (Cloud Run native logging) + OTLP to upstat. Operational
+  telemetry (X-9) is SEPARATE from product analytics events (upstat
+  /v1/events counters) — never mix the pipelines. Env names standard:
+  OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS,
+  OTEL_RESOURCE_ATTRIBUTES. ☑

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -92,3 +92,17 @@ tokens, generated tax documents' contents, AI prompts containing user data
   `Authorization, Content-Type, Idempotency-Key, X-Org-Id`; preflight 204
   with `Access-Control-Max-Age: 600`.
 - **Current middleware is a flagged DEFECT: it reflects any origin with `Allow-Credentials: true` — must adopt the contract below at first touch (tracked as a Phase 0 hardening item).**
+
+## Telemetry (OpenTelemetry, X-9)
+
+- Traces: OTel SDK auto-instrumentation (HTTP server/client, gRPC, DB) +
+  manual spans on domain operations; W3C traceparent propagated on every
+  outbound call (incl. service-to-service).
+- Metrics: OTel Meter API — each service registers its KPI instruments
+  (request histograms come free; domain counters per the flow specs'
+  instrumentation sections are PRODUCT events via upstat /v1/events, NOT
+  OTel metrics — keep the pipelines separate).
+- Logs: slog/logging → OTel bridge dual-emit (JSON stdout for Cloud Run +
+  OTLP to upstat). The never-log list applies to BOTH pipelines.
+- Export: direct OTLP, env-gated (no endpoint ⇒ no-op); receiver = upstat
+  ingest (X-9). Sampling: parent-based, 10% default, errors always.

--- a/docs/features.md
+++ b/docs/features.md
@@ -81,3 +81,4 @@
 | EX-4 | build-and-test.yml + release.yml (tag-gated) | deployment.md, X-6 |
 | EX-5 | cuesoft-iac expendit stack (Cloud Run, WIF, Doppler, Aiven PG) | deployment.md §2, X-5 |
 | EX-6 | E2E smoke (release gate) | engineering §4 |
+| EX-7 | OTel instrumentation (traces/metrics/log bridge, env-gated export → upstat) | engineering §Telemetry, X-9 |


### PR DESCRIPTION
OTel everywhere: SDK instrumentation (traces, custom metrics, log bridges), W3C traceparent propagation, direct OTLP export env-gated until upstat's OBS-001 receiver ships, dual-emit logging, and a hard separation between operational telemetry and product analytics events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)