### PR TITLE
docs: financial-platform completeness — remittance authorities, statement capture/analysis gaps, X-10 identity tiers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -63,7 +63,7 @@ without `:userID`, error envelope, pagination) plus these new capabilities:
 
 | Method & path | Purpose |
 | --- | --- |
-| `POST /api/v1/reports` | `{kind: monthly_summary\|cash_movement, period, format: pdf\|csv}` → `201 {artifact_id, signed_url, expires_at}` — **signed URL from the X-5 bucket [Decided]**, 30-day artifact TTL |
+| `POST /api/v1/reports` | `{kind: monthly_summary\|cash_movement\|category_deep_dive\|financial_statement, period, format: pdf\|csv, category?, statement_kind?}` (`category` required for `category_deep_dive`; `statement_kind` + statement-grammar `period` for `financial_statement` — pages.md B5/B6) → `201 {artifact_id, signed_url, expires_at}` — **signed URL from the X-5 bucket [Decided]**, 30-day artifact TTL |
 | `GET /api/v1/reports` | past artifacts (TTL'd) |
 | `POST /api/v1/account/export` | full-history export — USR-001: `202 {job_id}`; poll `GET /api/v1/account/export/{job_id}` → `{status, signed_url?}`; archive = ZIP of CSV per collection + manifest.json; **7-day download TTL [Decided]** |
 | `POST /api/v1/account/purge` | request full deletion (grace window) — USR-002 |
@@ -110,11 +110,11 @@ idempotency keys on upload/purge/report creation.
 
 | Group | Endpoints |
 | --- | --- |
-| Orgs | `POST /orgs` · `GET /orgs` · members: `POST /orgs/{id}/members` (email invite → pending until that email's first sign-in), `PATCH /orgs/{id}/members/{user}` (role), `DELETE` (remove) · **org context via `X-Org-Id` header [Decided]** (absent = personal org) |
+| Orgs | `POST /orgs` · `GET /orgs` · `PATCH /orgs/{id}` (name, `registered_address`, `fiscal_year_end` — data-model.md §5) · members: `POST /orgs/{id}/members` (email invite → pending until that email's first sign-in), `PATCH /orgs/{id}/members/{user}` (role), `DELETE` (remove) · **org context via `X-Org-Id` header [Decided]** (absent = personal org) |
 | Bank links | `POST /bank-links` (widget config) · `PUT /bank-links/{id}/exchange {code}` (token exchange, flows/bank-link.md §1) · `/webhooks/bank` (signature-verified) · `GET /bank-links` · `POST /bank-links/{id}/sync` · `PATCH` (pause/auto-confirm) · `DELETE ?purge=bool` |
-| Company statements | `POST /statements` (upload) · `GET /statements/{id}/mapping` (staged line items) · `PATCH /statements/{id}/mapping` (fix canonical keys) · `POST /statements/{id}/confirm` |
+| Company statements | `POST /statements` (multipart upload → `202 processing`, or JSON manual entry `{kind, period, currency, line_items[]}` → `201` staged directly — flows/statement-mapping.md §2) · `GET /statements/{id}/mapping` (staged line items) · `PATCH /statements/{id}/mapping` (fix canonical keys · add parser-missed rows) · `POST /statements/{id}/confirm` |
 | Ratios | `POST /ratios/compute {period}` · `GET /ratios?period` · `GET /ratios/{key}/trace` |
-| Taxes | `GET /tax/profile` · `PUT /tax/profile` · `GET /tax/estimates` · `POST /tax/filings` (wizard draft) · `POST /tax/filings/{id}/generate` · `POST /tax/filings/{id}/submit` (v2, provider-gated) · `GET /tax/filings` |
+| Taxes | `GET /tax/profile` · `PUT /tax/profile` (jurisdiction, treatments, `state_of_residence`, `tin`/`rc_number`/`nin` — data-model.md §5) · `GET /tax/estimates` (responses include the resolved remittance-authority block, tax-engine.md §5.5) · `POST /tax/filings` (wizard draft) · `POST /tax/filings/{id}/generate` (gated on tax identity — `422 tax_identity_incomplete`) · `POST /tax/filings/{id}/submit` (v2, provider-gated) · `GET /tax/filings` (rows carry authority + deadline) |
 
 Bank-synced transactions enter the existing import pipeline as jobs
 (`source: bank_sync`) — one staged-review path for every ingress. Statement

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -19,14 +19,14 @@ paths:
   /api/v1/import/{jobId}/confirm: { post: { tags: [imports], summary: Commit staged rows (atomic, idempotent), responses: { "200": { description: Result } } } }
   /api/v1/bank-links: { post: { tags: [banking], summary: Init Mono link, responses: { "201": { description: Connect config } } }, get: { tags: [banking], summary: List links, responses: { "200": { description: Links } } } }
   /api/v1/bank-links/{id}/sync: { post: { tags: [banking], summary: Manual sync (rate-limited), responses: { "202": { description: Job } } } }
-  /api/v1/statements: { post: { tags: [company], summary: Upload financial statement, responses: { "202": { description: Mapping staged } } } }
+  /api/v1/orgs: { post: { tags: [company], summary: Create org, responses: { "201": { description: Org } } }, get: { tags: [company], summary: List my orgs, responses: { "200": { description: Orgs } } } }
+  /api/v1/orgs/{id}: { patch: { tags: [company], parameters: [{ $ref: "#/components/parameters/Id" }], summary: "Update org (name, registered_address, fiscal_year_end — data-model.md §5)", responses: { "200": { description: Org } } } }
+  /api/v1/statements: { post: { tags: [company], summary: "Upload financial statement (multipart) OR manual JSON entry {kind, period, currency, line_items[]} staged directly (flows/statement-mapping.md §2)", responses: { "202": { description: "Upload accepted (mapping_status: processing)" }, "201": { description: "Staged (manual entry)" } } } }
   /api/v1/statements/{id}/confirm: { post: { tags: [company], summary: Confirm mapping (identity-checked), responses: { "200": { description: Statement }, "422": { description: mapping_identity_violation } } } }
   /api/v1/ratios: { get: { tags: [company], summary: Ratio report for period, responses: { "200": { description: Ratios + traces } } } }
-  /api/v1/tax/estimates: { get: { tags: [taxes], summary: Current estimates (rule-set versioned), responses: { "200": { description: Estimates } } } }
+  /api/v1/tax/estimates: { get: { tags: [taxes], summary: "Current estimates (rule-set versioned; incl. resolved remittance authority — tax-engine.md §5.5)", responses: { "200": { description: Estimates } } } }
   /api/v1/tax/filings: { post: { tags: [taxes], summary: Start filing draft, responses: { "201": { description: Draft } } } }
-  /api/v1/reports: { post: { tags: [rights], summary: Generate downloadable report, responses: { "201": { description: Artifact } } } }
   /api/v1/account/export: { post: { tags: [rights], summary: Full-history export (owner), responses: { "202": { description: Archive job } } } }
-  /api/v1/account/purge: { post: { tags: [rights], summary: Request purge (grace window), responses: { "202": { description: Scheduled } } } }
   /api/v1/bank-links/{id}/exchange:
     put: { tags: [banking], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Exchange Mono widget code for account token, responses: { "200": { description: Link active }, "422": { description: link_expired } } }
   /api/v1/bank-links/{id}:
@@ -36,21 +36,39 @@ paths:
     post: { tags: [banking], summary: Mono webhook — signature-auth only; idempotent by provider event id, security: [], responses: { "200": { description: Accepted }, "401": { description: Invalid signature } } }
   /api/v1/statements/{id}/mapping:
     get: { tags: [company], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Poll mapping (processing|staged|failed) + staged line items, responses: { "200": { description: Mapping } } }
-    patch: { tags: [company], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Fix canonical keys / park rows unmapped, responses: { "200": { description: Mapping } } }
+    patch: { tags: [company], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Fix canonical keys / park rows unmapped / add parser-missed rows, responses: { "200": { description: Mapping } } }
   /api/v1/ratios/compute:
     post: { tags: [company], summary: Compute ratio report for a period, requestBody: { content: { application/json: { schema: { type: object, required: [period], properties: { period: { type: string } } } } } }, responses: { "201": { description: Ratio report with traces } } }
   /api/v1/ratios/{key}/trace:
     get: { tags: [company], parameters: [{ name: key, in: path, required: true, schema: { type: string } }, { name: period, in: query, required: true, schema: { type: string } }], summary: Formula trace (line-item inputs), responses: { "200": { description: Trace } } }
   /api/v1/tax/profile:
     get: { tags: [taxes], summary: Tax profile, responses: { "200": { description: Profile } } }
-    put: { tags: [taxes], summary: Update profile (jurisdiction, treatments), responses: { "200": { description: Profile } } }
+    put: { tags: [taxes], summary: "Update profile (jurisdiction, treatments, state_of_residence, tin/rc_number/nin — data-model.md §5)", responses: { "200": { description: Profile } } }
   /api/v1/tax/filings/{id}/generate:
-    post: { tags: [taxes], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Generate filing documents, responses: { "201": { description: Artifacts }, "409": { description: ruleset_unsigned }, "422": { description: period_incomplete | mapping_unconfirmed } } }
+    post: { tags: [taxes], parameters: [{ $ref: "#/components/parameters/Id" }], summary: "Generate filing documents (incl. remittance sheet — tax-engine.md §5.5)", responses: { "201": { description: Artifacts }, "409": { description: ruleset_unsigned }, "422": { description: period_incomplete | mapping_unconfirmed | tax_identity_incomplete } } }
   /api/v1/reports:
+    post:
+      tags: [rights]
+      summary: Generate downloadable report
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [kind, period, format]
+              properties:
+                kind: { enum: [monthly_summary, cash_movement, category_deep_dive, financial_statement] }
+                period: { type: string, description: "YYYY-MM; statement grammar (line-items.md §6) for financial_statement" }
+                format: { enum: [pdf, csv] }
+                category: { type: string, description: required for category_deep_dive }
+                statement_kind: { enum: [balance_sheet, income_statement, cash_flow], description: required for financial_statement }
+      responses:
+        "201": { description: Artifact }
     get: { tags: [rights], summary: Artifact history (30d TTL), responses: { "200": { description: List } } }
   /api/v1/account/export/{jobId}:
     get: { tags: [rights], parameters: [{ name: jobId, in: path, required: true, schema: { type: string } }], summary: Export job status + signed URL (7d TTL), responses: { "200": { description: Job } } }
   /api/v1/account/purge:
+    post: { tags: [rights], summary: Request purge (grace window), responses: { "202": { description: Scheduled } } }
     delete: { tags: [rights], summary: Cancel purge within grace, responses: { "204": { description: Cancelled }, "410": { description: grace_expired } } }
   /api/v1/consent:
     get: { tags: [rights], summary: Accepted documents, responses: { "200": { description: List } } }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,6 +120,10 @@ flowchart TD
 AI provider selection: `GROQ_API_KEY` → `GEMINI_API_KEY` → none (CSV/PDF regex
 still work; image uploads error with guidance).
 
+The anomaly engine's four rule types have their computational contract
+(formulas, v1 constants, severities) in flows/import.md §7 — a rules-as-data
+registry like line-items.md §5.
+
 ### 4.2 Known architectural debts **[Current → Proposed fixes]**
 
 | Debt | Consequence | Proposed fix |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -85,7 +85,8 @@ Notes:
   `internal/model/`; `password`/`refresh_token` are excluded from all JSON
   responses (`json:"-"`).
 - Anomaly vocabulary **[Current]**: `large_transaction`, `spending_spike`,
-  `abnormal_category`, `duplicate_charge`.
+  `abnormal_category`, `duplicate_charge`. Computational contract (formulas,
+  v1 constants, severities): flows/import.md §7.
 - Raw uploaded file bytes are **not persisted** — parsed in-memory only.
   This is a privacy feature to keep, and to document (prd.md §8.3).
 
@@ -100,9 +101,10 @@ erDiagram
     REPORT_ARTIFACT {
         objectid _id PK
         string userid
-        string kind "monthly_summary | cash_movement | full_export"
+        string kind "monthly_summary | cash_movement | category_deep_dive | financial_statement | full_export"
         string format "pdf | csv | json"
-        string period "e.g. 2026-06"
+        string period "e.g. 2026-06; statement grammar for financial_statement"
+        json params "category_deep_dive: {category}; financial_statement: {statement_kind}"
         string object_key "or streamed; TTL"
         datetime created_at
     }
@@ -142,7 +144,7 @@ the same Firebase project — no further migration.
 
 | Class | Data | Rules |
 | --- | --- | --- |
-| High-sensitivity | Transactions (all), import staging, summaries, AI narratives, uploaded file bytes (in flight) | Never in logs (the current `[pdf] sample:` log line must go — architecture.md §4.2); TLS in transit; third-party AI processing disclosed; raw files not at rest |
+| High-sensitivity | Transactions (all), import staging, summaries, AI narratives, uploaded file bytes (in flight), tax identity & location (`tin`, `rc_number`, `nin`, `state_of_residence`, `registered_address` — X-10 tier-1/tier-2 fields, §5) | Never in logs (the current `[pdf] sample:` log line must go — architecture.md §4.2); TLS in transit; third-party AI processing disclosed; raw files not at rest |
 | Sensitive | User identity, consent, purge requests | Standard PII handling; consent/purge rows immutable audit records |
 | Operational | Job status/counters, event counters to Upstat | Safe for logs/metrics; Upstat events are **counters only, never amounts or descriptions** |
 
@@ -171,7 +173,9 @@ erDiagram
         string name
         string kind "personal | company"
         string currency
-        string country }
+        string country
+        string fiscal_year_end "MM-DD, default 12-31 — defines FYYYYY periods (line-items.md §6)"
+        json registered_address "company orgs: {line1, line2?, city, state, country} — state required (CIT/VAT authority, tax-engine.md §5.5); high-sensitivity (§4)" }
     BANK_LINK { objectid _id PK
         objectid org_id FK
         string provider "mono (E-1 ratified); plaid later"
@@ -196,26 +200,34 @@ erDiagram
         objectid org_id FK
         string jurisdiction "NG"
         string taxpayer_kind "individual|company"
-        string tin "optional"
+        string tin "optional until filing (422 tax_identity_incomplete)"
+        string state_of_residence "NG state code; required for individual profiles — resolves the PIT State IRS (tax-engine.md §5.5); high-sensitivity (§4)"
+        string rc_number "company; optional until filing; high-sensitivity (§4)"
+        string nin "individual; optional; high-sensitivity (§4)"
         json category_treatments "category → tax_treatment + vat_treatment + vat_basis" }
     TAX_ESTIMATE { objectid _id PK
         objectid profile_id FK
         string kind "pit|cit|vat"
         string period
         json computed_fields "with input traces"
+        json authority "resolved remittance authority {code, name} — tax-engine.md §5.5"
         string ruleset_id
         datetime computed_at }
     FIN_STATEMENT { objectid _id PK
         objectid org_id FK
         string kind "balance_sheet|income_statement|cash_flow"
-        string period "e.g. 2026-Q2 / FY2025"
-        string source_file_type
-        string mapping_status "staged|confirmed" }
+        string period "closed grammar (line-items.md §6): YYYY-Qn | YYYY-H1/H2 | FYYYYY"
+        string source_file_type "csv|xlsx|pdf|image|manual"
+        string mapping_status "processing|staged|confirmed|failed|superseded (flows/statement-mapping.md §4)"
+        objectid superseded_by FK "nullable — the replacement statement (audit trail)" }
     LINE_ITEM { objectid _id PK
         objectid statement_id FK
-        string canonical_key "current_assets|inventory|total_debt|revenue|cogs|net_income|..."
+        string canonical_key "current_assets|inventory|long_term_debt|revenue|cogs|net_income|..."
         string source_label "as it appeared in the upload"
-        float amount }
+        float amount
+        string status "mapped|unmapped (parked rows excluded from ratios)"
+        float confidence "nullable — AI suggestion confidence 0-1"
+        string mapped_by "ai|user" }
     RATIO_REPORT { objectid _id PK
         objectid org_id FK
         string period
@@ -227,7 +239,8 @@ erDiagram
         string period
         string status "draft|generated|submitted|accepted"
         json computed_fields "each with input trace"
-        string artifact_key "generated forms"
+        json authority "resolved remittance authority {code, name} — immutable once generated"
+        string artifact_key "generated forms incl. remittance sheet"
         datetime filed_at }
 ```
 
@@ -241,6 +254,17 @@ Ratio formulas persist **with their inputs** so every gauge is auditable
 Bank credentials are never stored — only provider tokens, encrypted, with
 provider-side revocation honored (BNK-002 unlink offers keep-or-purge for
 already-imported transactions).
+
+**Who uses which org kind [Decided 2026-07-16]:** individuals and
+unincorporated freelancers use their auto-created **personal org** (ledger
+capture, imports, PIT — no financial statements); any business entity that
+wants statement capture / ratios / CIT creates a **company org regardless of
+incorporation status**, with `TAX_PROFILE.taxpayer_kind`
+(`individual | company`) deciding PIT-vs-CIT treatment (tax-engine.md §2's
+freelancer limitation applies to gross-income PIT either way).
+Cross-referenced from pages.md B6's empty state and prd.md §2. Estimates and
+filings persist their resolved remittance authority (tax-engine.md §5.5) so
+historical records survive registry changes.
 
 ---
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -32,6 +32,11 @@ the tax-profile model.
 
 ☑ Ratified (jurisdiction: Nigeria)
 
+**Scope note (2026-07-16) [Decided]:** PAYE (employer payroll remittance),
+WHT tracking/credits, and state-specific levies are **out of v1 scope** —
+considered and excluded, not overlooked; the rule-set mechanism
+(`kind: paye | wht`) is the extension point when they land (tax-engine.md §1).
+
 ## E-3 · AI processing of financial data — gates the privacy hub copy (Phase 0)
 
 | Option | For | Against |
@@ -160,3 +165,29 @@ until a real customer needs it.
   /v1/events counters) — never mix the pipelines. Env names standard:
   OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS,
   OTEL_RESOURCE_ATTRIBUTES. ☑
+- **X-10 Identity, profile & KYC tiers (RATIFIED, directive 2026-07-16)**: layered on
+  X-1 — Google-only sign-in stays the sole credential; tiers add profile data and
+  verification, never alternative logins. **Tier 0 — Google identity** (all
+  products): firebase_uid + Google-verified email; grants all read/basic use.
+  **Tier 1 — self-attested profile & location** (captured in product
+  profile/settings; sensitive PII, never logged): apparule = bio + profile
+  location {city, state, country} powering proximity-ranked designer
+  recommendations ("near me") and delivery-address pre-fill (delivery address
+  itself stays frozen per order); expendit = tax-jurisdiction location —
+  state_of_residence for individuals, registered_address for company orgs —
+  which resolves the remittance authority (State IRS vs FIRS); upstat = org
+  timezone (IANA) only, for accurate report rendering and time-bucketing —
+  deliberately the entire upstat requirement. **Tier 2 — provider-verified
+  financial identity** (only where money moves or government filings
+  generate; store provider refs + verification state, never raw government
+  IDs): apparule designer payouts = Paystack bank resolution, BVN-backed
+  (already ratified A-2 — canonized as the ecosystem pattern); expendit
+  filing identity = TIN (+ RC number + registered address for companies)
+  required at filing-pack generation (422 tax_identity_incomplete); v1
+  verification is format validation + attestation, provider-verified arrives
+  with direct e-filing (post-v1); upstat = N/A until billing enters the PRD.
+  **Rules**: tiers gate capabilities, never sign-in; KYC state machines +
+  error codes live in flow docs (apparule kyc_incomplete/post_unavailable is
+  the template); tier-2 fields are high-sensitivity in every data-model §4
+  classification; verification is delegated to the money/filing provider —
+  no in-house document review. ☑

--- a/docs/design.md
+++ b/docs/design.md
@@ -90,7 +90,7 @@ ecosystem change, PR'd to all three design.md files together.
 | `LinkAccountCard` | bank logo · masked account · sync status dot · last-synced | bank linking |
 | `WizardShell` | left step rail + content + sticky summary right | imports, tax filing |
 | `Inspector` | right slide-in panel, ESC closes | record detail everywhere |
-| `CommandPalette` | ⌘K: navigate, actions ("upload statement", "new category"), recent records | Brex signature **[Proposed]** |
+| `CommandPalette` | ⌘K: navigate, actions ("upload statement", "new transaction", "new category"), recent records | Brex signature **[Proposed]** |
 | `Toast/Banner` | toasts transient; banners persistent (bank re-auth needed, tax deadline) | |
 
 ## 4. Microinteraction catalog
@@ -151,8 +151,8 @@ component samples are the next Style Guide iteration.
 | --- | --- | --- |
 | 0 Foundations | type styles (§2 incl. editorial display sizes) · Lucide icons · table grid styles (compact 32 / comfortable 44 rows) | everything |
 | 1 Atoms | Button, Input, MoneyCell, CategoryChip, AnomalyBadge, Toast/Banner | molecules |
-| 2 Molecules | StatCard, TxnTable row, UploadDropzone, LinkAccountCard, RatioGauge, Inspector chrome, CommandPalette, WizardShell chrome | tables + flows |
-| 3 Assemblies | TxnTable (full), staged-review table, ratio grid, filing wizard steps, EmptyState set | screens |
+| 2 Molecules | StatCard, TxnTable row, UploadDropzone, LinkAccountCard, RatioGauge, Inspector chrome, CommandPalette, WizardShell chrome, FormRow, ManualStatementRow, RemitToCard, TaxCalendarRow | tables + flows |
+| 3 Assemblies | TxnTable (full), staged-review table, ratio grid, StatementView, filing wizard steps, EmptyState set | screens |
 | 4 Screen templates | dashboard, transactions, import review, accounts, company statements+ratios, tax center+wizard, settings/rights | dashboard design |
 | 5 Home page | A1–A11 Brex-editorial sections | landing redesign |
 
@@ -171,6 +171,11 @@ component samples are the next Style Guide iteration.
 | RatioGauge | healthy / warning / critical / n-a ("missing input") · with/without benchmark band |
 | Inspector | record / anomaly-explain / trace ("how we got this") |
 | Banner | info / warn (deadline T-30/T-7/T-1 tints) / error (reauth) |
+| FormRow | label + control + helper/error · state: default/focus/error/disabled (tax profile, org settings, manual entry) |
+| RemitToCard | tax: pit/cit/vat · resolved authority (State IRS e.g. LIRS / FIRS) + amount due + deadline + payment-channel chip (tax-engine §"Remittance & authorities" registry) |
+| StatementView | kind: balance_sheet / income_statement / cash_flow · derived rows flagged (formula note) · mapping-warning badges · period-selector header (pages.md B6 statement view) |
+| ManualStatementRow | canonical-key combobox + amount input · state: default / error (identity check) — manual entry + mapping add-row |
+| TaxCalendarRow | tax kind + period + due date + T-30/T-7/T-1 escalation tint (MI-13 data source) |
 | EmptyState | transactions / imports / accounts / ratios / tax (each with demo-data toggle where specced) |
 
 ### 8.3 Design-prep needed from content

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -12,8 +12,9 @@ codes live in their flow specs: import (flows/import.md §3 — `file_too_large`
 `unsupported_type`, `no_transactions_found`, `password_protected_pdf`,
 `ai_unavailable`, `job_already_confirmed`), bank-link (flows/bank-link.md —
 `already_linked`, `link_expired`, `reauth_required`), tax
-(`ruleset_unsigned`, `period_incomplete`, `mapping_unconfirmed` — mapped to
-wizard steps in tax-engine.md §5), statements
+(`ruleset_unsigned`, `period_incomplete`, `mapping_unconfirmed`,
+`tax_identity_incomplete` — mapped to wizard steps in tax-engine.md §5),
+statements
 (`mapping_identity_violation`, `unmapped_threshold_exceeded` —
 line-items.md §4), rights (`purge_pending` — 409 on writes while a purge grace window is open;
 `grace_expired` — 410 on cancel attempts after execution). Plus universal:
@@ -49,6 +50,7 @@ Cross-org access is `404 not_found`, never `403` (no existence leaks).
 | Surface | Limit |
 | --- | --- |
 | Import uploads | 10/hr per org, 30/day |
+| Statement uploads | 10/hr per org (flows/statement-mapping.md §5) |
 | Manual bank sync | 1/10min per link (flows/bank-link.md) |
 | Report generation | 12/hr per org |
 | Export-all | 2/day per org |

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,7 +19,7 @@
 
 | ID | Unit | Delivers | Refs | Deps |
 | --- | --- | --- | --- | --- |
-| E1-1 | Report artifact engine | monthly summary + cash-movement, PDF/CSV render, TTL storage (Cloud Storage) | api.md §2, EXP-004 | — |
+| E1-1 | Report artifact engine | monthly summary + cash-movement + category deep-dive (`category` param), PDF/CSV render, TTL storage (Cloud Storage) | api.md §2, EXP-004 | — |
 | E1-2 | Reports UI | generate/download/history MI-14 | pages.md B5 | E1-1 |
 | E1-3 | Export-all | full-history archive job (CSV/JSON) | USR-001 | E1-1 |
 | E1-4 | Purge flow | grace-window purge + MI-15 danger UX | USR-002, architecture §5.3 | — |
@@ -53,20 +53,21 @@
 | --- | --- | --- | --- | --- |
 | E4-1 | Mongo→Postgres migration | schema per data-model, parity harness, cutover | X-5, engineering §4 | — |
 | E4-2 | Org model | personal-org auto-create, roles, org switcher | data-model §5, E-4 | E4-1 |
-| E4-3 | Statement upload + mapping | canonical line-item staging, AI-suggested mapping, review UI | line-items.md §1–4, pages.md B6 | E4-2 |
-| E4-4 | Ratio engine | 14 ratios + formula traces + identity cross-checks | line-items.md §5 | E4-3 |
-| E4-5 | Ratio UI | RatioGauge grid MI-8, trends, export | pages.md B6 | E4-4 |
+| E4-3 | Statement upload + mapping | canonical line-item staging (file upload · scanned-image vision path · manual JSON entry), AI-suggested mapping, review UI with add-row | line-items.md §1–4, flows/statement-mapping.md, pages.md B6 | E4-2 |
+| E4-4 | Ratio engine | 22 registry metrics (17 ratios + growth/value rows) + benchmark-band constants + formula traces + identity cross-checks | line-items.md §5 | E4-3 |
+| E4-5 | Ratio UI | RatioGauge grid MI-8, trends (ratios + line items), export | pages.md B6 | E4-4 |
 | E4-6 | Authz matrix enforcement | member/admin/owner capabilities + tests | engineering §2 | E4-2 |
+| E4-7 | Statement viewer + artifact export | normalized statement view (derived rows flagged, mapping warnings, period selector) + `financial_statement` report kind | pages.md B6, line-items.md §4, api.md §2 | E4-3, E1-1 |
 
 ## Phase 5 — Tax center
 
 | ID | Unit | Delivers | Refs | Deps |
 | --- | --- | --- | --- | --- |
-| E5-1 | Rule-set mechanism | versioned TAX_RULESET + period resolution + sign-off gate | tax-engine §1 | E4-1 |
+| E5-1 | Rule-set mechanism | versioned TAX_RULESET + period resolution + sign-off gate + filing calendar & remittance-authority registry | tax-engine §1, §5.5 | E4-1 |
 | E5-2 | PIT engine | both regimes, band tests, rent relief, category treatments | tax-engine §2 | E5-1 |
 | E5-3 | CIT engine | classification, adjustments worksheet, levy | tax-engine §3 | E4-4, E5-1 |
 | E5-4 | VAT engine | treatments, net position, monthly deadlines MI-13 | tax-engine §4 | E5-1 |
-| E5-5 | Filing wizard | WizardShell MI-10, traces, document generation | pages.md B7, tax-engine §5 | E5-2..4 |
+| E5-5 | Filing wizard | WizardShell MI-10, traces, document generation incl. remittance sheet, tax-identity gate (`tax_identity_incomplete`) | pages.md B7, tax-engine §5–5.5 | E5-2..4 |
 | E5-6 | Tax golden suite | band-edge fixtures per rule set (launch gate) | engineering §4 | E5-2..4 |
 
 ## Phase 6 — Mobile parity (receipt-capture-first) — units defined at phase entry

--- a/docs/flows/import.md
+++ b/docs/flows/import.md
@@ -76,3 +76,21 @@ Events: `upload_success{file_type}` (job completed), `import_confirmed`,
 - [ ] Statement re-upload imports only the non-duplicate remainder
 - [ ] AI-down leaves CSV imports fully functional
 - [ ] No transaction contents in logs (the `[pdf] sample:` class of leak, gone)
+
+## 7. Anomaly rules registry **[Proposed — ratify; capture the actual current-code thresholds during E2-4 and correct this table]**
+
+The computational contract behind the anomaly vocabulary (data-model.md §1,
+architecture.md §4.1) — rules-as-data like line-items.md §5, so a threshold
+change is a docs PR, not a code change. Severity drives the AnomalyBadge
+tint (design.md §3) and escalates `info → warn` when the flagging value
+exceeds 2× its rule threshold.
+
+| rule_id | Formula | Params (v1 constants) | Base severity |
+| --- | --- | --- | --- |
+| `large_transaction` | flag when `\|amount\| > max(k × median_90d, floor)` — median of trailing-90d confirmed transactions, same direction | `k = 5` · `floor = ₦50,000` | warn |
+| `spending_spike` | category month total `> μ + z·σ` of the trailing window; rule skipped below the history minimum | `window = 6 months` · `z = 2` · `min history = 3 months` | warn |
+| `abnormal_category` | flag when `\|amount\| > k ×` trailing mean of its category (same direction); rule skipped below the sample minimum | `k = 3` · `min = 5 prior transactions` | info |
+| `duplicate_charge` | same normalized counterpart + exact amount within `N` days **post-confirm** — distinct from staged-import dedup (§4, which prevents re-imports); this catches double-billing already in the ledger | `N = 3 days` | warn |
+
+Any anomaly on a bank-synced job forces review — §5's auto-confirm override
+consumes these rules.

--- a/docs/flows/statement-mapping.md
+++ b/docs/flows/statement-mapping.md
@@ -10,13 +10,15 @@
 ```mermaid
 flowchart TD
     UP[/company/statements: drop file/] --> VAL{client checks}
