### PR TITLE
docs: iteration 1 — enriched home narrative (contribute/self-host/FAQ), flow screens, screen-state rule, canvas hygiene

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -216,6 +216,17 @@ above (docs Stage 3 = Assemblies); the "Mode test — Dark" and "About —
 Component Library" frames on that page are QA/scaffolding artifacts, not
 stages or contract rows.
 
+**Screen-state rule [Directive 2026-07-18].** Every data-driven Stage-4
+screen template ships **three frames**: **default** (populated), **empty**
+(EmptyState + first-run copy; demo-data toggle where specced — MI-16), and
+**loading** (Skeleton set, MI-12). pages.md calls the rule out on B1/B2/B6/B7;
+it applies to every data-driven template in the Stage-4 row.
+
+**Canvas hygiene [Directive 2026-07-18].** Design canvases carry **product
+copy only**. Spec annotations — MI references, requirement IDs,
+implementation notes — live in component descriptions and in these docs,
+never on screens.
+
 ### 8.2 Variant matrices
 
 > **Theme note (2026-07-17).** `theme ×2` in the rows here and in §8.2b

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -4,7 +4,10 @@
 > (`MI-n`). Part A public home page, Part B dashboard, Part C mobile sketch.
 > The 2026-07-16 expansion **[Directive]**: bank-account linking, company
 > financial-records analysis (solvency/profitability ratios), tax calculation
-> **and filing**.
+> **and filing**. Iteration 1 (2026-07-18) **[Directive]**: enriched home
+> narrative (deep-dives, how-it-works, contribute, self-host, FAQ, final CTA)
+> + flow-state screens; data-driven screens ship default/empty/loading frames
+> (screen-state rule, design.md §8.1).
 
 ## Part A — Public home page (expendit.cuesoft.io)
 
@@ -18,16 +21,22 @@ setup → Discord + GitHub + preview links → **Try Cloud** / **Self Host** CTA
 | A2 | Hero (dark editorial) | display-type H1 "Financial intelligence for modern growth"; sub; dual CTA **Try Cloud** / **Self Host**; hero visual: dashboard in device frame with animated categorization chips | chips animate once; pauses reduced-motion |
 | A3 | Logos/social proof strip | placeholder for case-study logos (PRD §6) | |
 | A4 | Product pillars | 3 editorial cards: **Statements → intelligence** (upload/link), **Company financials** (ratios), **Taxes** (calculate + file) | card hover: 2px lift + accent underline draw |
+| A4a | Feature deep-dives **[Directive 2026-07-18]** | benefit-led deep-dive per pillar, alternating editorial split (claim → outcome copy → product still): categorized ledger in minutes · company health at a glance (ratios + trends) · filing-ready taxes with a named authority | stills swap on scroll-into-view; static under reduced-motion |
 | A5 | Interactive preview (EXP-001) | embedded read-only demo report: synthetic txn table + category donut + cash-flow line; "This is demo data" badge | tabs switch datasets (freelancer/SME/company); MI-7 count-ups |
+| A5a | How it works **[Directive 2026-07-18]** | 3 numbered steps — link/upload → AI review & confirm → reports, ratios & filings — each carrying a **real screen thumbnail** (Stage-4 template captures, not illustrations) | thumbnail click scrolls to the A5 live demo |
 | A6 | AI section | how categorization/anomalies work + privacy note inline (AI providers disclosed) | |
 | A7 | Security & privacy | encryption, retention, delete-all rights; links: security policy + privacy hub (D3) | |
-| A8 | Open source | `docker compose up` snippet + copy; architecture mini-diagram; GitHub/CONTRIBUTING | copy ✓ morph |
+| A8 | For developers — Contribute (expands Open source **[Directive 2026-07-18]**) | stack line (Go/Gin API · Next.js web · Mongo/Postgres/Redis, architecture.md); "interesting problems" list (statement parsing, categorization engine, ratio/tax engines); good-first-issues + CONTRIBUTING + Discord links; GitHub badge; architecture mini-diagram | badge star count live from GitHub API |
+| A8a | Self-host **[Directive 2026-07-18]** | data-ownership pitch ("your ledger, your infra"); `docker compose up` one-liner + copy (moves here from A8); what ships (api-common · web · Mongo · Redis, architecture.md); self-host docs link | copy ✓ morph |
 | A9 | Community | Discord card + roadmap link | |
 | A10 | Cloud vs Self-host | comparison table; per-column CTAs | |
