### PR TITLE
docs: SUMMARY nav label parity — Web Implementation Standard

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -21,7 +21,7 @@
 - [Tax Engine](tax-engine.md)
 - [OpenAPI Draft](api/openapi.yaml)
 - [Engineering Contracts](engineering.md)
-- [Web Implementation](web-implementation.md)
+- [Web Implementation Standard](web-implementation.md)
 - [Deployment](deployment.md)
 
 ## Flows


### PR DESCRIPTION
SUMMARY label convention is H1-minus-product-prefix; apparule already reads 'Web Implementation Standard' — this aligns the nav label. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)