+    MAN[/company/statements: enter manually/] --> MPOST[POST /statements JSON → 201, staged directly]
     VAL -->|fail| E0[inline error]
     VAL --> POST[POST /statements → 202 statement_id, mapping_status: processing]
     POST --> POLL[GET /statements/id/mapping — poll 2s]
     POLL --> ST{status}
     ST -->|failed| FAIL[error + guidance]
     ST -->|staged| REVIEW[mapping review: source rows → canonical keys]
-    REVIEW --> FIX[fix keys MI-4-style; park rows as unmapped]
+    MPOST --> REVIEW
+    REVIEW --> FIX[fix keys MI-4-style; park rows as unmapped; add missed rows]
     FIX --> CONFIRM[POST /statements/id/confirm]
     CONFIRM -->|identity ±1% fails| E1[422 mapping_identity_violation]
     CONFIRM -->|>20% unmapped| E2[422 unmapped_threshold_exceeded]
@@ -27,10 +29,11 @@ flowchart TD
 
 | Step | Contract |
 | --- | --- |
-| Client checks | CSV/XLSX/PDF, ≤ 15 MB (shared limit); statement `kind` + `period` selected at upload |
+| Client checks | CSV/XLSX/PDF **plus scanned/photographed statements: JPG/PNG/HEIC and image-only PDFs [Decided 2026-07-16]**, ≤ 15 MB (shared limit); statement `kind` + `period` (closed-grammar picker, line-items.md §6) selected at upload |
 | Upload | `Idempotency-Key` per file selection; same-key semantics as flows/import.md §2 (failed releases the key) |