+| A10a | FAQ **[Directive 2026-07-18]** | 4–5 product Q&As (Accordion): is my bank data safe (read-only via Mono) · does AI see my data (consent-gated, providers disclosed) · can I self-host everything · what does "filing" mean in v1 (filing-ready documents + guided handoff) · which banks/jurisdictions (NG-first) | accordion open/close, one open at a time |
+| A10b | Final CTA band **[Directive 2026-07-18]** | dark editorial band: one-line close + dual CTA **Try Cloud** / **Self Host** (mirrors A2) | CTAs re-emit the A2 events |
 | A11 | Footer | standard + "View Security Policy" CTA (PRD §6) | |
 
 Events → Upstat (D2): `page_view`, `try_cloud_click`, `self_host_click`,
-`github_click`, `demo_interact`.
+`github_click`, `demo_interact`, `contribute_click`, `faq_open`
+**[Directive 2026-07-18 additions]**.
 
 ## Part B — Dashboard (app)
 
@@ -36,12 +45,18 @@ Left nav groups **[Proposed]**: Overview · Transactions · Imports · Accounts
 Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
 (personal ↔ company orgs, data-model.md §5).
 
+### B0 `/onboarding` — First-run **[Directive 2026-07-18]**
+- One post-auth screen: create org — personal (default) / company kind picker
+  (data-model.md §5 "Who uses which org kind") — plus the AI-consent sheet
+  (`ai_processing` CONSENT_RECORD) before first import.
+
 ### B1 `/dashboard` — Overview
 - StatCard row: net cash flow, income, expenses, runway (company orgs;
   formula + n/a rules in line-items.md §5) (MI-7).
 - Cash-flow chart (12mo), category donut, anomaly feed (MI-5), latest
   transactions table (5 rows → Transactions).
-- Empty state: MI-16 with demo-data toggle.
+- Empty state: MI-16 with demo-data toggle; empty + loading frames ship per
+  the screen-state rule (design.md §8.1) **[Directive 2026-07-18]**.
 
 ### B2 `/transactions` — Ledger
 - Full `TxnTable` (virtualized): filters (date range, category, source,
@@ -53,6 +68,11 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   manual path for cash spending with no statement or receipt (the existing
   `POST /expense/create` / `POST /income/create` endpoints).
 - Bulk select → bulk re-categorize / export selection.
+- Anomaly-explain inspector state: AnomalyBadge click opens the Inspector
+  `anomaly-explain` variant (design.md §8.2) — what flagged, severity,
+  comparable txns, dismiss/confirm **[Directive 2026-07-18]**.
+- Empty + loading frames per the screen-state rule (design.md §8.1)
+  **[Directive 2026-07-18]**.
 
 ### B3 `/imports` — Import hub
 - UploadDropzone (CSV/PDF/receipt image) (MI-2) + import-job history table
@@ -60,6 +80,9 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
 - Job detail: staged-review table (AI categories ✨, duplicates pre-flagged),
   per-row category fix (MI-4), then confirm/discard (MI-3).
 - Async model (202 + polling) per architecture.md §4.2.
+- Import failure state: a `failed` job renders the error screen —
+  failure-taxonomy copy + retry (new job), flows/import.md §3
+  **[Directive 2026-07-18]**.
 
 ### B4 `/accounts` — Linked bank accounts **[Directive — new]**
 - `LinkAccountCard` grid + "Link account" CTA → provider flow (MI-9).
@@ -71,6 +94,9 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   (single ingestion path **[Proposed]**), auto-confirm option per account
   once trust is established.
 - Re-auth banners when a link expires (design.md banners).
+- Bank-link journey states as screens: consent (Mono widget hand-off) /
+  syncing (progress + live txn counter) / done — the MI-9 stepper,
+  flows/bank-link.md **[Directive 2026-07-18]**.
 
 ### B5 `/reports` — Reports & downloads (EXP-004)
 - Generate: monthly summary / cash-movement / category deep-dive
@@ -89,6 +115,10 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   rows addable in review) (MI-2/3 reused). **"Enter manually" affordance
   beside the dropzone** — ManualStatementRow rows (canonical key + amount)
   land directly in staged review (flows/statement-mapping.md §2).