-| Parse + suggest | tabular → direct row extraction; PDF → text extraction → AI mapping suggestions (Vertex, X-4); every suggestion carries `confidence` 0–1; rows with confidence < 0.6 arrive **unmapped** rather than guessed **[Decided]** |
-| Mapping review | per-row canonical-key combobox (closed vocabulary, line-items.md §1–3); currency field user-confirmed (mismatch vs org ⇒ `422 currency_mismatch`, line-items §4) |
+| Manual entry | `POST /statements` with JSON `{kind, period, currency, line_items: [{canonical_key, amount, label?}]}` → `source_file_type: manual`, lands **directly in `staged`** (no parse, no AI call, no `ai_processing` consent needed) — same review + confirm-time validations as uploads |
+| Parse + suggest | tabular → direct row extraction; PDF → text extraction → AI mapping suggestions (Vertex, X-4); **images + image-only PDFs (no text layer) → AI vision extraction — the flows/import.md VIS path reused; requires `ai_processing` consent [Decided 2026-07-16]**; every suggestion carries `confidence` 0–1; rows with confidence < 0.6 arrive **unmapped** rather than guessed **[Decided]** |
+| Mapping review | per-row canonical-key combobox (closed vocabulary, line-items.md §1–3); **rows the parser missed can be added** (canonical_key + amount — added rows count toward the identity check); currency field user-confirmed (mismatch vs org ⇒ `422 currency_mismatch`, line-items §4) |
 | Confirm | runs derivations + identity cross-check (line-items §4); immutable once confirmed — corrections = upload a replacement statement for the same period (supersedes, keeps audit history) |
 
 ## 3. Failure taxonomy
@@ -40,7 +43,8 @@ flowchart TD
 | `413 file_too_large` / `415 unsupported_type` | limits |
 | `422 no_line_items_found` | parse produced zero rows |
 | `422 password_protected_pdf` | encrypted |
-| `503 ai_unavailable` | Vertex down — manual mapping still available (suggestions absent) |
+| `403 consent_required` | scanned/image statement with `ai_processing` consent declined — guidance: export CSV/XLSX from the accounting tool, or use manual entry |
+| `503 ai_unavailable` | Vertex down — manual mapping still available for text uploads (suggestions absent); scanned/image statements cannot parse → guidance: export CSV/XLSX or use manual entry |
 | `422 mapping_identity_violation` · `422 unmapped_threshold_exceeded` · `422 currency_mismatch` | confirm-time rules (line-items §4) |
 | `409 period_exists` | confirmed statement of same kind+period exists — offer supersede |
 
@@ -59,7 +63,14 @@ before implementation**.
 
 ## 6. Acceptance
 
-- [ ] Fixtures per taxonomy row (incl. an identity-violating balance sheet)
+- [ ] Fixtures per taxonomy row (incl. an identity-violating balance sheet
+      and a scanned/photographed balance sheet through the vision path)
 - [ ] Low-confidence suggestions arrive unmapped, never silently guessed
 - [ ] Supersede path recomputes ratios and preserves old traces