+- Statement mapping review screen: AI-suggested mappings with per-row
+  `confidence` (low-confidence rows arrive unmapped, never guessed) +
+  ManualStatementRow add-row for parser-missed lines —
+  flows/statement-mapping.md **[Directive 2026-07-18]**.
 - **Statement view**: per confirmed statement (kind × period), render the
   normalized statement — canonical rows, *(derived)* rows flagged with their
   formula, `mapping_warning` badges, period-selector header (StatementView,
@@ -112,7 +142,8 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   across periods; export to report artifact.
 - Requires ≥1 mapped statement period; empty state explains inputs needed
   and which org kind captures statements (data-model.md §5 "Who uses which
-  org kind").
+  org kind"); empty + loading frames per the screen-state rule
+  (design.md §8.1) **[Directive 2026-07-18]**.
 
 ### B7 `/taxes` — Tax center **[Directive — new]**
 - Overview: jurisdiction profile (org settings; captures **state of
@@ -139,6 +170,8 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
     **[Proposed staging — "file the taxes" acceptance met in v2]**
 - Filing history: immutable records with stamped receipts; rows show
   authority + deadline columns.
+- Empty + loading frames per the screen-state rule (design.md §8.1)
+  **[Directive 2026-07-18]**.
 
 ### B8 `/categories`, B9 `/settings`
 - Categories: CRUD + color/dot, merge tool, AI-training note.
@@ -147,6 +180,10 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   FormRow), data & privacy (export-all USR-001, purge USR-002 with MI-15),
   AI-processing consent, bank-link permissions, notifications,
   theme/density.
+- Rights & data screens: export-all progress (202 job → running/completed
+  with signed-url download, flows/rights.md §1) and delete-account
+  typed-confirm (MI-15, 7-day grace, flows/rights.md §2)
+  **[Directive 2026-07-18]**.
 
 ## Part C — Mobile app (later phase; parity direction **[Directive]**)
 


### PR DESCRIPTION
## Summary

Iteration 1 (2026-07-18 directive) docs pass across `pages.md` and `design.md`.

### pages.md — Part A (home)
- **A4a Feature deep-dives** — benefit-led deep-dive per pillar, alternating editorial split with product stills.
- **A5a How it works** — 3 numbered steps carrying **real screen thumbnails** (Stage-4 template captures, not illustrations).
- **A8 For developers — Contribute** (expands Open source) — stack line (Go/Gin · Next.js · Mongo/Postgres/Redis), "interesting problems" list, good-first-issues/CONTRIBUTING/Discord, GitHub badge.
- **A8a Self-host** — data-ownership pitch, `docker compose up` one-liner (moves here from A8), what ships, docs link.
- **A10a FAQ** — 4–5 product Q&As (bank-data safety, AI & privacy, self-host parity, v1 filing meaning, banks/jurisdictions).
- **A10b Final CTA band** — dark editorial close mirroring the A2 dual CTA.
- Events line extended: `contribute_click`, `faq_open`.

### pages.md — Part B (new screens)
- **B0 `/onboarding`** — create org (personal/company kind picker) + AI-consent sheet.
- **B2** — anomaly-explain inspector state (Inspector `anomaly-explain` variant).
- **B3** — import failure state (flows/import.md §3 taxonomy + retry).
- **B4** — bank-link journey states as screens: consent / syncing (live txn counter) / done (MI-9).
- **B6** — statement mapping review screen: AI-suggested mappings + `confidence` + ManualStatementRow add-row.
- **B9** — rights & data screens: export-all progress, delete-account typed-confirm (flows/rights.md).
- Empty/loading frames noted on **B1/B2/B6/B7** per the screen-state rule.

### design.md §8
- **Screen-state rule [Directive 2026-07-18]** — every data-driven Stage-4 template ships three frames: default, empty (EmptyState + first-run copy; demo-data toggle where specced), loading (Skeleton).
- **Canvas hygiene [Directive 2026-07-18]** — canvases carry product copy only; MI references, requirement IDs, and implementation notes live in component descriptions and docs, never on screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)