-- [ ] Consent-declined path offers manual mapping with no AI call made
+- [ ] Consent-declined path offers manual mapping with no AI call made;
+      consent-declined scanned/image statements get the CSV/XLSX +
+      manual-entry guidance
+- [ ] Manual-entry statement skips parse/AI entirely and passes the same
+      confirm-time validations
+- [ ] Rows added in review (parser-missed) flow into derivations and the
+      identity check

--- a/docs/line-items.md
+++ b/docs/line-items.md
@@ -47,13 +47,13 @@
 
 ## 3. Cash-flow statement
 
-| Key | Examples |
-| --- | --- |
-| `cfo` | Net cash from operating activities |
-| `cfi` | Net cash from investing activities |
-| `cff` | Net cash from financing activities |
-| `capex` | Purchase of PP&E |
-| `net_change_in_cash` *(derived)* | |
+| Key | Examples | Used by |
+| --- | --- | --- |
+| `cfo` | Net cash from operating activities | operating cash-flow ratio, free cash flow, CFO-to-total-debt, runway |
+| `cfi` | Net cash from investing activities | `net_change_in_cash` |
+| `cff` | Net cash from financing activities | `net_change_in_cash` |
+| `capex` | Purchase of PP&E | free cash flow |
+| `net_change_in_cash` *(derived)* | | — |
 
 ## 4. Derivation & validation rules
 
@@ -88,24 +88,60 @@
   failure at confirm returns `422 mapping_identity_violation` (these codes
   originate here; engineering.md §1 catalogs them).
 
-## 5. Ratio formulas (the auditable registry)
+## 5. Ratio & metric formulas + benchmark bands (the auditable registry)
 
-| Ratio | Formula (canonical keys) |
-| --- | --- |
-| Current ratio | `current_assets / current_liabilities` |
-| Quick ratio | `(current_assets - inventory) / current_liabilities` |
-| Cash ratio | `cash_and_equivalents / current_liabilities` |
-| Debt-to-equity | `(short_term_debt + long_term_debt) / equity` |
-| Debt ratio | `total_liabilities / total_assets` |
-| Interest coverage | `operating_profit / interest_expense` |
-| Gross margin | `gross_profit / revenue` |
-| Operating margin | `operating_profit / revenue` |
-| Net margin | `net_income / revenue` |
-| ROA | `net_income / total_assets` |
-| ROE | `net_income / equity` |
-| Asset turnover | `revenue / total_assets` |
-| Inventory turnover | `cogs / inventory` |
-| Receivables days | `receivables / revenue × 365` |
+Benchmark bands ship as **constants in this registry [Decided v1]**
+(pages.md B6), labeled "general guidance" in the UI — industry-specific
+benchmarks are a later data product; changing a band is a docs PR, exactly
+like extending the vocabulary. `Direction` feeds gauge/delta coloring:
+`higher` = higher is better, `lower` = lower is better, `band` = healthy is
+a range.
+
+| Metric | Formula (canonical keys) | Healthy band (v1 general guidance) | Direction |
+| --- | --- | --- | --- |
+| Current ratio | `current_assets / current_liabilities` | healthy 1.5–3.0 · warning 1.0–1.5 or >3.0 · critical <1.0 | band |
+| Quick ratio | `(current_assets - inventory) / current_liabilities` | healthy ≥1.0 · warning 0.5–1.0 · critical <0.5 | higher |
+| Cash ratio | `cash_and_equivalents / current_liabilities` | healthy ≥0.2 · warning 0.1–0.2 · critical <0.1 | higher |
+| Working capital | `current_assets − current_liabilities` | no band — currency value (StatCard/MoneyCell, not RatioGauge) | higher |
+| Debt-to-equity | `(short_term_debt + long_term_debt) / equity` | healthy <1.0 · warning 1.0–2.0 · critical >2.0 | lower |
+| Debt ratio | `total_liabilities / total_assets` | healthy <0.5 · warning 0.5–0.7 · critical >0.7 | lower |
+| Interest coverage | `operating_profit / interest_expense` | healthy ≥3.0 · warning 1.5–3.0 · critical <1.5 | higher |
+| Interest coverage (EBITDA) | `(operating_profit + depreciation_amortization) / interest_expense` | as the EBIT variant | higher |
+| Gross margin | `gross_profit / revenue` | no band — trend-only (industry-sensitive) | higher |
+| Operating margin | `operating_profit / revenue` | no band — trend-only | higher |
+| Net margin | `net_income / revenue` | no band — trend-only | higher |
+| ROA | `net_income / total_assets` | no band — trend-only | higher |
+| ROE | `net_income / equity` | no band — trend-only | higher |
+| Asset turnover | `revenue / total_assets` | no band — trend-only | higher |
+| Inventory turnover | `cogs / inventory` | no band — trend-only | higher |
+| Receivables days | `receivables / revenue × 365` | no band — trend-only | lower |
+| Operating cash-flow ratio | `cfo / current_liabilities` | no band — trend-only | higher |
+| Free cash flow | `cfo + capex` (as-reported; see CF convention below) | no band — currency value | higher |
+| CFO-to-total-debt | `cfo / (short_term_debt + long_term_debt)` | no band — trend-only | higher |
+| Revenue growth | `(revenue_t − revenue_prev) / revenue_prev` | no band | higher |
+| Net-income growth | `(net_income_t − net_income_prev) / net_income_prev` | no band | higher |
+| Runway (months) | `cash_and_equivalents / avg monthly net cash burn` | no band — value; "n/a — cash-flow positive" when not burning | higher |
+
+**EBITDA-variant rule:** Interest coverage (EBITDA) is shown only when
+`depreciation_amortization` was separately mapped; otherwise it is omitted
+and the EBIT-basis trace note (§4) applies.
+
+**Growth-metric rules:** consecutive same-kind periods only (Q-over-Q,
+H-over-H, or FY-over-FY — never mixed granularity); "n/a — no prior period"
+when absent; when the prior value is ≤ 0 (e.g. loss to profit), the
+percentage is suppressed and the trace shows the absolute change with a
+"sign change" note.
+
+**Cash-flow convention:** `cfo`/`capex` are signed (§4 exception) — free
+cash flow computes `cfo + capex` as-reported (capex reported negative),
+i.e. CFO minus the capex outflow magnitude.
+
+**Runway (company orgs, pages.md B1 StatCard):** `burn` = trailing-3-period
+average net cash outflow — from `cfo` when confirmed cash-flow statements
+exist, else from the ledger's monthly net cash flow (income − expenses);
+renders "n/a — cash-flow positive" when not burning and "n/a — insufficient
+history" under 3 periods; the trace names the burn source (statement vs
+ledger).
 
 Each computed `RATIO_REPORT` row persists the formula string + the exact
 `LINE_ITEM` ids used (data-model.md §5) — the MI-8 trace. Period-average
@@ -125,3 +161,21 @@ with a trace note (never ∞/error): interest coverage with no
 `interest_expense` → "n/a — no interest expense"; inventory turnover with no
 `inventory` → "n/a"; ROE with `equity ≤ 0` → shown as "negative equity"
 badge instead of a number (a real signal, not hidden).
+
+## 6. Period grammar **[Proposed — ratify]**
+
+`FIN_STATEMENT.period` (data-model.md §5) is a **closed grammar**, selected
+from a picker at upload/manual entry — never free text — because statement
+pairing ("SAME `period` value", §5) and uniqueness (`409 period_exists`,
+flows/statement-mapping.md §3) both key on the exact string:
+
+| Token | Meaning | Annualization (§5) |
+| --- | --- | --- |
+| `YYYY-Qn` (e.g. `2026-Q2`) | calendar quarter | ×4 |
+| `YYYY-H1` / `YYYY-H2` | calendar half-year | ×2 |
+| `FYYYYY` (e.g. `FY2025`) | the org's fiscal year: the 12 months **ending on `ORG.fiscal_year_end`** (MM-DD, default `12-31`) in that year — a June-year-end company's FY2025 runs 2024-07-01 → 2025-06-30 | ×1 |
+
+Monthly statements (`YYYY-MM`) are **not accepted in v1** — the token is
+reserved; aggregate monthly management accounts to a quarter. The FY start
+date derived here feeds tax-engine.md §1 rule-set resolution ("by the
+period's start date").

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -37,7 +37,8 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
 (personal ↔ company orgs, data-model.md §5).
 
 ### B1 `/dashboard` — Overview
-- StatCard row: net cash flow, income, expenses, runway (company orgs) (MI-7).
+- StatCard row: net cash flow, income, expenses, runway (company orgs;
+  formula + n/a rules in line-items.md §5) (MI-7).
 - Cash-flow chart (12mo), category donut, anomaly feed (MI-5), latest
   transactions table (5 rows → Transactions).
 - Empty state: MI-16 with demo-data toggle.
@@ -47,6 +48,10 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   direction, amount range, anomaly-only), saved filter views, search.
 - Inline category edit (MI-4), row inspector (MI-11) with split-transaction
   and exclude-from-reports controls **[Proposed]**.
+- "New transaction" button (also a ⌘K action, MI-1) → inspector form:
+  amount, direction, category, date (MoneyCell/CategoryChip reuse) — the
+  manual path for cash spending with no statement or receipt (the existing
+  `POST /expense/create` / `POST /income/create` endpoints).
 - Bulk select → bulk re-categorize / export selection.
 
 ### B3 `/imports` — Import hub
@@ -68,48 +73,80 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
 - Re-auth banners when a link expires (design.md banners).
 
 ### B5 `/reports` — Reports & downloads (EXP-004)
-- Generate: monthly summary / cash-movement / category deep-dive; period
-  picker; format PDF/CSV.
+- Generate: monthly summary / cash-movement / category deep-dive
+  (`kind: category_deep_dive` + `category` param, api.md §2); period picker;
+  format PDF/CSV.
 - Artifact history table (TTL'd) with download (MI-14).
 - Scheduled reports (monthly email) **[Proposed, later]**.
 
 ### B6 `/company` — Company financials **[Directive — new]**
 - **Statements**: upload balance sheet / income statement / cash-flow
-  (CSV/XLSX/PDF via the same dropzone); mapped into a normalized line-item
-  model (data-model.md §5) with a mapping-review step (like staged txns:
-  AI-suggested line mapping, human confirm) (MI-2/3 reused).
+  (CSV/XLSX/PDF via the same dropzone — scanned/photographed statements
+  JPG/PNG/HEIC and image-only PDFs go through the import vision path,
+  `ai_processing` consent required **[Decided 2026-07-16]**); mapped into a
+  normalized line-item model (data-model.md §5) with a mapping-review step
+  (like staged txns: AI-suggested line mapping, human confirm; parser-missed
+  rows addable in review) (MI-2/3 reused). **"Enter manually" affordance
+  beside the dropzone** — ManualStatementRow rows (canonical key + amount)
+  land directly in staged review (flows/statement-mapping.md §2).
+- **Statement view**: per confirmed statement (kind × period), render the
+  normalized statement — canonical rows, *(derived)* rows flagged with their
+  formula, `mapping_warning` badges, period-selector header (StatementView,
+  design.md §8.2); export to report artifact
+  (`kind: financial_statement`, api.md §2).
 - **Ratios** (`/company/ratios`): RatioGauge grid (MI-8), grouped:
   - *Liquidity*: current ratio, quick ratio, cash ratio
   - *Solvency*: debt-to-equity, debt ratio, interest coverage
   - *Profitability*: gross/operating/net margin, ROA, ROE
   - *Efficiency*: asset turnover, inventory turnover, receivables days
+  - *Cash flow & scale*: working capital, operating cash-flow ratio, free
+    cash flow, CFO-to-total-debt — currency values render as
+    StatCard/MoneyCell, not gauges (line-items.md §5)
   - Each gauge: value, period delta, benchmark band, "how we got this"
     formula trace (MI-8 tooltip → inspector with line items). **Benchmark
     bands [Decided v1]: static per-ratio healthy ranges shipped as constants
     in the ratio registry** (line-items.md §5), clearly labeled "general
     guidance"; industry-specific benchmarks are a later data product.
-- Trend view: ratio time-series across periods; export to report artifact.
-- Requires ≥1 mapped statement period; empty state explains inputs needed.
+- Trend view: ratio **and key line-item** time-series (revenue,
+  gross_profit, net_income + period-over-period growth, line-items.md §5)
+  across periods; export to report artifact.
+- Requires ≥1 mapped statement period; empty state explains inputs needed
+  and which org kind captures statements (data-model.md §5 "Who uses which
+  org kind").
 
 ### B7 `/taxes` — Tax center **[Directive — new]**
-- Overview: jurisdiction profile (org settings), tax calendar with deadline
-  banners (MI-13), estimated liabilities StatCards.
+- Overview: jurisdiction profile (org settings; captures **state of
+  residence** for individuals — explainer: "determines your State IRS for
+  PIT" — and TIN/RC + registered address for company orgs, tax-engine.md
+  §5.5), tax calendar (contents from the tax-engine §5.5 filing calendar)
+  with deadline banners (MI-13, TaxCalendarRow), estimated liabilities
+  StatCards **each with a "remit to" line** (RemitToCard: resolved authority
+  — State IRS e.g. LIRS, or FIRS — + amount due + deadline + payment
+  channel).
 - **Calculators** (v1 scope **[Proposed — jurisdiction to ratify, NG-first]**):
   - Personal income tax (PIT) from categorized income
   - Company income tax (CIT) estimate from company statements
   - VAT summary from ledger (output vs input VAT)
 - **Filing wizard** (`/taxes/file`): WizardShell (MI-10): period → data review
-  (traceable computed fields) → generated filing forms → submission:
+  (traceable computed fields; blocks with a "complete your tax profile"
+  prompt when TIN/RC/state identifiers are missing —
+  `422 tax_identity_incomplete`, tax-engine.md §5) → generated filing forms
+  (incl. the **remittance sheet**: authority name/code, amount due, period,
+  deadline, payment channels, TIN/RC — tax-engine.md §5.5; the final step
+  names the authority) → submission:
   - v1: produce filing-ready documents + guided handoff (download/export)
   - v2: direct e-filing via jurisdiction APIs/partners where they exist
     **[Proposed staging — "file the taxes" acceptance met in v2]**
-- Filing history: immutable records with stamped receipts.
+- Filing history: immutable records with stamped receipts; rows show
+  authority + deadline columns.
 
 ### B8 `/categories`, B9 `/settings`
 - Categories: CRUD + color/dot, merge tool, AI-training note.
-- Settings: org members/roles (company orgs), data & privacy (export-all
-  USR-001, purge USR-002 with MI-15), AI-processing consent, bank-link
-  permissions, notifications, theme/density.
+- Settings: org members/roles (company orgs), organization profile — name,
+  registered address, fiscal year end (company orgs; data-model.md §5,
+  FormRow), data & privacy (export-all USR-001, purge USR-002 with MI-15),
+  AI-processing consent, bank-link permissions, notifications,
+  theme/density.
 
 ## Part C — Mobile app (later phase; parity direction **[Directive]**)
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -33,6 +33,11 @@ downloadable artifacts) and *ecosystem integration*, not building the engine.
 | Operational teams | Cash-position analysis and financial reporting | Reports, downloadable summaries |
 | Cuesoft partners | Product incubation, internal financial auditing | Whole stack |
 
+Org-kind mapping: individuals and unincorporated freelancers use their
+auto-created personal org; any business entity that wants statement capture
+/ ratios / CIT creates a company org regardless of incorporation status
+(data-model.md §5 "Who uses which org kind").
+
 ## 3. Functional requirements
 
 ### 3.1 Stated requirements, mapped against current state

--- a/docs/tax-engine.md
+++ b/docs/tax-engine.md
@@ -18,15 +18,21 @@
 TAX_RULESET {
   id: "ng-pit-2026" | "ng-pit-legacy" | "ng-cit-2026" | "ng-vat-2026" | …
   jurisdiction: "NG"
-  kind: pit | cit | vat
+  kind: pit | cit | vat   // PAYE, WHT & state levies: out of v1 scope [Decided] — this field is their extension point
   effective_from / effective_to
-  params: { bands: […], reliefs: {…}, rates: {…} }
+  params: { bands: […], reliefs: {…}, rates: {…}, filing: {…} }
   signoff: { by, date, reference }   // professional review gate
 }
 ```
 
 Period → rule-set resolution is by the period's start date. FY2025 personal
 filings resolve `ng-pit-legacy`; 2026 onward resolve `ng-pit-2026`.
+`FYYYYY` statement periods derive their start date from the org's
+`fiscal_year_end` (data-model.md §5, default 12-31; grammar in
+line-items.md §6) — a June-year-end company's FY2025 starts 2024-07-01.
+**Authority resolution** (where the liability is payable) is separate from
+rule-set resolution: it reads `TAX_PROFILE.state_of_residence` (individuals)
+/ `ORG.registered_address.state` (companies) — see §5.5.
 
 ## 2. PIT (personal income tax)
 
@@ -135,15 +141,54 @@ theirs to confirm.
 | Mode | Behaviour |
 | --- | --- |
 | **Estimate** (always available) | computed from whatever data exists; banner lists gaps ("3 months of statements missing") |
-| **Filing draft** (TAX-002) | requires: full-period data, confirmed category treatments, signed-off rule set; generates filing-ready documents (PIT self-assessment pack, CIT computation + capital-allowance worksheet, VAT return schedule) with the full trace appendix |
+| **Filing draft** (TAX-002) | requires: full-period data, confirmed category treatments, signed-off rule set, **tax identity complete** (TIN; + RC number and registered address for company profiles; state of residence for individuals); generates filing-ready documents (PIT self-assessment pack, CIT computation + capital-allowance worksheet, VAT return schedule, **plus a remittance sheet per filing**: authority name/code from the §5.5 registry, amount due, period, deadline from the §5.5 calendar, payment channel(s), taxpayer identifiers TIN/RC) with the full trace appendix — TIN/RC/registered address are stamped on every generated form |
 | Direct e-filing (TAX-003) | later; per-channel integration decisions |
 
 Every generated figure stores `{value, ruleset_id, inputs: [transaction/line-item ids], formula}` — the immutable trace that makes an audit answerable.
 
 Error codes per wizard step (engineering.md §1 catalog): draft creation →
 `422 period_incomplete` (missing months) · generate → `409 ruleset_unsigned`
-(no professional sign-off) and `422 mapping_unconfirmed` (CIT draft with
-staged statements) · submit (v2) → provider-specific.
+(no professional sign-off), `422 mapping_unconfirmed` (CIT draft with
+staged statements) and `422 tax_identity_incomplete` (missing TIN; RC
+number/registered address for companies; state of residence for
+individuals) · submit (v2) → provider-specific.
+
+## 5.5 Remittance & authorities
+
+The "where to pay" half of the contract (pages.md B7 "remit to" lines,
+RemitToCard). Same governing rule as the rate tables: **authorities and
+filing deadlines are versioned rules-as-data**, sign-off-gated, so a
+registry change is a config release, not code.
+
+### Authority resolution (rules-as-data)
+
+| Tax kind | Taxpayer | Authority | Resolved from |
+| --- | --- | --- | --- |
+| `pit` | individual (NG resident) | **State IRS** of the state of residence (e.g. `NG-LA` → LIRS) | `TAX_PROFILE.state_of_residence` |
+| `pit` | non-resident / FCT / armed-forces & foreign-service edge cases | **FIRS** | rule-set param; edge cases prompt review |
+| `cit` + development levy | company | **FIRS** | — |
+| `vat` | all | **FIRS** | — |
+
+Authority registry entries carry `{code, name, payment_channels,
+reference_format}` — e.g. FIRS: TaxPro-Max portal + Remita; each State IRS:
+its e-tax portal (LIRS eTax for Lagos) — versioned like `TAX_RULESET` with
+the same professional sign-off gate. Estimates and filings **persist the
+resolved authority** (`TAX_ESTIMATE.authority`, `TAX_FILING.authority` —
+data-model.md §5) so historical records survive registry changes; API
+responses include the authority block (api.md §5).
+
+### Filing calendar (rule-set params)
+
+| Kind | Frequency | Due rule |
+| --- | --- | --- |
+| `pit` annual return | annual | `03-31` — 31 March following the year of assessment |
+| `cit` (+ development levy) | annual | `fy_end+6m` — within 6 months of the accounting year end (`ORG.fiscal_year_end`) |
+| `vat` | monthly | `next_month_21` — the 21st of the following month (§4) |
+
+Encoded as rule-set params (`filing: {frequency: annual|monthly, due_rule}`),
+versioned and sign-off-gated like the rate tables — the data source for the
+B7 tax calendar and the MI-13 T-30/T-7/T-1 deadline banners. ⚠️ Flagged for
+professional review with the rest of the rule set.
 
 ## 6. Acceptance
 
@@ -153,3 +198,7 @@ staged statements) · submit (v2) → provider-specific.
 - [ ] CIT small-company test uses mapped line items; borderline prompts review
 - [ ] VAT net position reconciles to category-filtered transaction sums
 - [ ] No filing document generates from an unsigned rule set
+- [ ] No filing document generates with an incomplete tax identity
+      (`422 tax_identity_incomplete`)
+- [ ] Authority resolution: Lagos-resident individual PIT → LIRS; company
+      CIT/VAT → FIRS; the resolved authority persists on estimate and filing


### PR DESCRIPTION
Applies the audited completeness gaps for expendit's financial platform docs (capture / analysis / tax / KYC), per the 2026-07-16 orchestrator decisions. Docs only; every touched mermaid block validated with mermaid-cli and `api/openapi.yaml` verified to parse.

## Capture
- **capture-1** — manual statement entry is v1: JSON `POST /statements` path (`source_file_type: manual`, lands in `staged`) + `PATCH …/mapping` can now add parser-missed rows (flow, api.md, openapi, pages B6, data model, E4-3 scope).
- **capture-2** — closed period grammar (`YYYY-Qn | YYYY-H1/H2 | FYYYYY`, monthly rejected in v1) in line-items.md §6; `ORG.fiscal_year_end` (MM-DD, default 12-31) defines FY periods and feeds tax rule-set resolution.
- **capture-3** — data-model §5 synced to the flow: full `mapping_status` state machine + `superseded_by`; `LINE_ITEM` gains `status`/`confidence`/`mapped_by`; bogus `total_debt` example key replaced.
- **capture-4** — scanned/photographed statements (JPG/PNG/HEIC + image-only PDFs) reuse the import AI-vision path **[Decided 2026-07-16]**; consent-declined/AI-down → export-CSV/XLSX or manual-entry guidance; acceptance fixtures added.
- **capture-5** — "Who uses which org kind" note (personal vs company org; `taxpayer_kind` decides PIT-vs-CIT) cross-referenced from pages B6 + prd §2.
- **capture-6** — "New transaction" button + ⌘K action documented (pages B2, design §3) on the existing create endpoints.
- **capture-7** — engineering §3 rate-limit table gains the promised statement-uploads row (10/hr per org).

## Analysis
- **analysis-1** — benchmark bands + direction shipped as constants in the line-items §5 registry (bands = "general guidance"; margins/turnovers trend-only).
- **analysis-2** — statement view surface (pages B6 + StatementView component), `financial_statement` report kind in REPORT_ARTIFACT + `POST /reports` (+ openapi), new **E4-7** feature unit.
- **analysis-3** — anomaly rules registry (flows/import.md §7): formulas, v1 constants, severities for all four types [Proposed — thresholds reconciled at E2-4]; cross-refs from architecture §4.1 + data-model §1.
- **analysis-4** — revenue growth + net-income growth rows with same-kind-period rules; B6 trend view extended to key line items.
- **analysis-5** — cash-flow keys now consumed: working capital, operating cash-flow ratio, free cash flow (signed-capex convention stated), CFO-to-total-debt; §3 gains a "Used by" column; E4-4 count updated.
- **analysis-6** — runway formula (burn source: cfo vs ledger; n/a rules) in the registry, cross-referenced from B1.
- **analysis-7** — interest coverage (EBITDA) added with the only-when-D&A-mapped rule, resolving the vocabulary/registry inconsistency.
- **analysis-8** — `category_deep_dive` added to both enums with a `category` param (data model, api.md, openapi, E1-1 scope) — kept in v1 per directive.

## Tax + KYC / X-10
- **tax-1** — new tax-engine **§5.5 Remittance & authorities**: rules-as-data authority resolution (resident-individual PIT → State IRS e.g. LIRS; CIT/levy/VAT → FIRS), versioned sign-off-gated registry with payment channels; `authority` persisted on TAX_ESTIMATE/TAX_FILING and surfaced in API responses + B7 "remit to" lines (RemitToCard).
- **tax-2 + kyc-3** (union, applied once) — `ORG.registered_address {line1, line2?, city, state, country}` (company; state required), `TAX_PROFILE.state_of_residence` (required for individuals), `rc_number`, `nin`; authority resolution reads them; all classified high-sensitivity in data-model §4; mirrored in api.md/openapi (tax profile + `PATCH /orgs/{id}`), pages B7/B9.
- **tax-3 + kyc-4** — filing-draft tax-identity gate: `422 tax_identity_incomplete` (tax-engine §5 requirements + error codes, engineering §1 catalog, openapi generate 422, B7 wizard block, acceptance checkboxes); TIN/RC/registered address stamped on generated forms.
- **tax-4** — filing calendar as rule-set params (PIT 03-31 · CIT fy_end+6m · VAT next_month_21), the data source for the B7 calendar + MI-13 banners.
- **tax-5** — remittance sheet artifact in every filing pack (authority, amount due, deadline, channels, identifiers); filing history shows authority + deadline columns.
- **tax-6** — PAYE/WHT/state-levies recorded as explicit out-of-v1 **[Decided]** in decisions.md E-2 + the TAX_RULESET.kind extension point.
- **X-10** — canonical "Identity, profile & KYC tiers" decision inserted into decisions.md Cross-cutting after X-9 (tier 0 Google identity · tier 1 self-attested profile/location · tier 2 provider-verified financial identity).

## Design & register consistency
- design.md: FormRow / RemitToCard / StatementView / ManualStatementRow / TaxCalendarRow added to §8.1 build order + §8.2 variant matrices; ⌘K examples gain "new transaction".
- features.md: E4-7 added; E1-1/E4-3/E4-4/E4-5/E5-1/E5-5 scope notes updated.
- Housekeeping while editing `api/openapi.yaml`: merged the duplicate `/api/v1/reports` and `/api/v1/account/purge` path keys (the later key was silently overriding the former) and quoted flow-scalar summaries whose unquoted commas were mis-parsing into stray keys.

Validation: `npx @mermaid-js/mermaid-cli` green on all touched mermaid blocks (data-model §2/§5, statement-mapping flow); `yaml.safe_load` green on `api/openapi.yaml` with all edited paths verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)