### PR TITLE
fix(web): W1 Figma-match QA — component fidelity pass

### DIFF
--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -389,7 +389,11 @@ export const ComponentGallery: React.FC = () => {
               <Input label="Description" name="g-desc" placeholder="Fuel" />
             </div>
             <div className="w-56">
-              <Input type="search" placeholder="Search transactions" />
+              <Input
+                type="search"
+                placeholder="Search transactions"
+                kbdHint="⌘K"
+              />
             </div>
             <div className="w-56">
               <Input label="Amount" name="g-amt" error="Amount is required" />
@@ -436,27 +440,43 @@ export const ComponentGallery: React.FC = () => {
             <AnomalyBadge type="duplicate_charge" severity="info" />
           </Variant>
           <Variant label="feed · MI-5 pulse">
-            <AnomalyBadge
-              type="spending_spike"
-              severity="warn"
-              variant="feed"
-            />
-            <AnomalyBadge
-              type="large_transaction"
-              severity="warn"
-              variant="feed"
-              pulse
-            />
+            <div className="w-full max-w-sm space-y-2">
+              <AnomalyBadge
+                type="spending_spike"
+                severity="warn"
+                variant="feed"
+                description="Dining out is up 62% vs last month"
+                timestamp="2h"
+              />
+              <AnomalyBadge
+                type="large_transaction"
+                severity="warn"
+                variant="feed"
+                description="₦480,000.00 is 3.4× your median for Equipment"
+                timestamp="2h"
+                pulse
+              />
+            </div>
           </Variant>
         </Section>
 
         <Section title="Toast / Banner">
           <Variant label="Toast: info / warn / error">
-            <Toast kind="info" onDismiss={() => undefined}>
+            <Toast
+              kind="info"
+              action={<button type="button">Download</button>}
+              onDismiss={() => undefined}
+            >
               214 transactions found
             </Toast>
-            <Toast kind="warn">Some rows were partially extracted</Toast>
-            <Toast kind="error" onDismiss={() => undefined}>
+            <Toast kind="warn" onDismiss={() => undefined}>
+              Some rows were partially extracted
+            </Toast>
+            <Toast
+              kind="error"
+              action={<button type="button">Retry</button>}
+              onDismiss={() => undefined}
+            >
               Upload failed — unreadable_file
             </Toast>
           </Variant>
@@ -470,11 +490,7 @@ export const ComponentGallery: React.FC = () => {
               </Banner>
               <Banner
                 kind="error"
-                action={
-                  <Button size="sm" kind="quiet">
-                    Re-link
-                  </Button>
-                }
+                action={<button type="button">Re-authenticate</button>}
               >
                 GTBank needs re-authentication
               </Banner>
@@ -490,6 +506,7 @@ export const ComponentGallery: React.FC = () => {
                 value={statValue}
                 format={(value) => formatMoney(value, "NGN", { decimals: 0 })}
                 delta={0.042}
+                deltaCaption="vs Jun"
                 sparkline={[3, 5, 4, 8, 7, 9, 12]}
               />
               <StatCard label="Expenses (June)" value={412000} delta={-0.08} />
@@ -644,6 +661,8 @@ export const ComponentGallery: React.FC = () => {
               display="1.85"
               status="healthy"
               band={{ from: 1.2, to: 2.0 }}
+              delta={0.21}
+              deltaCaption="vs Q1"
               formula="Current ratio = current assets ÷ current liabilities"
             />
             <RatioGauge
@@ -652,6 +671,8 @@ export const ComponentGallery: React.FC = () => {
               display="0.95"
               status="warning"
               band={{ from: 1.0, to: 1.5 }}
+              delta={-0.18}
+              deltaCaption="vs Q1"
             />
             <RatioGauge
               label="Debt to equity"
@@ -659,6 +680,8 @@ export const ComponentGallery: React.FC = () => {
               display="2.60"
               status="critical"
               max={3}
+              delta={-0.44}
+              deltaCaption="vs Q1"
             />
             <RatioGauge
               label="Interest cover"
@@ -884,10 +907,11 @@ export const ComponentGallery: React.FC = () => {
                 authority={{
                   code: "FIRS",
                   name: "Federal Inland Revenue Service",
-                  payment_channels: ["TaxPro-Max"],
+                  payment_channels: ["TaxPro-Max", "Remita"],
                 }}
                 amountDue={87500}
                 dueDate="2026-07-21"
+                daysToDue={1}
               />
             </div>
           </Variant>
@@ -976,6 +1000,7 @@ export const ComponentGallery: React.FC = () => {
                     orgs={orgs}
                     currentOrgId="org-c"
                     compact={navCollapsed}
+                    onCreate={() => undefined}
                   />
                 }
               >

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -4,6 +4,19 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Design-system base resets (QA loop 2026-07-18): UA button chrome
+ * centers text, which corrupted left-aligned row/nav buttons. Preflight
+ * does not reset text-align, so do it here in the base layer.
+ */
+@layer base {
+  button {
+    text-align: inherit;
+  }
+}
+
+/* ---- Legacy globals (pre-redesign pages; retired at W3) -------------- */
+
 * {
   margin: 0;
   padding: 0;

--- a/web/src/components/ui/AnomalyBadge.test.tsx
+++ b/web/src/components/ui/AnomalyBadge.test.tsx
@@ -13,32 +13,41 @@ describe("AnomalyBadge (design.md §8.2, MI-5)", () => {
     ).toBeInTheDocument();
     rerender(<AnomalyBadge type="duplicate_charge" severity="info" />);
     expect(
-      screen.getByRole("button", { name: "Possible duplicate charge (info)" }),
+      screen.getByRole("button", { name: "Possible duplicate (info)" }),
     ).toBeInTheDocument();
   });
 
-  it("severity picks the tint", () => {
+  it("tint keys off the anomaly type (Figma: spike = expense)", () => {
     const { rerender } = render(
       <AnomalyBadge type="spending_spike" severity="warn" />,
     );
-    expect(screen.getByRole("button")).toHaveClass("text-warn");
-    rerender(<AnomalyBadge type="spending_spike" severity="info" />);
+    expect(screen.getByRole("button")).toHaveClass("text-expense");
+    rerender(<AnomalyBadge type="abnormal_category" severity="info" />);
     expect(screen.getByRole("button")).toHaveClass("text-info");
+    rerender(<AnomalyBadge type="large_transaction" severity="warn" />);
+    expect(screen.getByRole("button")).toHaveClass("text-warn");
   });
 
-  it("feed variant shows the label text; inline is icon-only", () => {
-    const { rerender } = render(
-      <AnomalyBadge type="abnormal_category" severity="warn" variant="feed" />,
-    );
-    expect(screen.getByText("Abnormal for category")).toBeInTheDocument();
-    rerender(
+  it("inline shows the Figma short label", () => {
+    render(<AnomalyBadge type="large_transaction" severity="warn" />);
+    expect(screen.getByText("Large txn")).toBeInTheDocument();
+  });
+
+  it("feed variant renders title, description and timestamp", () => {
+    render(
       <AnomalyBadge
-        type="abnormal_category"
+        type="spending_spike"
         severity="warn"
-        variant="inline"
+        variant="feed"
+        description="Dining out is up 62% vs last month"
+        timestamp="2h"
       />,
     );
-    expect(screen.queryByText("Abnormal for category")).not.toBeInTheDocument();
+    expect(screen.getByText("Spending spike")).toBeInTheDocument();
+    expect(
+      screen.getByText("Dining out is up 62% vs last month"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("2h")).toBeInTheDocument();
   });
 
   it("MI-5 pulse class applies on first render only when asked", () => {

--- a/web/src/components/ui/AnomalyBadge.tsx
+++ b/web/src/components/ui/AnomalyBadge.tsx
@@ -1,28 +1,73 @@
 /**
- * AnomalyBadge — design.md §3/§8.2: type icon + severity tint; variants
- * inline / feed; click opens the anomaly-explain inspector (wired by the
- * consumer). MI-5 pulse handled at first render via CSS.
+ * AnomalyBadge — design.md §3/§8.2, Figma Stage 1 Atoms (node 57:86):
+ * inline = borderless pill (12% type tint, 12px icon, Table/13 Medium
+ * short label); feed = bordered card with a 32px tinted icon well, title +
+ * description copy and a timestamp. Tint keys off the anomaly TYPE
+ * (large txn/duplicate = warn, spike = expense, unusual category = info).
+ * Click opens the anomaly-explain inspector (wired by the consumer).
+ * MI-5 pulse handled at first render via CSS.
  */
 
 import React from "react";
-import { ArrowUpRight, Copy, Tag, TrendingUp } from "lucide-react";
+import { Receipt, Sparkles, TrendingUp, TriangleAlert } from "lucide-react";
 import type { AnomalySeverity, AnomalyType } from "@/models";
 import { cn } from "@/lib/cn";
 
 const TYPE_META: Record<
   AnomalyType,
-  { label: string; Icon: React.ComponentType<{ className?: string }> }
+  {
+    label: string;
+    shortLabel: string;
+    Icon: React.ComponentType<{ className?: string }>;
+    tone: "warn" | "expense" | "info";
+  }
 > = {
-  large_transaction: { label: "Large transaction", Icon: ArrowUpRight },
-  spending_spike: { label: "Spending spike", Icon: TrendingUp },
-  abnormal_category: { label: "Abnormal for category", Icon: Tag },
-  duplicate_charge: { label: "Possible duplicate charge", Icon: Copy },
+  large_transaction: {
+    label: "Large transaction",
+    shortLabel: "Large txn",
+    Icon: TriangleAlert,
+    tone: "warn",
+  },
+  spending_spike: {
+    label: "Spending spike",
+    shortLabel: "Spike",
+    Icon: TrendingUp,
+    tone: "expense",
+  },
+  abnormal_category: {
+    label: "Unusual category",
+    shortLabel: "Unusual category",
+    Icon: Sparkles,
+    tone: "info",
+  },
+  duplicate_charge: {
+    label: "Possible duplicate",
+    shortLabel: "Duplicate",
+    Icon: Receipt,
+    tone: "warn",
+  },
+};
+
+const TONE_TEXT: Record<string, string> = {
+  warn: "text-warn",
+  expense: "text-expense",
+  info: "text-info",
+};
+
+const TONE_TINT: Record<string, string> = {
+  warn: "bg-warn/[0.12]",
+  expense: "bg-expense/[0.12]",
+  info: "bg-info/[0.12]",
 };
 
 export interface AnomalyBadgeProps {
   type: AnomalyType;
   severity: AnomalySeverity;
   variant?: "inline" | "feed";
+  /** Feed variant: explanation line under the title. */
+  description?: string;
+  /** Feed variant: relative timestamp, e.g. "2h". */
+  timestamp?: string;
   /** MI-5: pulse twice on first render. */
   pulse?: boolean;
   onClick?: () => void;
@@ -32,14 +77,52 @@ export const AnomalyBadge: React.FC<AnomalyBadgeProps> = ({
   type,
   severity,
   variant = "inline",
+  description,
+  timestamp,
   pulse = false,
   onClick,
 }) => {
-  const { label, Icon } = TYPE_META[type];
-  const tint =
-    severity === "warn"
-      ? "text-warn border-warn/40 bg-warn/10"
-      : "text-info border-info/40 bg-info/10";
+  const { label, shortLabel, Icon, tone } = TYPE_META[type];
+
+  if (variant === "feed") {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        data-severity={severity}
+        className={cn(
+          "flex w-full items-start gap-3 rounded border border-border bg-bg px-3 py-2.5 text-left",
+          "transition-colors duration-fast ease-standard",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1",
+          pulse &&
+            "animate-pulse [animation-iteration-count:2] motion-reduce:animate-none",
+        )}
+      >
+        <span
+          aria-hidden
+          className={cn(
+            "flex h-8 w-8 shrink-0 items-center justify-center rounded",
+            TONE_TINT[tone],
+            TONE_TEXT[tone],
+          )}
+        >
+          <Icon className="h-4 w-4" />
+        </span>
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5 text-[13px] leading-4">
+          <span className="font-medium text-text">{label}</span>
+          {description ? (
+            <span className="text-text-2">{description}</span>
+          ) : null}
+        </span>
+        {timestamp ? (
+          <span className="shrink-0 text-[13px] leading-4 text-text-2">
+            {timestamp}
+          </span>
+        ) : null}
+      </button>
+    );
+  }
+
   return (
     <button
       type="button"
@@ -47,22 +130,18 @@ export const AnomalyBadge: React.FC<AnomalyBadgeProps> = ({
       aria-label={`${label} (${severity})`}
       data-severity={severity}
       className={cn(
-        "inline-flex items-center gap-1 rounded border font-medium",
+        "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5",
+        "text-[13px] font-medium leading-4",
         "transition-colors duration-fast ease-standard",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1",
-        tint,
-        variant === "inline"
-          ? "px-1.5 py-0.5 text-[11px]"
-          : "px-2 py-1 text-[13px]",
+        TONE_TEXT[tone],
+        TONE_TINT[tone],
         pulse &&
           "animate-pulse [animation-iteration-count:2] motion-reduce:animate-none",
       )}
     >
-      <Icon
-        aria-hidden
-        className={variant === "inline" ? "h-3 w-3" : "h-4 w-4"}
-      />
-      {variant === "feed" ? <span>{label}</span> : null}
+      <Icon aria-hidden className="h-3 w-3" />
+      <span>{shortLabel}</span>
     </button>
   );
 };

--- a/web/src/components/ui/AppNav.tsx
+++ b/web/src/components/ui/AppNav.tsx
@@ -33,7 +33,8 @@ export const NavItem: React.FC<NavItemProps> = ({
 }) => {
   const collapsed = useContext(NavCollapsedContext);
   const className = cn(
-    "group/nav-item relative flex w-full items-center gap-2.5 rounded px-2.5 py-1.5 text-[13px] font-medium",
+    // text-left: buttons default to centered text, the kit is left-aligned.
+    "group/nav-item relative flex w-full items-center gap-2.5 rounded px-2.5 py-1.5 text-left text-[13px] font-medium",
     "transition-colors duration-fast ease-standard",
     active
       ? "bg-accent/10 text-accent"

--- a/web/src/components/ui/Avatar.tsx
+++ b/web/src/components/ui/Avatar.tsx
@@ -29,8 +29,12 @@ const initials = (name: string): string =>
 export const Avatar: React.FC<AvatarProps> = ({ name, src, size = "sm" }) => (
   <span
     className={cn(
-      "inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full",
-      "border border-border bg-bg-elev font-medium text-text-2",
+      "inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full font-medium",
+      // Figma: initials disc = 15% accent tint + accent text (no border);
+      // image/icon fallbacks stay neutral.
+      !src && name
+        ? "bg-accent/[0.15] text-accent"
+        : "border border-border bg-bg-elev text-text-2",
       SIZE_CLASSES[size],
     )}
   >

--- a/web/src/components/ui/Banner.test.tsx
+++ b/web/src/components/ui/Banner.test.tsx
@@ -5,12 +5,14 @@ import Banner from "./Banner";
 
 describe("Banner (design.md §8.2, MI-13)", () => {
   it("renders info / warn / error tints", () => {
+    // Figma: 10% kind tint + 35% kind edge.
     const { rerender } = render(<Banner kind="info">T-30: VAT due</Banner>);
-    expect(screen.getByRole("status")).toHaveClass("border-info/40");
+    expect(screen.getByRole("status")).toHaveClass("border-info/35");
+    expect(screen.getByRole("status")).toHaveClass("bg-info/10");
     rerender(<Banner kind="warn">T-7: VAT due</Banner>);
-    expect(screen.getByRole("status")).toHaveClass("border-warn/40");
+    expect(screen.getByRole("status")).toHaveClass("border-warn/35");
     rerender(<Banner kind="error">Bank re-auth needed</Banner>);
-    expect(screen.getByRole("status")).toHaveClass("border-expense/40");
+    expect(screen.getByRole("status")).toHaveClass("border-expense/35");
   });
 
   it("carries an action slot and snooze-dismiss", async () => {

--- a/web/src/components/ui/Banner.tsx
+++ b/web/src/components/ui/Banner.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { CircleAlert, Info, TriangleAlert, X } from "lucide-react";
+import { Calendar, Landmark, Sparkles, X } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 export type BannerKind = "info" | "warn" | "error";
@@ -17,19 +17,29 @@ export interface BannerProps {
   onDismiss?: () => void;
 }
 
+// Figma Banner (node 58:109): kind tint at 10%, kind edge at 35%; message
+// stays body text color — only icon and action carry the kind color.
 const KIND_CLASSES: Record<BannerKind, string> = {
-  info: "border-info/40 bg-info/10 text-info",
-  warn: "border-warn/40 bg-warn/10 text-warn",
-  error: "border-expense/40 bg-expense/10 text-expense",
+  info: "border-info/35 bg-info/10",
+  warn: "border-warn/35 bg-warn/10",
+  error: "border-expense/35 bg-expense/10",
 };
 
+const KIND_ICON_CLASSES: Record<BannerKind, string> = {
+  info: "text-info",
+  warn: "text-warn",
+  error: "text-expense",
+};
+
+// Figma icons: info = sparkles (AI), warn = calendar (deadline),
+// error = landmark (bank).
 const KIND_ICON: Record<
   BannerKind,
   React.ComponentType<{ className?: string }>
 > = {
-  info: Info,
-  warn: TriangleAlert,
-  error: CircleAlert,
+  info: Sparkles,
+  warn: Calendar,
+  error: Landmark,
 };
 
 export const Banner: React.FC<BannerProps> = ({
@@ -44,13 +54,25 @@ export const Banner: React.FC<BannerProps> = ({
       role="status"
       data-kind={kind}
       className={cn(
-        "flex items-center gap-2 rounded border px-3 py-2 text-[13px]",
+        "flex items-center gap-2.5 rounded border px-4 py-2.5 text-sm",
         KIND_CLASSES[kind],
       )}
     >
-      <Icon aria-hidden className="h-4 w-4 shrink-0" />
+      <Icon
+        aria-hidden
+        className={cn("h-4 w-4 shrink-0", KIND_ICON_CLASSES[kind])}
+      />
       <div className="flex-1 text-text">{children}</div>
-      {action}
+      {action ? (
+        <div
+          className={cn(
+            "shrink-0 text-[13px] font-medium leading-4",
+            kind === "error" ? "text-expense" : "text-accent",
+          )}
+        >
+          {action}
+        </div>
+      ) : null}
       {onDismiss ? (
         <button
           type="button"

--- a/web/src/components/ui/Button.test.tsx
+++ b/web/src/components/ui/Button.test.tsx
@@ -8,17 +8,19 @@ describe("Button (design.md §8.2)", () => {
     const { rerender } = render(<Button kind="primary">Save</Button>);
     expect(screen.getByRole("button")).toHaveClass("bg-accent");
     expect(screen.getByRole("button")).toHaveClass("text-on-accent");
+    // Figma: quiet is borderless — text on transparent, bg-elev on hover.
     rerender(<Button kind="quiet">Save</Button>);
-    expect(screen.getByRole("button")).toHaveClass("border-border");
+    expect(screen.getByRole("button")).toHaveClass("bg-transparent");
+    expect(screen.getByRole("button")).not.toHaveClass("border-border");
     rerender(<Button kind="destructive">Delete</Button>);
     expect(screen.getByRole("button")).toHaveClass("bg-expense");
   });
 
-  it("supports md/sm sizes", () => {
+  it("supports md/sm sizes (Figma: 36px / 28px)", () => {
     const { rerender } = render(<Button size="md">A</Button>);
-    expect(screen.getByRole("button")).toHaveClass("h-10");
+    expect(screen.getByRole("button")).toHaveClass("h-9");
     rerender(<Button size="sm">A</Button>);
-    expect(screen.getByRole("button")).toHaveClass("h-8");
+    expect(screen.getByRole("button")).toHaveClass("h-7");
   });
 
   it("loading state disables and shows the spinner", () => {
@@ -38,11 +40,12 @@ describe("Button (design.md §8.2)", () => {
     );
     const button = screen.getByRole("button");
     expect(button).toBeDisabled();
-    expect(screen.getByTestId("button-countdown")).toHaveTextContent("(2)");
+    // Figma countdown pill reads "2s", not "(2)".
+    expect(screen.getByTestId("button-countdown")).toHaveTextContent("2s");
     act(() => {
       vi.advanceTimersByTime(1000);
     });
-    expect(screen.getByTestId("button-countdown")).toHaveTextContent("(1)");
+    expect(screen.getByTestId("button-countdown")).toHaveTextContent("1s");
     act(() => {
       vi.advanceTimersByTime(1000);
     });

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useEffect, useState } from "react";
+import { TriangleAlert } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 export type ButtonKind = "primary" | "quiet" | "destructive" | "danger-armed";
@@ -24,17 +25,20 @@ export interface ButtonProps extends Omit<
   className?: string;
 }
 
+// Figma Stage 1 Atoms — Button set (node 53:118): quiet is borderless
+// (pressed/hover show bg-elev only); primary/destructive dim via fill.
 const KIND_CLASSES: Record<ButtonKind, string> = {
   primary: "bg-accent text-on-accent hover:opacity-90 active:opacity-80",
-  quiet:
-    "bg-transparent text-text border border-border hover:bg-bg-elev active:bg-bg-elev",
+  quiet: "bg-transparent text-text hover:bg-bg-elev active:bg-bg-elev",
   destructive: "bg-expense text-on-accent hover:opacity-90 active:opacity-80",
   "danger-armed": "bg-expense text-on-accent",
 };
 
+// Figma: md = 36px / 16px pad / Body 14 Medium; sm = 28px / 12px pad /
+// Table 13 Medium.
 const SIZE_CLASSES: Record<ButtonSize, string> = {
-  md: "h-10 px-4 text-sm",
-  sm: "h-8 px-3 text-[13px]",
+  md: "h-9 px-4 text-sm",
+  sm: "h-7 px-3 text-[13px]",
 };
 
 export const Button: React.FC<ButtonProps> = ({
@@ -72,7 +76,10 @@ export const Button: React.FC<ButtonProps> = ({
         "inline-flex items-center justify-center gap-2 rounded font-medium",
         "transition-colors duration-fast ease-standard select-none",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
-        "disabled:cursor-not-allowed disabled:opacity-60",
+        "disabled:cursor-not-allowed",
+        // Figma: only the true disabled state pales — loading and the
+        // armed countdown keep the full fill.
+        disabled && "opacity-60",
         KIND_CLASSES[kind],
         SIZE_CLASSES[size],
         className,
@@ -83,13 +90,21 @@ export const Button: React.FC<ButtonProps> = ({
         <span
           data-testid="button-spinner"
           aria-hidden
-          className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-on-accent/40 border-t-on-accent motion-reduce:animate-none"
+          // currentColor arc so the spinner also reads on quiet buttons.
+          className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent motion-reduce:animate-none"
         />
+      ) : null}
+      {kind === "danger-armed" && !loading ? (
+        <TriangleAlert aria-hidden className="h-4 w-4" />
       ) : null}
       <span>{children}</span>
       {armed ? (
-        <span data-testid="button-countdown" className="tabular-nums">
-          ({countdown})
+        <span
+          data-testid="button-countdown"
+          // Figma countdown pill: on-accent 25% tint, 13px medium.
+          className="rounded-full bg-on-accent/25 px-1.5 py-0.5 text-[13px] font-medium leading-4 tabular-nums"
+        >
+          {countdown}s
         </span>
       ) : null}
     </button>

--- a/web/src/components/ui/CategoryChip.test.tsx
+++ b/web/src/components/ui/CategoryChip.test.tsx
@@ -56,10 +56,8 @@ describe("CategoryChip (design.md §8.2, MI-4)", () => {
       />,
     );
     await userEvent.click(screen.getByRole("button"));
-    await userEvent.type(
-      screen.getByPlaceholderText("Search categories"),
-      "zzz",
-    );
+    // Figma editing state: the chip itself becomes the combobox input.
+    await userEvent.type(screen.getByRole("combobox"), "zzz");
     expect(screen.getByText("No matching category")).toBeInTheDocument();
   });
 

--- a/web/src/components/ui/CategoryChip.tsx
+++ b/web/src/components/ui/CategoryChip.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
-import { Sparkles } from "lucide-react";
+import { Check, Sparkles } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 export interface CategoryOption {
@@ -62,47 +62,65 @@ export const CategoryChip: React.FC<CategoryChipProps> = ({
 
   return (
     <span ref={rootRef} className="relative inline-flex">
-      <button
-        type="button"
-        disabled={!editable}
-        aria-expanded={open}
-        aria-haspopup={editable ? "listbox" : undefined}
-        onClick={() => editable && setOpen((value) => !value)}
-        className={cn(
-          "inline-flex items-center gap-1.5 rounded border border-border bg-bg-elev",
-          "px-2 py-0.5 text-[13px] text-text transition-colors duration-fast ease-standard",
-          editable && "hover:border-text-2 cursor-pointer",
-          !editable && "cursor-default",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1",
-        )}
-      >
-        <span
-          aria-hidden
-          data-testid="category-dot"
-          className="h-2 w-2 rounded-full"
-          style={{ backgroundColor: category.color }}
+      {open ? (
+        // Figma editing state: the chip itself becomes the combobox input
+        // (28px, 2px accent border) with the menu anchored below.
+        <input
+          autoFocus
+          role="combobox"
+          aria-expanded
+          aria-controls="category-chip-listbox"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder={category.name}
+          className={cn(
+            "h-7 w-[180px] rounded border-2 border-accent bg-bg px-2",
+            "text-[13px] font-medium leading-4 text-text placeholder:text-text-2",
+            "focus:outline-none",
+          )}
         />
-        <span>{category.name}</span>
-        {aiSuggested ? (
-          <Sparkles
-            data-testid="category-ai-mark"
-            aria-label="AI-suggested"
-            className="h-3 w-3 text-info"
+      ) : (
+        <button
+          type="button"
+          disabled={!editable}
+          aria-expanded={open}
+          aria-haspopup={editable ? "listbox" : undefined}
+          onClick={() => editable && setOpen(true)}
+          className={cn(
+            // Figma chip: bg-elev pill, hairline border, Table/13 Medium.
+            "inline-flex items-center gap-1.5 rounded-full border border-border bg-bg-elev",
+            "px-2 py-[3px] text-[13px] font-medium leading-4 text-text",
+            "transition-colors duration-fast ease-standard",
+            editable && "hover:border-text-2 cursor-pointer",
+            !editable && "cursor-default",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1",
+          )}
+        >
+          <span
+            aria-hidden
+            data-testid="category-dot"
+            className="h-2 w-2 rounded-full"
+            style={{ backgroundColor: category.color }}
           />
-        ) : null}
-      </button>
+          <span>{category.name}</span>
+          {aiSuggested ? (
+            <Sparkles
+              data-testid="category-ai-mark"
+              aria-label="AI-suggested"
+              className="h-3 w-3 text-info"
+            />
+          ) : null}
+        </button>
+      )}
 
       {open ? (
         // Absolutely positioned: the open combobox never shifts row layout.
-        <div className="absolute left-0 top-full z-dropdown mt-1 w-56 rounded border border-border bg-bg shadow-lg">
-          <input
-            autoFocus
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search categories"
-            className="w-full border-b border-border bg-transparent px-3 py-2 text-[13px] text-text placeholder:text-text-2 focus:outline-none"
-          />
-          <ul role="listbox" className="max-h-56 overflow-auto py-1">
+        <div className="absolute left-0 top-8 z-dropdown w-[180px] rounded border border-border bg-bg py-1 shadow-[0px_4px_16px_0px_rgba(0,0,0,0.12)]">
+          <ul
+            id="category-chip-listbox"
+            role="listbox"
+            className="max-h-56 overflow-auto"
+          >
             {filtered.map((option) => (
               <li key={option.id}>
                 <button
@@ -115,7 +133,7 @@ export const CategoryChip: React.FC<CategoryChipProps> = ({
                     setQuery("");
                   }}
                   className={cn(
-                    "flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] text-text",
+                    "flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-[13px] leading-4 text-text",
                     "hover:bg-bg-elev transition-colors duration-fast ease-standard",
                     option.id === category.id && "bg-bg-elev",
                   )}
@@ -125,12 +143,15 @@ export const CategoryChip: React.FC<CategoryChipProps> = ({
                     className="h-2 w-2 rounded-full"
                     style={{ backgroundColor: option.color }}
                   />
-                  {option.name}
+                  <span className="min-w-0 flex-1 truncate">{option.name}</span>
+                  {option.id === category.id ? (
+                    <Check aria-hidden className="h-3 w-3 text-accent" />
+                  ) : null}
                 </button>
               </li>
             ))}
             {filtered.length === 0 ? (
-              <li className="px-3 py-1.5 text-[13px] text-text-2">
+              <li className="px-2 py-1.5 text-[13px] text-text-2">
                 No matching category
               </li>
             ) : null}

--- a/web/src/components/ui/ChartDonut.test.tsx
+++ b/web/src/components/ui/ChartDonut.test.tsx
@@ -41,8 +41,6 @@ describe("Chart/Donut (design.md §8.2b)", () => {
     const { rerender } = render(<ChartDonut state="loading" />);
     expect(screen.getByTestId("skeleton-chart")).toBeInTheDocument();
     rerender(<ChartDonut state="empty" emptyKind="ratios" />);
-    expect(
-      screen.getByText("No statements to compute ratios from."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("No ratios yet")).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/ChartLine.test.tsx
+++ b/web/src/components/ui/ChartLine.test.tsx
@@ -49,6 +49,6 @@ describe("Chart/Line (design.md §8.2b, MI-12)", () => {
 
   it("empty renders the MI-16 empty state", () => {
     render(<ChartLine state="empty" emptyKind="transactions" />);
-    expect(screen.getByText("No transactions yet.")).toBeInTheDocument();
+    expect(screen.getByText("No transactions yet")).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/EmptyState.test.tsx
+++ b/web/src/components/ui/EmptyState.test.tsx
@@ -7,9 +7,13 @@ describe("EmptyState (design.md §8.2, MI-16)", () => {
   it("renders the one-line + primary action per kind", async () => {
     const onAction = vi.fn();
     render(<EmptyState kind="transactions" onAction={onAction} />);
-    expect(screen.getByText("No transactions yet.")).toBeInTheDocument();
+    // Figma copy: title + hint + CTA.
+    expect(screen.getByText("No transactions yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("Upload your first statement to see your ledger."),
+    ).toBeInTheDocument();
     await userEvent.click(
-      screen.getByRole("button", { name: "Upload your first statement" }),
+      screen.getByRole("button", { name: "Upload statement" }),
     );
     expect(onAction).toHaveBeenCalled();
   });
@@ -37,7 +41,7 @@ describe("EmptyState (design.md §8.2, MI-16)", () => {
         demoToggle={{ enabled: false, onChange }}
       />,
     );
-    expect(screen.getByText("Synthetic")).toBeInTheDocument();
+    expect(screen.getByText("synthetic")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("switch"));
     expect(onChange).toHaveBeenCalledWith(true);
   });

--- a/web/src/components/ui/EmptyState.tsx
+++ b/web/src/components/ui/EmptyState.tsx
@@ -5,7 +5,14 @@
  */
 
 import React from "react";
-import { Banknote, Gauge, Landmark, ReceiptText, Upload } from "lucide-react";
+import {
+  Calendar,
+  Landmark,
+  ReceiptText,
+  Sparkles,
+  TrendingUp,
+  Upload,
+} from "lucide-react";
 import { cn } from "@/lib/cn";
 import Button from "./Button";
 import Switch from "./Switch";
@@ -13,37 +20,44 @@ import Switch from "./Switch";
 export type EmptyStateKind =
   "transactions" | "imports" | "accounts" | "ratios" | "tax";
 
+// Figma Stage 2 EmptyState (node 71:390): title + hint + primary CTA.
 const KIND_META: Record<
   EmptyStateKind,
   {
     Icon: React.ComponentType<{ className?: string }>;
+    title: string;
     line: string;
     action: string;
   }
 > = {
   transactions: {
     Icon: ReceiptText,
-    line: "No transactions yet.",
-    action: "Upload your first statement",
+    title: "No transactions yet",
+    line: "Upload your first statement to see your ledger.",
+    action: "Upload statement",
   },
   imports: {
     Icon: Upload,
-    line: "Nothing imported yet.",
-    action: "Upload a statement",
+    title: "No imports yet",
+    line: "Drop a CSV, PDF, or receipt image to get started.",
+    action: "Upload statement",
   },
   accounts: {
     Icon: Landmark,
-    line: "No bank accounts linked.",
-    action: "Link a bank account",
+    title: "No linked accounts",
+    line: "Connect your bank through Mono to sync transactions automatically.",
+    action: "Link account",
   },
   ratios: {
-    Icon: Gauge,
-    line: "No statements to compute ratios from.",
-    action: "Upload a financial statement",
+    Icon: TrendingUp,
+    title: "No ratios yet",
+    line: "Upload and map at least one statement period to compute ratios.",
+    action: "Upload statements",
   },
   tax: {
-    Icon: Banknote,
-    line: "Complete your tax profile to see estimates.",
+    Icon: Calendar,
+    title: "Tax center not set up",
+    line: "Set your jurisdiction to see deadlines and estimated liabilities.",
     action: "Set up tax profile",
   },
 };
@@ -65,31 +79,37 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   demoToggle,
   className,
 }) => {
-  const { Icon, line, action } = KIND_META[kind];
+  const { Icon, title, line, action } = KIND_META[kind];
   return (
     <div
       data-kind={kind}
       className={cn(
-        "flex flex-col items-center gap-3 rounded border border-dashed border-border px-6 py-10 text-center",
+        // Figma: solid hairline card on the plain canvas.
+        "flex flex-col items-center gap-3 rounded border border-border bg-bg px-6 py-8 text-center",
         className,
       )}
     >
-      <span className="flex h-10 w-10 items-center justify-center rounded-full bg-bg-elev">
-        <Icon aria-hidden className="h-5 w-5 text-text-2" />
+      <span className="flex h-8 w-8 items-center justify-center rounded bg-bg-elev">
+        <Icon aria-hidden className="h-4 w-4 text-text" />
       </span>
-      <p className="text-sm text-text-2">{line}</p>
+      <div>
+        <p className="text-sm font-medium leading-5 text-text">{title}</p>
+        <p className="mt-1 text-[13px] leading-4 text-text-2">{line}</p>
+      </div>
       <Button size="sm" onClick={onAction}>
         {action}
       </Button>
       {demoToggle ? (
-        <div className="mt-2 flex items-center gap-2">
+        <div className="mt-1 flex items-center gap-2">
           <Switch
             checked={demoToggle.enabled}
             onCheckedChange={demoToggle.onChange}
-            label="Show demo data"
+            label="Preview with demo data"
           />
-          <span className="rounded border border-info/40 bg-info/10 px-1.5 text-[11px] font-medium text-info">
-            Synthetic
+          {/* Figma: info-tinted "synthetic" pill with the AI sparkle. */}
+          <span className="inline-flex items-center gap-1 rounded-full bg-info/[0.12] px-1.5 py-0.5 text-[11px] font-medium leading-4 text-info">
+            <Sparkles aria-hidden className="h-3 w-3" />
+            synthetic
           </span>
         </div>
       ) : null}

--- a/web/src/components/ui/FilingHistoryRow.test.tsx
+++ b/web/src/components/ui/FilingHistoryRow.test.tsx
@@ -25,18 +25,16 @@ const filing = (overrides: Partial<TaxFiling> = {}): TaxFiling => ({
 });
 
 describe("FilingHistoryRow (design.md §8.2b, MI-10)", () => {
-  it("renders kind, period, authority, amount, deadline columns", () => {
+  it("renders the Figma title, caption, and amount", () => {
     render(<FilingHistoryRow filing={filing()} />);
+    // "PIT · FY2026" title; "LIRS · Filed 15 Jan 2027" caption.
     expect(screen.getByText("pit")).toBeInTheDocument();
-    expect(screen.getByText("FY2026")).toBeInTheDocument();
-    expect(
-      screen.getByText("Lagos State Internal Revenue Service"),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/· FY2026/)).toBeInTheDocument();
+    expect(screen.getByText(/LIRS · Filed 15 Jan 2027/)).toBeInTheDocument();
     expect(screen.getByText("₦342,500.00")).toHaveClass("tabular-nums");
-    expect(screen.getByText("due 2027-03-31")).toBeInTheDocument();
   });
 
-  it("accepted filing carries the stamped-✓ and receipt download", async () => {
+  it("accepted filing carries the stamped-✓ and Receipt download", async () => {
     const onDownloadReceipt = vi.fn();
     render(
       <FilingHistoryRow
@@ -45,9 +43,7 @@ describe("FilingHistoryRow (design.md §8.2b, MI-10)", () => {
       />,
     );
     expect(screen.getByRole("img", { name: "pit filed" })).toBeInTheDocument();
-    await userEvent.click(
-      screen.getByRole("button", { name: "Download receipt" }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: /Receipt/ }));
     expect(onDownloadReceipt).toHaveBeenCalled();
   });
 

--- a/web/src/components/ui/FilingHistoryRow.tsx
+++ b/web/src/components/ui/FilingHistoryRow.tsx
@@ -1,15 +1,18 @@
 /**
- * FilingHistoryRow — design.md §8.2b: tax kind + period + authority +
- * deadline columns · stamped-✓ receipt download · immutable (no edit
- * affordances by construction).
+ * FilingHistoryRow — design.md §8.2b, Figma Stage 3b: stamped-✓ left ·
+ * "KIND · period" title + "{authority} · Filed {date}" caption · amount +
+ * "Receipt" download at right · immutable (no edit affordances by
+ * construction). Draft filings show a neutral status tag instead.
  */
 
 import React from "react";
-import { Download } from "lucide-react";
+import { Download, FileText } from "lucide-react";
+import dayjs from "dayjs";
 import type { TaxFiling } from "@/models";
 import { cn } from "@/lib/cn";
 import { formatMoney } from "@/lib/format";
 import StampedCheck from "./StampedCheck";
+import Tag from "./Tag";
 
 export interface FilingHistoryRowProps {
   filing: TaxFiling;
@@ -23,54 +26,63 @@ export const FilingHistoryRow: React.FC<FilingHistoryRowProps> = ({
   currency = "NGN",
   onDownloadReceipt,
   className,
-}) => (
-  <div
-    role="row"
-    data-status={filing.status}
-    className={cn(
-      "flex items-center gap-3 border-b border-border px-3 py-2 text-[13px] text-text",
-      className,
-    )}
-  >
-    <span className="w-10 shrink-0 font-medium uppercase">{filing.kind}</span>
-    <span className="w-24 shrink-0 tabular-nums text-text-2">
-      {filing.period}
-    </span>
-    <span className="min-w-0 flex-1 truncate text-text-2">
-      {filing.authority.name}
-    </span>
-    <span className="w-28 shrink-0 text-right tabular-nums">
-      {formatMoney(filing.amount_due, currency)}
-    </span>
-    <span className="w-24 shrink-0 tabular-nums text-text-2">
-      due {filing.due_date}
-    </span>
-    <span className="flex w-20 shrink-0 items-center justify-end gap-1.5">
-      {filing.status === "accepted" || filing.status === "submitted" ? (
-        <>
-          <StampedCheck
-            size="md"
-            label={`${filing.kind} filed`}
-            className="!h-6 !w-6"
-          />
-          {filing.artifact_key ? (
-            <button
-              type="button"
-              aria-label="Download receipt"
-              onClick={onDownloadReceipt}
-              className="rounded p-1 text-text-2 transition-colors duration-fast ease-standard hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-            >
-              <Download className="h-4 w-4" />
-            </button>
-          ) : null}
-        </>
+}) => {
+  const accepted =
+    filing.status === "accepted" || filing.status === "submitted";
+  const filedAt =
+    filing.filed_at && dayjs(filing.filed_at).isValid()
+      ? dayjs(filing.filed_at).format("D MMM YYYY")
+      : null;
+  return (
+    <div
+      role="row"
+      data-status={filing.status}
+      className={cn(
+        "flex items-center gap-3 border-b border-border px-3 py-2 text-[13px] text-text",
+        className,
+      )}
+    >
+      {accepted ? (
+        <StampedCheck
+          size="md"
+          label={`${filing.kind} filed`}
+          className="!h-6 !w-6 shrink-0"
+        />
       ) : (
-        <span className="text-[11px] font-medium uppercase text-text-2">
-          {filing.status}
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-bg-elev">
+          <FileText aria-hidden className="h-3.5 w-3.5 text-text-2" />
         </span>
       )}
-    </span>
-  </div>
-);
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-medium uppercase leading-4">
+          {filing.kind}
+          <span className="normal-case text-text-2"> · {filing.period}</span>
+        </span>
+        <span className="block truncate leading-4 text-text-2">
+          {filing.authority.code}
+          {filing.authority.payment_channels[0]
+            ? ` · ${filing.authority.payment_channels[0]}`
+            : ""}
+          {filedAt ? ` · Filed ${filedAt}` : ` · due ${filing.due_date}`}
+        </span>
+      </span>
+      <span className="shrink-0 text-right font-medium tabular-nums">
+        {formatMoney(filing.amount_due, currency)}
+      </span>
+      {accepted && filing.artifact_key ? (
+        <button
+          type="button"
+          onClick={onDownloadReceipt}
+          className="flex shrink-0 items-center gap-1 rounded p-1 text-text-2 transition-colors duration-fast ease-standard hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          <Download aria-hidden className="h-3.5 w-3.5" />
+          Receipt
+        </button>
+      ) : !accepted ? (
+        <Tag tint="neutral">{filing.status}</Tag>
+      ) : null}
+    </div>
+  );
+};
 
 export default FilingHistoryRow;

--- a/web/src/components/ui/ImportJobRow.test.tsx
+++ b/web/src/components/ui/ImportJobRow.test.tsx
@@ -37,16 +37,18 @@ describe("ImportJobRow (design.md §8.2b)", () => {
     );
   });
 
-  it("completed shows counts + anomalies found", () => {
+  it("completed shows the Figma caption + status tag", () => {
     render(<ImportJobRow job={job()} />);
-    expect(screen.getByText("209/214 imported")).toBeInTheDocument();
-    expect(screen.getByText("5 duplicates")).toBeInTheDocument();
-    expect(screen.getByText("1")).toBeInTheDocument(); // anomaly count tag
+    expect(
+      screen.getByText("209 transactions · 5 duplicates · 1 anomalies found"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Completed")).toBeInTheDocument();
   });
 
-  it("processing renders the spinner copy", () => {
+  it("processing renders the parsing caption + info tag", () => {
     render(<ImportJobRow job={job({ status: "processing" })} />);
-    expect(screen.getByText("Processing…")).toBeInTheDocument();
+    expect(screen.getByText("Parsing…")).toBeInTheDocument();
+    expect(screen.getByText("Processing")).toBeInTheDocument();
   });
 
   it("failed renders the taxonomy code", () => {
@@ -64,7 +66,10 @@ describe("ImportJobRow (design.md §8.2b)", () => {
         job={job({ total_parsed: 0, imported: 0, anomalies: [] })}
       />,
     );
-    expect(screen.getByText("No transactions found")).toBeInTheDocument();
+    expect(
+      screen.getByText("0 transactions found — check file contents"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Empty")).toBeInTheDocument();
     rerender(
       <ImportJobRow job={job({ source: "bank_sync", file_name: null })} />,
     );
@@ -72,6 +77,9 @@ describe("ImportJobRow (design.md §8.2b)", () => {
       "data-status",
       "completed-bank",
     );
-    expect(screen.getByText("bank")).toBeInTheDocument();
+    expect(screen.getByText("Bank sync")).toBeInTheDocument();
+    expect(
+      screen.getByText("209 transactions · auto-confirmed"),
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/ImportJobRow.tsx
+++ b/web/src/components/ui/ImportJobRow.tsx
@@ -1,18 +1,19 @@
 /**
- * ImportJobRow — design.md §8.2b: status processing / completed /
- * completed-empty / completed-bank / failed · counts + anomalies-found.
- * As built the source axis folds into status (completed-bank =
- * bank_sync; processing/failed render as upload-source).
+ * ImportJobRow — design.md §8.2b, Figma Stage 3b: file icon · filename
+ * title + caption line · status Tag (Processing info / Completed success /
+ * Empty neutral / Failed error) · timestamp. As built the source axis
+ * folds into status (completed-bank = bank_sync; processing/failed render
+ * as upload-source).
  */
 
 import React from "react";
 import {
-  CircleAlert,
   FileSpreadsheet,
   FileText,
   Image as ImageIcon,
   Landmark,
 } from "lucide-react";
+import dayjs from "dayjs";
 import type { ImportJob } from "@/models";
 import { cn } from "@/lib/cn";
 import Tag from "./Tag";
@@ -34,6 +35,39 @@ const FILE_ICON = {
   image: ImageIcon,
 } as const;
 
+/** Figma caption line per status. */
+const caption = (job: ImportJob, status: ImportJobRowStatus): string => {
+  switch (status) {
+    case "processing":
+      return "Parsing…";
+    case "failed":
+      return job.error_code ?? "failed";
+    case "completed-empty":
+      return "0 transactions found — check file contents";
+    case "completed-bank":
+      return `${job.imported} transactions${job.confirmed ? " · auto-confirmed" : ""}`;
+    case "completed": {
+      const parts = [`${job.imported} transactions`];
+      if (job.duplicates_found > 0)
+        parts.push(`${job.duplicates_found} duplicates`);
+      if (job.anomalies.length > 0)
+        parts.push(`${job.anomalies.length} anomalies found`);
+      return parts.join(" · ");
+    }
+  }
+};
+
+const STATUS_TAG: Record<
+  ImportJobRowStatus,
+  { label: string; tint: "info" | "success" | "neutral" | "error" }
+> = {
+  processing: { label: "Processing", tint: "info" },
+  completed: { label: "Completed", tint: "success" },
+  "completed-bank": { label: "Completed", tint: "success" },
+  "completed-empty": { label: "Empty", tint: "neutral" },
+  failed: { label: "Failed", tint: "error" },
+};
+
 export interface ImportJobRowProps {
   job: ImportJob;
   onOpen?: () => void;
@@ -48,6 +82,10 @@ export const ImportJobRow: React.FC<ImportJobRowProps> = ({
   const status = rowStatus(job);
   const Icon =
     status === "completed-bank" ? Landmark : FILE_ICON[job.file_type ?? "csv"];
+  const tag = STATUS_TAG[status];
+  const when = dayjs(job.created_at).isValid()
+    ? dayjs(job.created_at).format("D MMM")
+    : job.created_at;
   return (
     <button
       type="button"
@@ -62,45 +100,23 @@ export const ImportJobRow: React.FC<ImportJobRowProps> = ({
       )}
     >
       <Icon aria-hidden className="h-4 w-4 shrink-0 text-text-2" />
-      <span className="min-w-0 flex-1 truncate">
-        {job.file_name ?? (job.source === "bank_sync" ? "Bank sync" : "Upload")}
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-medium leading-4">
+          {job.file_name ??
+            (job.source === "bank_sync" ? "Bank sync" : "Upload")}
+        </span>
+        <span
+          className={cn(
+            "block truncate leading-4",
+            status === "failed" ? "font-mono text-expense" : "text-text-2",
+          )}
+        >
+          {caption(job, status)}
+        </span>
       </span>
-
-      {status === "processing" ? (
-        <span className="inline-flex items-center gap-1.5 text-text-2">
-          <span
-            aria-hidden
-            className="h-3 w-3 animate-spin rounded-full border-2 border-border border-t-accent motion-reduce:animate-none"
-          />
-          Processing…
-        </span>
-      ) : status === "failed" ? (
-        <span className="inline-flex items-center gap-1 text-expense">
-          <CircleAlert aria-hidden className="h-3.5 w-3.5" />
-          <span className="font-mono text-[12px]">
-            {job.error_code ?? "failed"}
-          </span>
-        </span>
-      ) : status === "completed-empty" ? (
-        <span className="text-text-2">No transactions found</span>
-      ) : (
-        <>
-          <span className="tabular-nums text-text-2">
-            {job.imported}/{job.total_parsed} imported
-          </span>
-          {job.duplicates_found > 0 ? (
-            <span className="tabular-nums text-text-2">
-              {job.duplicates_found} duplicates
-            </span>
-          ) : null}
-          {job.anomalies.length > 0 ? (
-            <Tag tint="warn" count={job.anomalies.length} />
-          ) : null}
-          {status === "completed-bank" ? <Tag tint="info">bank</Tag> : null}
-        </>
-      )}
-      <span className="w-20 shrink-0 text-right tabular-nums text-text-2">
-        {job.created_at.slice(0, 10)}
+      <Tag tint={tag.tint}>{tag.label}</Tag>
+      <span className="w-14 shrink-0 text-right tabular-nums text-text-2">
+        {when}
       </span>
     </button>
   );

--- a/web/src/components/ui/Input.tsx
+++ b/web/src/components/ui/Input.tsx
@@ -16,12 +16,18 @@ export interface InputProps extends Omit<
   type?: "text" | "search";
   error?: string | null;
   label?: string;
+  /**
+   * Keyboard-shortcut hint chip (Figma search default state shows "⌘K");
+   * hidden once the field is focused or filled.
+   */
+  kbdHint?: string;
 }
 
 export const Input: React.FC<InputProps> = ({
   type = "text",
   error = null,
   label,
+  kbdHint,
   id,
   className,
   ...rest
@@ -49,16 +55,33 @@ export const Input: React.FC<InputProps> = ({
           type={type === "search" ? "search" : "text"}
           aria-invalid={error ? true : undefined}
           className={cn(
-            "h-10 w-full rounded border bg-bg px-3 text-sm text-text",
+            // Figma field: 36px tall, 12px pad, Body/14 Regular, radius 6.
+            "peer h-9 w-full rounded border bg-bg px-3 text-sm text-text",
             "placeholder:text-text-2 transition-colors duration-fast ease-standard",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
-            "disabled:cursor-not-allowed disabled:bg-bg-elev disabled:opacity-60",
+            // Figma disabled: whole field at 40% opacity, bg stays bg.
+            "disabled:cursor-not-allowed disabled:opacity-40",
             type === "search" && "pl-9",
+            kbdHint && "pr-12",
             error ? "border-expense" : "border-border",
             className,
           )}
           {...rest}
         />
+        {kbdHint ? (
+          <span
+            aria-hidden
+            className={cn(
+              "pointer-events-none absolute right-3 top-1/2 -translate-y-1/2",
+              "rounded-[4px] border border-border bg-bg-elev px-[5px] py-px",
+              "text-[13px] leading-4 text-text-2",
+              // Figma: only the default (empty, unfocused) state shows it.
+              "peer-focus:hidden peer-[:not(:placeholder-shown)]:hidden",
+            )}
+          >
+            {kbdHint}
+          </span>
+        ) : null}
       </div>
       {error ? (
         <p role="alert" className="mt-1 text-[13px] text-expense">

--- a/web/src/components/ui/LinkAccountCard.test.tsx
+++ b/web/src/components/ui/LinkAccountCard.test.tsx
@@ -21,7 +21,10 @@ describe("LinkAccountCard (design.md §8.2, MI-9)", () => {
     render(<LinkAccountCard link={link("active")} />);
     expect(screen.getByText("GTBank")).toBeInTheDocument();
     expect(screen.getByText("•••• 4521")).toBeInTheDocument();
-    expect(screen.getByText(/last synced 2026-07-17/)).toBeInTheDocument();
+    // Figma active caption: "Last synced … · n transactions".
+    expect(
+      screen.getByText(/Last synced 2026-07-17 · 120 transactions/),
+    ).toBeInTheDocument();
   });
 
   it("covers all five BANK_LINK states", () => {
@@ -49,8 +52,11 @@ describe("LinkAccountCard (design.md §8.2, MI-9)", () => {
     expect(dot).toHaveClass("animate-breathe", "motion-reduce:animate-none");
   });
 
-  it("reauth_required tints the card border", () => {
+  it("reauth_required shows the warn status pill", () => {
     render(<LinkAccountCard link={link("reauth_required")} />);
-    expect(screen.getByText("Re-auth required")).toBeInTheDocument();
+    const pill = screen.getByText("Re-auth required");
+    expect(pill).toBeInTheDocument();
+    // Figma: reauth pill is warn-tinted (not expense).
+    expect(pill.closest("span")).toHaveClass("text-warn");
   });
 });

--- a/web/src/components/ui/LinkAccountCard.tsx
+++ b/web/src/components/ui/LinkAccountCard.tsx
@@ -1,7 +1,10 @@
 /**
- * LinkAccountCard — design.md §3/§8.2: bank logo · masked account · sync
- * status dot · last-synced. States pending / active (breathing dot,
- * MI-9) / reauth_required / degraded / paused.
+ * LinkAccountCard — design.md §3/§8.2, Figma Stage 2 (node 65:323): white
+ * card · 32px icon well · institution + masked account (mono) · tinted
+ * status pill top-right · status caption line · optional action. States
+ * pending / active (breathing dot, MI-9) / reauth_required / degraded /
+ * paused. Pill tints: pending=info, active=income, reauth/degraded=warn,
+ * paused=neutral.
  */
 
 import React from "react";
@@ -11,13 +14,50 @@ import { cn } from "@/lib/cn";
 
 const STATUS_META: Record<
   BankLinkStatus,
-  { label: string; dotClass: string; breathe?: boolean }
+  { label: string; pillClass: string; dotClass: string; breathe?: boolean }
 > = {
-  pending: { label: "Connecting…", dotClass: "bg-text-2" },
-  active: { label: "Active", dotClass: "bg-income", breathe: true },
-  reauth_required: { label: "Re-auth required", dotClass: "bg-expense" },
-  degraded: { label: "Degraded", dotClass: "bg-warn" },
-  paused: { label: "Paused", dotClass: "bg-text-2" },
+  pending: {
+    label: "Connecting…",
+    pillClass: "bg-info/[0.12] text-info",
+    dotClass: "bg-info",
+  },
+  active: {
+    label: "Active",
+    pillClass: "bg-income/[0.12] text-income",
+    dotClass: "bg-income",
+    breathe: true,
+  },
+  reauth_required: {
+    label: "Re-auth required",
+    pillClass: "bg-warn/[0.12] text-warn",
+    dotClass: "bg-warn",
+  },
+  degraded: {
+    label: "Degraded",
+    pillClass: "bg-warn/[0.12] text-warn",
+    dotClass: "bg-warn",
+  },
+  paused: {
+    label: "Paused",
+    pillClass: "bg-bg-elev text-text-2",
+    dotClass: "bg-text-2",
+  },
+};
+
+/** Figma caption line per status (data-driven where the model allows). */
+const caption = (link: BankLink): string => {
+  switch (link.status) {
+    case "pending":
+      return `Waiting for ${link.provider === "mono" ? "Mono" : link.provider} consent`;
+    case "active":
+      return `Last synced ${link.last_synced_at ?? "—"} · ${link.imported_txn_count.toLocaleString("en-NG")} transactions`;
+    case "reauth_required":
+      return `Sync paused since ${link.last_synced_at ?? "—"}`;
+    case "degraded":
+      return "Failed syncs — retrying hourly";
+    case "paused":
+      return "Paused by you · syncs stop until resumed";
+  }
 };
 
 export interface LinkAccountCardProps {
@@ -39,45 +79,48 @@ export const LinkAccountCard: React.FC<LinkAccountCardProps> = ({
     <div
       data-status={link.status}
       className={cn(
-        "flex items-center gap-3 rounded border bg-bg-elev p-4",
-        link.status === "reauth_required"
-          ? "border-expense/40"
-          : "border-border",
+        "flex items-start gap-3 rounded border border-border bg-bg p-4",
         className,
       )}
     >
-      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-border bg-bg">
-        <Landmark aria-hidden className="h-5 w-5 text-text-2" />
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-bg-elev">
+        <Landmark aria-hidden className="h-4 w-4 text-text" />
       </span>
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="truncate text-sm font-medium text-text">
-            {link.institution}
-          </span>
-          <span className="font-mono text-[12px] tabular-nums text-text-2">
-            {link.masked_account}
-          </span>
-        </div>
-        <div className="mt-0.5 flex items-center gap-1.5 text-[13px] text-text-2">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="truncate text-sm font-medium leading-5 text-text">
+              {link.institution}
+            </div>
+            <div className="font-mono text-[13px] leading-4 tabular-nums text-text-2">
+              {link.masked_account}
+            </div>
+          </div>
           <span
-            data-testid="sync-dot"
-            aria-hidden
             className={cn(
-              "h-2 w-2 rounded-full",
-              meta.dotClass,
-              (syncing || (meta.breathe && link.status === "active")) &&
-                "animate-breathe motion-reduce:animate-none",
+              "inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-[3px]",
+              "text-[13px] font-medium leading-4",
+              meta.pillClass,
             )}
-          />
-          <span>{meta.label}</span>
-          {link.last_synced_at ? (
-            <span className="tabular-nums">
-              · last synced {link.last_synced_at}
-            </span>
-          ) : null}
+          >
+            <span
+              data-testid="sync-dot"
+              aria-hidden
+              className={cn(
+                "h-1.5 w-1.5 rounded-full",
+                meta.dotClass,
+                (syncing || (meta.breathe && link.status === "active")) &&
+                  "animate-breathe motion-reduce:animate-none",
+              )}
+            />
+            {meta.label}
+          </span>
         </div>
+        <div className="mt-2 text-[13px] leading-4 text-text-2">
+          {caption(link)}
+        </div>
+        {action ? <div className="mt-2">{action}</div> : null}
       </div>
-      {action}
     </div>
   );
 };

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -38,7 +38,7 @@ export const MarketingFooter: React.FC<MarketingFooterProps> = ({
           </h3>
           <ul className="space-y-2">
             {column.links.map((link) => (
-              <li key={link.href}>
+              <li key={link.label}>
                 <a
                   href={link.href}
                   className="rounded text-[13px] text-text transition-colors duration-fast ease-standard hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -128,7 +128,7 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
             >
               {solutions.map((item) => (
                 <a
-                  key={item.href}
+                  key={item.label}
                   role="menuitem"
                   href={item.href}
                   className="block px-3 py-1.5 text-[13px] text-text transition-colors duration-fast ease-standard hover:bg-bg-elev"
@@ -142,7 +142,7 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
       ) : null}
 
       {links.map((link) => (
-        <a key={link.href} href={link.href} className={itemClass}>
+        <a key={link.label} href={link.href} className={itemClass}>
           {link.label}
         </a>
       ))}

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -68,7 +68,9 @@ export const Modal: React.FC<ModalProps> = ({
         <Dialog.Content
           aria-describedby={undefined}
           className={cn(
-            "fixed z-modal border border-border bg-bg shadow-lg focus:outline-none",
+            // font-sans: portals mount under <body>, which still carries
+            // the legacy Poppins font until the legacy pages retire (W3).
+            "fixed z-modal border border-border bg-bg font-sans shadow-lg focus:outline-none",
             variant === "sheet"
               ? "inset-y-0 right-0 flex w-full max-w-md flex-col rounded-none"
               : cn(

--- a/web/src/components/ui/MoneyCell.test.tsx
+++ b/web/src/components/ui/MoneyCell.test.tsx
@@ -31,6 +31,7 @@ describe("MoneyCell (design.md §3/§8.2)", () => {
       <MoneyCell amount={99.9} direction="income" size="stat" currency="USD" />,
     );
     const cell = screen.getByText("+$99.90").closest("span[data-direction]");
-    expect(cell).toHaveClass("text-2xl");
+    // Figma stat ramp: Display/32 Bold.
+    expect(cell).toHaveClass("text-[32px]", "font-bold");
   });
 });

--- a/web/src/components/ui/MoneyCell.tsx
+++ b/web/src/components/ui/MoneyCell.tsx
@@ -14,7 +14,11 @@ export interface MoneyCellProps {
   direction: "income" | "expense" | "zero";
   currency?: string;
   size?: "table" | "stat";
-  /** Direction icon (kept for accessibility; hide via prop when dense). */
+  /**
+   * Optional direction arrow. The Figma kit renders MoneyCell with sign
+   * only (+/− already encodes direction without color); arrows are an
+   * opt-in for call sites that want the extra cue.
+   */
   withIcon?: boolean;
   className?: string;
 }
@@ -24,7 +28,7 @@ export const MoneyCell: React.FC<MoneyCellProps> = ({
   direction,
   currency = "NGN",
   size = "table",
-  withIcon = true,
+  withIcon = false,
   className,
 }) => {
   const sign =
@@ -35,7 +39,10 @@ export const MoneyCell: React.FC<MoneyCellProps> = ({
       data-direction={direction}
       className={cn(
         "inline-flex items-center gap-1 tabular-nums",
-        size === "table" ? "text-[13px]" : "text-2xl font-semibold",
+        // Figma: table = Table/13 Medium; stat = Display/32 Bold (-1px).
+        size === "table"
+          ? "text-[13px] font-medium leading-4"
+          : "text-[32px] font-bold leading-[38px] tracking-[-1px]",
         direction === "income" && "text-income",
         direction === "expense" && "text-expense",
         direction === "zero" && "text-text", // never colored for zero

--- a/web/src/components/ui/OrgSwitcher.tsx
+++ b/web/src/components/ui/OrgSwitcher.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
-import { Building2, Check, ChevronsUpDown, User } from "lucide-react";
+import { Building2, Check, ChevronsUpDown, Plus } from "lucide-react";
 import type { Org } from "@/models";
 import { cn } from "@/lib/cn";
 
@@ -14,25 +14,54 @@ export interface OrgSwitcherProps {
   orgs: Org[];
   currentOrgId: string;
   onSelect?: (orgId: string) => void;
+  /** Figma: "+ Create organization" row at the bottom of the menu. */
+  onCreate?: () => void;
   /** Collapsed nav rail renders the icon-only trigger. */
   compact?: boolean;
   className?: string;
 }
 
-const KindIcon: React.FC<{ kind: Org["kind"]; className?: string }> = ({
-  kind,
+const initialsOf = (name: string): string =>
+  name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("");
+
+/**
+ * Figma org tile: company = info-tinted building icon; personal =
+ * accent-tinted initials.
+ */
+const OrgTile: React.FC<{ org: Org; className?: string }> = ({
+  org,
   className,
-}) =>
-  kind === "company" ? (
-    <Building2 aria-hidden className={className} />
-  ) : (
-    <User aria-hidden className={className} />
-  );
+}) => (
+  <span
+    aria-hidden
+    className={cn(
+      "flex shrink-0 items-center justify-center rounded",
+      org.kind === "company"
+        ? "bg-info/[0.12] text-info"
+        : "bg-accent/[0.12] text-accent",
+      className,
+    )}
+  >
+    {org.kind === "company" ? (
+      <Building2 className="h-3.5 w-3.5" />
+    ) : (
+      <span className="text-[10px] font-semibold leading-none">
+        {initialsOf(org.name)}
+      </span>
+    )}
+  </span>
+);
 
 export const OrgSwitcher: React.FC<OrgSwitcherProps> = ({
   orgs,
   currentOrgId,
   onSelect,
+  onCreate,
   compact = false,
   className,
 }) => {
@@ -68,15 +97,15 @@ export const OrgSwitcher: React.FC<OrgSwitcherProps> = ({
         data-kind={current.kind}
         onClick={() => setOpen((state) => !state)}
         className={cn(
-          "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left",
+          // Figma: bordered trigger; accent border while open.
+          "flex w-full items-center gap-2 rounded border bg-bg px-2 py-1.5 text-left",
+          open ? "border-accent" : "border-border",
           "transition-colors duration-fast ease-standard hover:bg-bg-elev",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
-          compact && "justify-center",
+          compact && "justify-center border-transparent",
         )}
       >
-        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded border border-border bg-bg-elev">
-          <KindIcon kind={current.kind} className="h-3.5 w-3.5 text-text-2" />
-        </span>
+        <OrgTile org={current} className="h-6 w-6" />
         {!compact ? (
           <>
             <span className="min-w-0 flex-1">
@@ -114,9 +143,10 @@ export const OrgSwitcher: React.FC<OrgSwitcherProps> = ({
                 className={cn(
                   "flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] text-text",
                   "transition-colors duration-fast ease-standard hover:bg-bg-elev",
+                  org.id === currentOrgId && "bg-bg-elev",
                 )}
               >
-                <KindIcon kind={org.kind} className="h-3.5 w-3.5 text-text-2" />
+                <OrgTile org={org} className="h-5 w-5" />
                 <span className="min-w-0 flex-1 truncate">{org.name}</span>
                 {org.id === currentOrgId ? (
                   <Check aria-hidden className="h-3.5 w-3.5 text-accent" />
@@ -124,6 +154,24 @@ export const OrgSwitcher: React.FC<OrgSwitcherProps> = ({
               </button>
             </li>
           ))}
+          {onCreate ? (
+            <li>
+              <button
+                type="button"
+                onClick={() => {
+                  onCreate();
+                  setOpen(false);
+                }}
+                className={cn(
+                  "flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] text-text-2",
+                  "transition-colors duration-fast ease-standard hover:bg-bg-elev hover:text-text",
+                )}
+              >
+                <Plus aria-hidden className="h-3.5 w-3.5" />
+                Create organization
+              </button>
+            </li>
+          ) : null}
         </ul>
       ) : null}
     </div>

--- a/web/src/components/ui/PeriodPicker.tsx
+++ b/web/src/components/ui/PeriodPicker.tsx
@@ -7,7 +7,8 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
-import { Calendar, ChevronsUpDown } from "lucide-react";
+import { Calendar, ChevronDown } from "lucide-react";
+import dayjs from "dayjs";
 import { cn } from "@/lib/cn";
 
 export type PeriodMode = "day" | "range" | "month" | "quarter" | "year";
@@ -48,6 +49,31 @@ const MODE_PATTERN: Record<PeriodMode, RegExp> = {
 /** Grammar validation for a period string in the given mode. */
 export const isValidPeriod = (mode: PeriodMode, value: string): boolean =>
   MODE_PATTERN[mode].test(value);
+
+/**
+ * Figma trigger copy is humanized ("12 Jan 2026", "1 Apr – 30 Jun 2026",
+ * "Jun 2026", "Q2 2026", "FY2025") while the value keeps the period
+ * grammar (line-items.md §6).
+ */
+export const formatPeriod = (mode: PeriodMode, value: string): string => {
+  if (!isValidPeriod(mode, value)) return value;
+  switch (mode) {
+    case "day":
+      return dayjs(value).format("D MMM YYYY");
+    case "range": {
+      const [from, to] = value.split("..");
+      return `${dayjs(from).format("D MMM")} – ${dayjs(to).format("D MMM YYYY")}`;
+    }
+    case "month":
+      return dayjs(`${value}-01`).format("MMM YYYY");
+    case "quarter": {
+      const [year, quarter] = value.split("-");
+      return `${quarter} ${year}`;
+    }
+    case "year":
+      return value;
+  }
+};
 
 export const PeriodPicker: React.FC<PeriodPickerProps> = ({
   mode,
@@ -114,11 +140,13 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
         disabled={disabled}
         onClick={() => setOpen((state) => !state)}
         className={cn(
-          "flex h-10 w-full items-center justify-between gap-2 rounded border bg-bg px-3 text-left text-sm",
+          // Figma trigger: 32px, Table/13.
+          "flex h-8 w-full items-center justify-between gap-2 rounded border bg-bg px-3 text-left text-[13px]",
           "transition-colors duration-fast ease-standard",
           shownError ? "border-expense" : "border-border",
+          open && !shownError && "border-accent",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
-          "disabled:cursor-not-allowed disabled:bg-bg-elev disabled:opacity-60",
+          "disabled:cursor-not-allowed disabled:opacity-40",
         )}
       >
         <span className="flex items-center gap-2">
@@ -126,10 +154,10 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
           <span
             className={cn("tabular-nums", value ? "text-text" : "text-text-2")}
           >
-            {value ?? MODE_PLACEHOLDER[mode]}
+            {value ? formatPeriod(mode, value) : MODE_PLACEHOLDER[mode]}
           </span>
         </span>
-        <ChevronsUpDown aria-hidden className="h-4 w-4 shrink-0 text-text-2" />
+        <ChevronDown aria-hidden className="h-4 w-4 shrink-0 text-text-2" />
       </button>
 
       {open ? (

--- a/web/src/components/ui/RatioGauge.test.tsx
+++ b/web/src/components/ui/RatioGauge.test.tsx
@@ -14,7 +14,8 @@ describe("RatioGauge (design.md §8.2, MI-8)", () => {
         max={3}
       />,
     );
-    expect(screen.getByText("1.85")).toHaveClass("text-income", "tabular-nums");
+    // Figma: the value reads in body text color; status colors the arc.
+    expect(screen.getByText("1.85")).toHaveClass("text-text", "tabular-nums");
     expect(screen.getByText("Current ratio")).toBeInTheDocument();
     expect(
       screen.getByRole("img", { name: "Current ratio: 1.85" }),
@@ -44,7 +45,8 @@ describe("RatioGauge (design.md §8.2, MI-8)", () => {
         band={{ from: 1, to: 2 }}
       />,
     );
-    expect(screen.getByText("n/a")).toBeInTheDocument();
+    // Figma n-a: dash in the value slot + reason caption.
+    expect(screen.getByTestId("gauge-na-dash")).toBeInTheDocument();
     expect(screen.getByText("n/a — negative equity")).toBeInTheDocument();
     // As built: n-a ships band=off only.
     expect(screen.queryByTestId("gauge-band")).not.toBeInTheDocument();
@@ -63,7 +65,7 @@ describe("RatioGauge (design.md §8.2, MI-8)", () => {
     expect(band).toHaveClass("animate-fade-in", "motion-reduce:animate-none");
   });
 
-  it("MI-8: formula tooltip trigger wraps the gauge; needle eases 600ms", () => {
+  it("MI-8: formula tooltip trigger wraps the gauge; arc eases 600ms", () => {
     render(
       <RatioGauge
         label="Current ratio"
@@ -75,9 +77,24 @@ describe("RatioGauge (design.md §8.2, MI-8)", () => {
     expect(
       screen.getByRole("button", { name: "Current ratio formula" }),
     ).toBeInTheDocument();
-    expect(screen.getByTestId("gauge-needle")).toHaveClass(
+    expect(screen.getByTestId("gauge-value-arc")).toHaveClass(
       "duration-[600ms]",
       "motion-reduce:transition-none",
     );
+  });
+
+  it("renders the Figma delta line colored by sign", () => {
+    render(
+      <RatioGauge
+        label="Current ratio"
+        value={1.82}
+        status="healthy"
+        delta={0.21}
+        deltaCaption="vs Q1"
+      />,
+    );
+    const delta = screen.getByTestId("gauge-delta");
+    expect(delta).toHaveTextContent("+0.21 vs Q1");
+    expect(delta).toHaveClass("text-income");
   });
 });

--- a/web/src/components/ui/RatioGauge.tsx
+++ b/web/src/components/ui/RatioGauge.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 /**
- * RatioGauge — design.md §3/§8.2 (MI-8): bespoke SVG semicircle gauge +
- * value + benchmark band. Status healthy / warning / critical / n-a
- * ("missing input" — band off, per the as-built note). Needle eases to
- * value 600ms cubic, benchmark band fades in after; hover/focus shows the
+ * RatioGauge — design.md §3/§8.2 (MI-8), Figma Stage 2 (node 66:321):
+ * white card · label top-left · bespoke SVG semicircle (12px track, value
+ * arc in the status color, 3px benchmark band floating outside at 45%
+ * income) · Display/32 value · delta line ("+0.21 vs Q1") · caption
+ * (benchmark or formula). Status healthy / warning / critical / n-a
+ * ("missing input" — band off, value dash). The value arc eases to its
+ * value over 600ms, the band fades in after; hover/focus shows the
  * formula tooltip; reduced motion jump-cuts (design.md §5).
  */
 
@@ -26,7 +29,12 @@ export interface RatioGaugeProps {
   status: RatioStatus;
   /** Benchmark band in the value domain; off for status="na". */
   band?: { from: number; to: number } | null;
-  /** MI-8 formula tooltip content. */
+  /** Delta vs previous period (Figma: "+0.21 vs Q1"). */
+  delta?: number;
+  deltaCaption?: string;
+  /** Caption line; defaults to the benchmark range when band is on. */
+  caption?: string;
+  /** MI-8 formula tooltip content (also the band-off caption). */
   formula?: string;
   /** n/a reason ("missing input"). */
   naReason?: string | null;
@@ -40,27 +48,27 @@ const STATUS_STROKE: Record<RatioStatus, string> = {
   na: "stroke-border",
 };
 
-const STATUS_TEXT: Record<RatioStatus, string> = {
-  healthy: "text-income",
-  warning: "text-warn",
-  critical: "text-expense",
-  na: "text-text-2",
-};
+// Figma gauge geometry (node 66:266): 182×100 viewBox, centre (88,88),
+// track r=70 / 12px round caps, band r=81 / 3px at 45% income.
+const CX = 88;
+const CY = 88;
+const R = 70;
+const BAND_R = 81;
 
-const CX = 80;
-const CY = 72;
-const R = 60;
-
-/** Angle in degrees for a domain fraction: 180° (left) → 0° (right). */
+/** Point on the arc for a domain fraction: 180° (left) → 0° (right). */
 const arcPoint = (fraction: number, radius = R): [number, number] => {
   const angle = Math.PI * (1 - fraction);
   return [CX + radius * Math.cos(angle), CY - radius * Math.sin(angle)];
 };
 
-const arcPath = (fromFraction: number, toFraction: number): string => {
-  const [x1, y1] = arcPoint(fromFraction);
-  const [x2, y2] = arcPoint(toFraction);
-  return `M ${x1.toFixed(2)} ${y1.toFixed(2)} A ${R} ${R} 0 0 1 ${x2.toFixed(2)} ${y2.toFixed(2)}`;
+const arcPath = (
+  fromFraction: number,
+  toFraction: number,
+  radius = R,
+): string => {
+  const [x1, y1] = arcPoint(fromFraction, radius);
+  const [x2, y2] = arcPoint(toFraction, radius);
+  return `M ${x1.toFixed(2)} ${y1.toFixed(2)} A ${radius} ${radius} 0 0 1 ${x2.toFixed(2)} ${y2.toFixed(2)}`;
 };
 
 const clamp01 = (fraction: number): number =>
@@ -74,6 +82,9 @@ export const RatioGauge: React.FC<RatioGaugeProps> = ({
   max = 3,
   status,
   band = null,
+  delta,
+  deltaCaption,
+  caption,
   formula,
   naReason = null,
   className,
@@ -84,69 +95,72 @@ export const RatioGauge: React.FC<RatioGaugeProps> = ({
     ? 0
     : clamp01((Number(value) - min) / (max - min || 1));
 
-  // MI-8: needle starts at rest and eases to the value (600ms cubic);
+  // MI-8: the value arc starts at rest and eases to the value (600ms);
   // reduced motion jump-cuts straight to the target.
-  const [needleFraction, setNeedleFraction] = useState(
-    reduced ? targetFraction : 0,
-  );
+  const [arcFraction, setArcFraction] = useState(reduced ? targetFraction : 0);
   useEffect(() => {
-    // One frame later in both modes; the reduced-motion jump-cut comes
-    // from motion-reduce:transition-none on the needle/arc.
-    const frame = requestAnimationFrame(() =>
-      setNeedleFraction(targetFraction),
-    );
+    const frame = requestAnimationFrame(() => setArcFraction(targetFraction));
     return () => cancelAnimationFrame(frame);
   }, [targetFraction]);
 
-  const needleAngle = -90 + needleFraction * 180;
+  const deltaPositive = (delta ?? 0) >= 0;
+  const captionText =
+    caption ??
+    (band && !isNa ? `Benchmark ${band.from}–${band.to}` : (formula ?? null));
 
   const gauge = (
     <figure
       data-status={status}
       className={cn(
-        "inline-flex flex-col items-center rounded border border-border bg-bg-elev p-4",
+        "inline-flex w-[240px] flex-col items-center gap-1 rounded border border-border bg-bg p-4",
         className,
       )}
     >
+      <figcaption className="w-full text-left text-[13px] font-medium leading-4 text-text-2">
+        {label}
+      </figcaption>
       <svg
-        width="160"
-        height="88"
-        viewBox="0 0 160 88"
+        width="182"
+        height="100"
+        viewBox="0 0 182 100"
         role="img"
         aria-label={`${label}: ${isNa ? (naReason ?? "n/a — missing input") : (display ?? String(value))}`}
+        className="overflow-visible"
       >
         {/* Track */}
         <path
           d={arcPath(0, 1)}
           fill="none"
-          strokeWidth="8"
+          strokeWidth="12"
           strokeLinecap="round"
           className="stroke-border"
         />
-        {/* Benchmark band — fades in after the needle settles (MI-8). */}
+        {/* Benchmark band — floats outside; fades in after the arc (MI-8). */}
         {band && !isNa ? (
           <path
             data-testid="gauge-band"
             d={arcPath(
               clamp01((band.from - min) / (max - min || 1)),
               clamp01((band.to - min) / (max - min || 1)),
+              BAND_R,
             )}
             fill="none"
-            strokeWidth="8"
+            strokeWidth="3"
             strokeLinecap="round"
             className={cn(
-              "stroke-income/40",
+              "stroke-income/45",
               !reduced &&
                 "animate-fade-in [animation-delay:600ms] motion-reduce:animate-none",
             )}
           />
         ) : null}
-        {/* Value arc */}
+        {/* Value arc — eases to the value (MI-8). */}
         {!isNa ? (
           <path
-            d={arcPath(0, Math.max(0.001, needleFraction))}
+            data-testid="gauge-value-arc"
+            d={arcPath(0, Math.max(0.001, arcFraction))}
             fill="none"
-            strokeWidth="8"
+            strokeWidth="12"
             strokeLinecap="round"
             className={cn(
               STATUS_STROKE[status],
@@ -154,45 +168,41 @@ export const RatioGauge: React.FC<RatioGaugeProps> = ({
             )}
           />
         ) : null}
-        {/* Needle */}
-        <g
-          data-testid="gauge-needle"
-          style={{
-            transform: `rotate(${needleAngle}deg)`,
-            transformOrigin: `${CX}px ${CY}px`,
-          }}
-          className={cn(
-            "transition-transform duration-[600ms] ease-standard",
-            "motion-reduce:transition-none",
-          )}
-        >
-          <line
-            x1={CX}
-            y1={CY}
-            x2={CX}
-            y2={CY - R + 14}
-            strokeWidth="2"
-            className={isNa ? "stroke-border" : "stroke-text"}
-          />
-        </g>
-        <circle cx={CX} cy={CY} r="3.5" className="fill-text" />
       </svg>
-      <figcaption className="mt-1 text-center">
+      {isNa ? (
+        // Figma n-a: a quiet dash in the value slot.
+        <span
+          aria-hidden
+          className="flex h-[38px] items-center"
+          data-testid="gauge-na-dash"
+        >
+          <span className="h-1 w-6 rounded-full bg-text-2" />
+        </span>
+      ) : (
+        <div className="text-[32px] font-bold leading-[38px] tracking-[-0.01em] tabular-nums text-text">
+          {display ?? String(value)}
+        </div>
+      )}
+      {!isNa && delta !== undefined ? (
         <div
+          data-testid="gauge-delta"
           className={cn(
-            "text-xl font-semibold tabular-nums",
-            STATUS_TEXT[status],
+            "text-[13px] font-medium leading-4 tabular-nums",
+            deltaPositive ? "text-income" : "text-expense",
           )}
         >
-          {isNa ? "n/a" : (display ?? String(value))}
+          {deltaPositive ? "+" : "−"}
+          {Math.abs(delta)}
+          {deltaCaption ? ` ${deltaCaption}` : null}
         </div>
-        <div className="text-[13px] text-text-2">{label}</div>
-        {isNa ? (
-          <div className="mt-0.5 text-[11px] text-text-2">
-            {naReason ?? "missing input"}
-          </div>
-        ) : null}
-      </figcaption>
+      ) : null}
+      {isNa ? (
+        <div className="text-[13px] leading-4 text-text-2">
+          {naReason ?? "missing input"}
+        </div>
+      ) : captionText ? (
+        <div className="text-[13px] leading-4 text-text-2">{captionText}</div>
+      ) : null}
     </figure>
   );
 

--- a/web/src/components/ui/RemitToCard.test.tsx
+++ b/web/src/components/ui/RemitToCard.test.tsx
@@ -23,15 +23,18 @@ describe("RemitToCard (design.md §8.2)", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("(LIRS)")).toBeInTheDocument();
     expect(screen.getByText("₦342,500.75")).toHaveClass("tabular-nums");
-    expect(screen.getByText("due 2027-03-31")).toBeInTheDocument();
-    expect(screen.getByText("eTax portal")).toBeInTheDocument();
-    expect(screen.getByText("Bank branch")).toBeInTheDocument();
+    // Figma: "Amount due" label + "Due 31 Mar 2027" + one "Pay via" chip.
+    expect(screen.getByText("Amount due")).toBeInTheDocument();
+    expect(screen.getByText("Due 31 Mar 2027")).toBeInTheDocument();
+    expect(
+      screen.getByText("Pay via eTax portal / Bank branch"),
+    ).toBeInTheDocument();
   });
 
   it("covers pit / cit / vat kinds", () => {
     const kinds = [
-      ["pit", "Personal income tax"],
-      ["cit", "Company income tax"],
+      ["pit", "Personal Income Tax"],
+      ["cit", "Companies Income Tax + Development Levy"],
       ["vat", "VAT"],
     ] as const;
     for (const [kind, label] of kinds) {

--- a/web/src/components/ui/RemitToCard.tsx
+++ b/web/src/components/ui/RemitToCard.tsx
@@ -1,18 +1,21 @@
 /**
- * RemitToCard — design.md §8.2: tax pit/cit/vat · resolved authority
- * (State IRS e.g. LIRS / FIRS) + amount due + deadline + payment-channel
- * chips (tax-engine §"Remittance & authorities" registry).
+ * RemitToCard — design.md §8.2, Figma Stage 2b: white card · tinted icon
+ * well · tax title + "Remit to {authority}" caption · "Amount due" label ·
+ * Display/32 tabular amount · calendar due line (T-x chip when close) ·
+ * one "Pay via …" channel chip (tax-engine §"Remittance & authorities").
  */
 
 import React from "react";
-import { Landmark } from "lucide-react";
+import { Calendar, Landmark } from "lucide-react";
 import type { Authority, TaxKind } from "@/models";
 import { cn } from "@/lib/cn";
 import { formatMoney } from "@/lib/format";
+import dayjs from "dayjs";
+import { thresholdFor } from "./TaxCalendarRow";
 
 const TAX_LABEL: Record<TaxKind, string> = {
-  pit: "Personal income tax",
-  cit: "Company income tax",
+  pit: "Personal Income Tax",
+  cit: "Companies Income Tax + Development Levy",
   vat: "VAT",
 };
 
@@ -21,8 +24,10 @@ export interface RemitToCardProps {
   authority: Authority;
   amountDue: number;
   currency?: string;
-  /** ISO due date, rendered as given. */
+  /** ISO due date. */
   dueDate: string;
+  /** Days until due — shows the T-30/T-7/T-1 chip when close. */
+  daysToDue?: number;
   className?: string;
 }
 
@@ -32,43 +37,54 @@ export const RemitToCard: React.FC<RemitToCardProps> = ({
   amountDue,
   currency = "NGN",
   dueDate,
+  daysToDue,
   className,
-}) => (
-  <div
-    data-kind={kind}
-    className={cn("rounded border border-border bg-bg-elev p-4", className)}
-  >
-    <div className="flex items-center justify-between gap-2">
-      <span className="rounded border border-border bg-bg px-1.5 text-[11px] font-medium uppercase tracking-wide text-text-2">
-        {TAX_LABEL[kind]}
-      </span>
-      <span className="text-[13px] tabular-nums text-text-2">
-        due {dueDate}
-      </span>
-    </div>
-    <div className="mt-3 flex items-center gap-2 text-sm text-text">
-      <Landmark aria-hidden className="h-4 w-4 text-text-2" />
-      <span className="font-medium">Remit to {authority.name}</span>
-      <span className="font-mono text-[12px] text-text-2">
-        ({authority.code})
-      </span>
-    </div>
-    <div className="mt-1 text-2xl font-semibold tabular-nums text-text">
-      {formatMoney(amountDue, currency)}
-    </div>
-    {authority.payment_channels.length > 0 ? (
-      <div className="mt-3 flex flex-wrap gap-1.5">
-        {authority.payment_channels.map((channel) => (
-          <span
-            key={channel}
-            className="rounded border border-info/40 bg-info/10 px-1.5 py-0 text-[11px] font-medium text-info"
-          >
-            {channel}
-          </span>
-        ))}
+}) => {
+  const due = dayjs(dueDate).isValid()
+    ? dayjs(dueDate).format("D MMM YYYY")
+    : dueDate;
+  const threshold = daysToDue === undefined ? "none" : thresholdFor(daysToDue);
+  return (
+    <div
+      data-kind={kind}
+      className={cn("rounded border border-border bg-bg p-4", className)}
+    >
+      <div className="flex items-start gap-2.5">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-accent/[0.12] text-accent">
+          <Landmark aria-hidden className="h-4 w-4" />
+        </span>
+        <div className="min-w-0">
+          <div className="text-sm font-medium leading-5 text-text">
+            {TAX_LABEL[kind]}
+          </div>
+          <div className="truncate text-[13px] leading-4 text-text-2">
+            Remit to {authority.name}{" "}
+            <span className="font-mono">({authority.code})</span>
+          </div>
+        </div>
       </div>
-    ) : null}
-  </div>
-);
+      <div className="mt-3 text-[13px] leading-4 text-text-2">Amount due</div>
+      <div className="mt-1 text-[32px] font-bold leading-[38px] tracking-[-0.01em] tabular-nums text-text">
+        {formatMoney(amountDue, currency)}
+      </div>
+      <div className="mt-2 flex items-center gap-1.5 text-[13px] leading-4 text-text-2">
+        <Calendar aria-hidden className="h-3.5 w-3.5" />
+        <span className="tabular-nums">Due {due}</span>
+        {threshold !== "none" ? (
+          <span className="rounded-full bg-warn/[0.15] px-1.5 py-0.5 text-[11px] font-medium uppercase leading-4 text-warn">
+            {threshold}
+          </span>
+        ) : null}
+      </div>
+      {authority.payment_channels.length > 0 ? (
+        <div className="mt-3">
+          <span className="inline-flex rounded border border-border bg-bg px-1.5 py-0.5 text-[11px] font-medium leading-4 text-text">
+            Pay via {authority.payment_channels.join(" / ")}
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+};
 
 export default RemitToCard;

--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -9,7 +9,7 @@
  */
 
 import React, { useEffect, useId, useRef, useState } from "react";
-import { Check, ChevronsUpDown, Search } from "lucide-react";
+import { Check, ChevronDown, Search } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 export interface SelectOption {
@@ -135,11 +135,14 @@ export const Select: React.FC<SelectProps> = ({
         className={cn(
           "flex w-full items-center justify-between gap-2 rounded border bg-bg text-left",
           "transition-colors duration-fast ease-standard",
-          size === "md" ? "h-10 px-3 text-sm" : "h-8 px-2.5 text-[13px]",
+          // Figma: md = 36px, sm = 28px.
+          size === "md" ? "h-9 px-3 text-sm" : "h-7 px-2.5 text-[13px]",
           error ? "border-expense" : "border-border",
-          open && "border-text-2",
+          // Figma open/focus trigger: accent border.
+          open && "border-accent",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
-          "disabled:cursor-not-allowed disabled:bg-bg-elev disabled:opacity-60",
+          // Figma disabled: whole control at 40%.
+          "disabled:cursor-not-allowed disabled:opacity-40",
         )}
       >
         <span
@@ -150,7 +153,7 @@ export const Select: React.FC<SelectProps> = ({
         >
           {selected?.label ?? placeholder}
         </span>
-        <ChevronsUpDown aria-hidden className="h-4 w-4 shrink-0 text-text-2" />
+        <ChevronDown aria-hidden className="h-4 w-4 shrink-0 text-text-2" />
       </button>
 
       {open ? (

--- a/web/src/components/ui/Skeleton.tsx
+++ b/web/src/components/ui/Skeleton.tsx
@@ -49,10 +49,11 @@ export const Skeleton: React.FC<SkeletonProps> = ({
     );
   }
   if (variant === "stat") {
+    // Figma StatCard loading: value bar then meta bar.
     return (
       <div data-testid="skeleton-stat" className={cn("space-y-2", className)}>
-        <span className={cn(shimmer, "block h-3 w-24")} />
         <span className={cn(shimmer, "block h-7 w-36")} />
+        <span className={cn(shimmer, "block h-3 w-24")} />
       </div>
     );
   }

--- a/web/src/components/ui/StatCard.tsx
+++ b/web/src/components/ui/StatCard.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
-import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+import { TrendingDown, TrendingUp } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { prefersReducedMotion } from "@/lib/use-reduced-motion";
 import Skeleton from "./Skeleton";
@@ -21,6 +21,8 @@ export interface StatCardProps {
   format?: (value: number) => string;
   /** Delta vs previous period, as a fraction (0.042 = +4.2%). */
   delta?: number;
+  /** Comparison caption after the delta (Figma: "vs Jun"). */
+  deltaCaption?: string;
   /** Sparkline series (bespoke SVG; omit to hide). */
   sparkline?: number[];
   loading?: boolean;
@@ -98,18 +100,21 @@ export const StatCard: React.FC<StatCardProps> = ({
   value,
   format = (val) => Math.round(val).toLocaleString("en-NG"),
   delta,
+  deltaCaption,
   sparkline,
   loading = false,
   className,
 }) => {
   const shown = useCountUp(value);
 
+  // Figma card: white bg + hairline border, 16px pad, 8px stack gap.
+  const card = "flex flex-col gap-2 rounded border border-border bg-bg p-4";
+
   if (loading) {
     return (
-      <div
-        data-loading="true"
-        className={cn("rounded border border-border bg-bg-elev p-4", className)}
-      >
+      <div data-loading="true" className={cn(card, className)}>
+        {/* Figma loading state keeps the label; value + meta shimmer. */}
+        <div className="text-[13px] leading-4 text-text-2">{label}</div>
         <Skeleton variant="stat" />
       </div>
     );
@@ -117,36 +122,42 @@ export const StatCard: React.FC<StatCardProps> = ({
 
   const positive = (delta ?? 0) >= 0;
   return (
-    <div
-      className={cn("rounded border border-border bg-bg-elev p-4", className)}
-    >
-      <div className="text-[13px] font-medium text-text-2">{label}</div>
-      <div className="mt-1 flex items-end justify-between gap-3">
-        <span className="text-2xl font-semibold tabular-nums text-text">
-          {format(shown)}
-        </span>
-        {sparkline && sparkline.length > 1 ? (
-          <Sparkline series={sparkline} positive={positive} />
-        ) : null}
-      </div>
-      {delta !== undefined ? (
-        <span
-          data-testid="stat-delta"
-          className={cn(
-            "mt-2 inline-flex items-center gap-0.5 rounded border px-1.5 py-0 text-[11px] font-medium tabular-nums",
-            positive
-              ? "border-income/40 bg-income/10 text-income"
-              : "border-expense/40 bg-expense/10 text-expense",
-          )}
-        >
-          {positive ? (
-            <ArrowUpRight aria-hidden className="h-3 w-3" />
+    <div className={cn(card, className)}>
+      <div className="text-[13px] leading-4 text-text-2">{label}</div>
+      {/* Figma value: Display/32 Bold. */}
+      <span className="text-[32px] font-bold leading-[38px] tracking-[-0.01em] tabular-nums text-text">
+        {format(shown)}
+      </span>
+      {delta !== undefined || (sparkline && sparkline.length > 1) ? (
+        <div className="flex w-full items-center justify-between gap-3">
+          {delta !== undefined ? (
+            <span
+              data-testid="stat-delta"
+              className={cn(
+                // Figma delta pill: 12% tint, no border, Table/13 Medium.
+                "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5",
+                "text-[13px] font-medium leading-4 tabular-nums",
+                positive
+                  ? "bg-income/[0.12] text-income"
+                  : "bg-expense/[0.12] text-expense",
+              )}
+            >
+              {positive ? (
+                <TrendingUp aria-hidden className="h-3 w-3" />
+              ) : (
+                <TrendingDown aria-hidden className="h-3 w-3" />
+              )}
+              {positive ? "+" : "−"}
+              {Math.abs(delta * 100).toFixed(1)}%
+              {deltaCaption ? <span>{deltaCaption}</span> : null}
+            </span>
           ) : (
-            <ArrowDownRight aria-hidden className="h-3 w-3" />
+            <span />
           )}
-          {positive ? "+" : "−"}
-          {Math.abs(delta * 100).toFixed(1)}%
-        </span>
+          {sparkline && sparkline.length > 1 ? (
+            <Sparkline series={sparkline} positive={positive} />
+          ) : null}
+        </div>
       ) : null}
     </div>
   );

--- a/web/src/components/ui/Tag.tsx
+++ b/web/src/components/ui/Tag.tsx
@@ -17,13 +17,14 @@ export interface TagProps {
   children?: React.ReactNode;
 }
 
+// Figma Tag (node 118:1053): borderless pill, 12% tint fill + tint text.
 const TINT_CLASSES: Record<TagTint, string> = {
-  neutral: "border-border bg-bg-elev text-text-2",
-  info: "border-info/40 bg-info/10 text-info",
-  warn: "border-warn/40 bg-warn/10 text-warn",
-  error: "border-expense/40 bg-expense/10 text-expense",
-  success: "border-income/40 bg-income/10 text-income",
-  "new-accent": "border-accent/40 bg-accent/10 text-accent",
+  neutral: "bg-bg-elev text-text-2",
+  info: "bg-info/[0.12] text-info",
+  warn: "bg-warn/[0.12] text-warn",
+  error: "bg-expense/[0.12] text-expense",
+  success: "bg-income/[0.12] text-income",
+  "new-accent": "bg-accent/[0.12] text-accent",
 };
 
 export const Tag: React.FC<TagProps> = ({
@@ -35,9 +36,11 @@ export const Tag: React.FC<TagProps> = ({
   <span
     data-tint={tint}
     className={cn(
-      "inline-flex items-center rounded border font-medium tabular-nums",
+      "inline-flex items-center rounded-full font-medium tabular-nums",
       TINT_CLASSES[tint],
-      size === "sm" ? "px-1.5 py-0 text-[11px]" : "px-2 py-0.5 text-[13px]",
+      size === "sm"
+        ? "px-1.5 py-px text-[11px] leading-4"
+        : "px-2 py-[3px] text-[13px] leading-4",
     )}
   >
     {count !== undefined ? (count > 9 ? "9+" : count) : children}

--- a/web/src/components/ui/TaxCalendarRow.test.tsx
+++ b/web/src/components/ui/TaxCalendarRow.test.tsx
@@ -22,26 +22,31 @@ describe("TaxCalendarRow (design.md §8.2, MI-13)", () => {
     expect(thresholdFor(0)).toBe("t-1");
   });
 
-  it("renders kind, period, authority, due date", () => {
+  it("renders kind · period and the Figma due date", () => {
     render(<TaxCalendarRow entry={entry} daysToDue={60} />);
-    expect(screen.getByText("vat")).toBeInTheDocument();
-    expect(screen.getByText("2026-06")).toBeInTheDocument();
-    expect(
-      screen.getByText("Federal Inland Revenue Service"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("due 2026-07-21")).toBeInTheDocument();
+    expect(screen.getByText("VAT")).toBeInTheDocument();
+    expect(screen.getByText(/· 2026-06/)).toBeInTheDocument();
+    // Figma: "Due 21 Jul 2026"; authority carried on the row title.
+    expect(screen.getByText("Due 21 Jul 2026")).toBeInTheDocument();
+    expect(screen.getByRole("row")).toHaveAttribute(
+      "title",
+      "Federal Inland Revenue Service",
+    );
     expect(screen.getByRole("row")).toHaveAttribute("data-threshold", "none");
   });
 
-  it("tints escalate info → warn → expense", () => {
+  it("tints escalate info → warn → warn-stronger (Figma MI-13)", () => {
     const { rerender } = render(
       <TaxCalendarRow entry={entry} daysToDue={20} />,
     );
-    expect(screen.getByRole("row")).toHaveClass("bg-info/10");
+    expect(screen.getByRole("row")).toHaveClass("bg-info/[0.08]");
+    expect(screen.getByText("Due in 30 days")).toBeInTheDocument();
     rerender(<TaxCalendarRow entry={entry} daysToDue={5} />);
-    expect(screen.getByRole("row")).toHaveClass("bg-warn/10");
+    expect(screen.getByRole("row")).toHaveClass("bg-warn/[0.08]");
+    expect(screen.getByText("Due in 7 days")).toBeInTheDocument();
     rerender(<TaxCalendarRow entry={entry} daysToDue={1} />);
-    expect(screen.getByRole("row")).toHaveClass("bg-expense/10");
-    expect(screen.getByText("t-1")).toBeInTheDocument();
+    // T-1 stays warn (stronger), never expense.
+    expect(screen.getByRole("row")).toHaveClass("bg-warn/[0.12]");
+    expect(screen.getByText("Due tomorrow")).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/TaxCalendarRow.tsx
+++ b/web/src/components/ui/TaxCalendarRow.tsx
@@ -1,9 +1,13 @@
 /**
- * TaxCalendarRow — design.md §8.2 (MI-13 data source): tax kind + period +
- * due date + T-30/T-7/T-1 escalation tint (info → warn).
+ * TaxCalendarRow — design.md §8.2 (MI-13 data source), Figma Stage 2b:
+ * calendar icon + "KIND · period" + right-aligned "Due …" date + an
+ * escalation chip ("Due in 30 days" info → "Due in 7 days" warn → "Due
+ * tomorrow" warn, stronger). Row surface tints with the threshold.
  */
 
 import React from "react";
+import { Calendar } from "lucide-react";
+import dayjs from "dayjs";
 import type { TaxCalendarEntry } from "@/models";
 import { cn } from "@/lib/cn";
 
@@ -17,11 +21,29 @@ export const thresholdFor = (daysToDue: number): DeadlineThreshold => {
   return "none";
 };
 
-const THRESHOLD_CLASSES: Record<DeadlineThreshold, string> = {
-  none: "",
-  "t-30": "border-info/40 bg-info/10",
-  "t-7": "border-warn/40 bg-warn/10",
-  "t-1": "border-expense/40 bg-expense/10",
+// Figma escalation: info tint → warn tint → warn, stronger (T-1 stays
+// warn, not expense).
+const ROW_CLASSES: Record<DeadlineThreshold, string> = {
+  none: "border-border bg-bg",
+  "t-30": "border-info/35 bg-info/[0.08]",
+  "t-7": "border-warn/35 bg-warn/[0.08]",
+  "t-1": "border-warn/50 bg-warn/[0.12]",
+};
+
+const ICON_CLASSES: Record<DeadlineThreshold, string> = {
+  none: "text-text-2",
+  "t-30": "text-info",
+  "t-7": "text-warn",
+  "t-1": "text-warn",
+};
+
+const CHIP_META: Record<
+  Exclude<DeadlineThreshold, "none">,
+  { label: string; className: string }
+> = {
+  "t-30": { label: "Due in 30 days", className: "bg-info/[0.12] text-info" },
+  "t-7": { label: "Due in 7 days", className: "bg-warn/[0.12] text-warn" },
+  "t-1": { label: "Due tomorrow", className: "bg-warn/[0.2] text-warn" },
 };
 
 export interface TaxCalendarRowProps {
@@ -37,34 +59,37 @@ export const TaxCalendarRow: React.FC<TaxCalendarRowProps> = ({
   className,
 }) => {
   const threshold = thresholdFor(daysToDue);
+  const due = dayjs(entry.due_date).isValid()
+    ? dayjs(entry.due_date).format("D MMM YYYY")
+    : entry.due_date;
   return (
     <div
       role="row"
       data-threshold={threshold}
+      title={entry.authority.name}
       className={cn(
-        "flex items-center gap-3 rounded border border-border px-3 py-2 text-[13px] text-text",
-        THRESHOLD_CLASSES[threshold],
+        "flex items-center gap-2.5 rounded border px-3 py-2 text-[13px] text-text",
+        ROW_CLASSES[threshold],
         className,
       )}
     >
-      <span className="w-10 shrink-0 font-medium uppercase">{entry.kind}</span>
-      <span className="w-24 shrink-0 tabular-nums text-text-2">
-        {entry.period}
+      <Calendar
+        aria-hidden
+        className={cn("h-4 w-4 shrink-0", ICON_CLASSES[threshold])}
+      />
+      <span className="min-w-0 flex-1 truncate font-medium">
+        {entry.kind.toUpperCase()}
+        <span className="font-normal text-text-2"> · {entry.period}</span>
       </span>
-      <span className="min-w-0 flex-1 truncate text-text-2">
-        {entry.authority.name}
-      </span>
-      <span className="tabular-nums">due {entry.due_date}</span>
+      <span className="tabular-nums text-text-2">Due {due}</span>
       {threshold !== "none" ? (
         <span
           className={cn(
-            "rounded border px-1.5 text-[11px] font-medium uppercase",
-            threshold === "t-30" && "border-info/40 text-info",
-            threshold === "t-7" && "border-warn/40 text-warn",
-            threshold === "t-1" && "border-expense/40 text-expense",
+            "rounded-full px-1.5 py-0.5 text-[11px] font-medium leading-4",
+            CHIP_META[threshold].className,
           )}
         >
-          {threshold}
+          {CHIP_META[threshold].label}
         </span>
       ) : null}
     </div>

--- a/web/src/components/ui/Toast.test.tsx
+++ b/web/src/components/ui/Toast.test.tsx
@@ -28,4 +28,15 @@ describe("Toast (design.md §8.2)", () => {
     render(<Toast>Copied</Toast>);
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
+
+  it("carries the Figma inline action slot", () => {
+    render(
+      <Toast kind="info" action={<button>Download</button>}>
+        Report ready
+      </Toast>,
+    );
+    expect(
+      screen.getByRole("button", { name: "Download" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { CircleAlert, Info, TriangleAlert, X } from "lucide-react";
+import { Check, TriangleAlert, X } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 export type ToastKind = "info" | "warn" | "error";
@@ -13,21 +13,26 @@ export type ToastKind = "info" | "warn" | "error";
 export interface ToastProps {
   kind?: ToastKind;
   children: React.ReactNode;
+  /** Inline action label ("Download", "Retry") — accent, 13 medium. */
+  action?: React.ReactNode;
   onDismiss?: () => void;
 }
 
+// Figma Toast (node 58:72): info = check, warn = alert-triangle,
+// error = x, each in the kind color on a plain elevated card.
 const KIND_META: Record<
   ToastKind,
   { Icon: React.ComponentType<{ className?: string }>; tint: string }
 > = {
-  info: { Icon: Info, tint: "text-info" },
+  info: { Icon: Check, tint: "text-info" },
   warn: { Icon: TriangleAlert, tint: "text-warn" },
-  error: { Icon: CircleAlert, tint: "text-expense" },
+  error: { Icon: X, tint: "text-expense" },
 };
 
 export const Toast: React.FC<ToastProps> = ({
   kind = "info",
   children,
+  action,
   onDismiss,
 }) => {
   const { Icon, tint } = KIND_META[kind];
@@ -35,10 +40,17 @@ export const Toast: React.FC<ToastProps> = ({
     <div
       role="status"
       data-kind={kind}
-      className="flex w-80 items-start gap-2 rounded border border-border bg-bg p-3 shadow-lg"
+      className="flex w-[400px] max-w-full items-center gap-2.5 rounded border border-border bg-bg p-3 shadow-[0px_8px_12px_0px_rgba(0,0,0,0.16)]"
     >
-      <Icon aria-hidden className={cn("mt-0.5 h-4 w-4 shrink-0", tint)} />
-      <div className="flex-1 text-[13px] text-text">{children}</div>
+      <Icon aria-hidden className={cn("h-4 w-4 shrink-0", tint)} />
+      <div className="flex-1 text-sm font-medium leading-5 text-text">
+        {children}
+      </div>
+      {action ? (
+        <div className="shrink-0 text-[13px] font-medium leading-4 text-accent">
+          {action}
+        </div>
+      ) : null}
       {onDismiss ? (
         <button
           type="button"

--- a/web/src/components/ui/Tooltip.tsx
+++ b/web/src/components/ui/Tooltip.tsx
@@ -30,7 +30,8 @@ export const Tooltip: React.FC<TooltipProps> = ({
           side={placement}
           sideOffset={6}
           className={cn(
-            "z-dropdown max-w-xs rounded border border-border bg-bg-elev px-2.5 py-1.5 text-text shadow-lg",
+            // font-sans: portals mount under <body> (legacy Poppins).
+            "z-dropdown max-w-xs rounded border border-border bg-bg-elev px-2.5 py-1.5 font-sans text-text shadow-lg",
             kind === "formula" ? "font-mono text-[12px]" : "text-[13px]",
           )}
         >

--- a/web/src/components/ui/TxnTableRow.test.tsx
+++ b/web/src/components/ui/TxnTableRow.test.tsx
@@ -27,7 +27,8 @@ const category = { id: "cat-1", name: "Transport", color: "#2456D6" };
 describe("TxnTableRow (design.md §8.2, MI-6)", () => {
   it("renders date, description, chip, money, anomaly, and source", () => {
     render(<TxnTableRow txn={txn} category={category} />);
-    expect(screen.getByText("2026-06-14")).toBeInTheDocument();
+    // Figma date column: short date ("14 Jun"), single line.
+    expect(screen.getByText("14 Jun")).toBeInTheDocument();
     expect(screen.getByText("Fuel — Lekki toll")).toBeInTheDocument();
     expect(screen.getByText("Transport")).toBeInTheDocument();
     expect(screen.getByText("−₦18,000.00")).toBeInTheDocument();
@@ -65,7 +66,9 @@ describe("TxnTableRow (design.md §8.2, MI-6)", () => {
       "data-state",
       "staged-duplicate",
     );
-    expect(screen.getByText("duplicate")).toBeInTheDocument();
+    // Figma staged-duplicate: warn-tinted row + inline Duplicate pill.
+    expect(screen.getByRole("row")).toHaveClass("bg-warn/[0.08]");
+    expect(screen.getByText("Duplicate")).toBeInTheDocument();
   });
 
   it("keyboard: Enter opens, `e` edits (design.md §5)", async () => {

--- a/web/src/components/ui/TxnTableRow.tsx
+++ b/web/src/components/ui/TxnTableRow.tsx
@@ -17,6 +17,7 @@ import {
   Pencil,
   Split,
 } from "lucide-react";
+import dayjs from "dayjs";
 import type { TxnEntry, TxnSource } from "@/models";
 import { cn } from "@/lib/cn";
 import AnomalyBadge from "./AnomalyBadge";
@@ -94,24 +95,40 @@ export const TxnTableRow: React.FC<TxnTableRowProps> = ({
         "transition-colors duration-[60ms] ease-standard",
         density === "compact" ? "h-[32px]" : "h-[44px]",
         "hover:bg-bg-elev focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent",
-        selected && "bg-accent/5",
-        stagedDuplicate && "opacity-60",
+        // Figma: selected = accent tint row; staged-duplicate = warn tint.
+        selected && "bg-accent/[0.08]",
+        stagedDuplicate && "bg-warn/[0.08]",
       )}
     >
-      {onSelectedChange ? (
-        <Checkbox
-          checked={selected}
-          onCheckedChange={(next) => onSelectedChange(next === true)}
-        />
-      ) : null}
-      <span className="w-20 shrink-0 tabular-nums text-text-2">
-        {txn.txn_date}
+      <Checkbox
+        checked={selected}
+        onCheckedChange={
+          onSelectedChange
+            ? (next) => onSelectedChange(next === true)
+            : undefined
+        }
+      />
+      {/* Figma date column: short date, Table/13, text-2 (e.g. "12 Jan"). */}
+      <span className="w-14 shrink-0 whitespace-nowrap tabular-nums text-text-2">
+        {dayjs(txn.txn_date).isValid()
+          ? dayjs(txn.txn_date).format("D MMM")
+          : txn.txn_date}
       </span>
+      {/* Figma: source icon sits between date and description. */}
+      <SourceIcon
+        aria-label={sourceLabel}
+        className="h-3.5 w-3.5 shrink-0 text-text-2"
+      />
       <span className="min-w-0 flex-1 truncate">{txn.description}</span>
       {stagedDuplicate ? (
-        <span className="rounded border border-warn/40 bg-warn/10 px-1.5 text-[11px] font-medium text-warn">
-          duplicate
-        </span>
+        // Figma staged-duplicate: the inline Duplicate anomaly pill.
+        <AnomalyBadge type="duplicate_charge" severity="info" />
+      ) : anomaly ? (
+        <AnomalyBadge
+          type={anomaly.rule_id}
+          severity={anomaly.severity}
+          variant="inline"
+        />
       ) : null}
       <CategoryChip
         category={category}
@@ -126,25 +143,13 @@ export const TxnTableRow: React.FC<TxnTableRowProps> = ({
           withIcon={false}
         />
       </span>
-      <span className="w-6 shrink-0">
-        {anomaly ? (
-          <AnomalyBadge
-            type={anomaly.rule_id}
-            severity={anomaly.severity}
-            variant="inline"
-          />
-        ) : null}
-      </span>
-      <SourceIcon
-        aria-label={sourceLabel}
-        className="h-3.5 w-3.5 shrink-0 text-text-2"
-      />
 
       {/* MI-6: absolutely positioned actions — hover reveal, no layout shift. */}
       <span
         data-testid="row-actions"
         className={cn(
-          "absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1 rounded border border-border bg-bg px-1 py-0.5 shadow-sm",
+          // Figma hover: bare icons over the row's hover surface.
+          "absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1 bg-bg-elev pl-2",
           "opacity-0 transition-opacity duration-[60ms] ease-standard",
           "group-hover:opacity-100 group-focus-within:opacity-100",
         )}

--- a/web/src/components/ui/UploadDropzone.tsx
+++ b/web/src/components/ui/UploadDropzone.tsx
@@ -86,7 +86,15 @@ const FileStateIndicator: React.FC<{ state: UploadFileState }> = ({
 }) => {
   switch (state.phase) {
     case "progress":
-      return <ProgressRing percent={state.percent} />;
+      // Figma: ring + percent readout ("64%").
+      return (
+        <span className="flex items-center gap-1.5">
+          <ProgressRing percent={state.percent} />
+          <span className="text-[13px] leading-4 tabular-nums text-text-2">
+            {Math.round(state.percent)}%
+          </span>
+        </span>
+      );
     case "ai-sweep":
       // MI-2: ring morphs to an indeterminate AI-sparkle sweep on parse.
       return (
@@ -150,8 +158,9 @@ export const UploadDropzone: React.FC<UploadDropzoneProps> = ({
         )}
       >
         <Upload aria-hidden className="h-5 w-5 text-text-2" />
-        <p className="text-sm text-text">
-          Drag a statement here, or{" "}
+        {/* Figma idle copy (node 63:207). */}
+        <p className="text-sm font-medium text-text">
+          Drop statements here or{" "}
           <button
             type="button"
             disabled={disabled}
@@ -161,10 +170,8 @@ export const UploadDropzone: React.FC<UploadDropzoneProps> = ({
             browse
           </button>
         </p>
-        <p className="flex items-center gap-2 text-[11px] text-text-2">
-          <FileSpreadsheet aria-hidden className="h-3.5 w-3.5" /> CSV
-          <FileText aria-hidden className="h-3.5 w-3.5" /> PDF
-          <ImageIcon aria-hidden className="h-3.5 w-3.5" /> Receipt image
+        <p className="text-[13px] leading-4 text-text-2">
+          CSV, PDF, or receipt images · up to 20 MB
         </p>
         <input
           ref={inputRef}

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -6,23 +6,32 @@ import type { Config } from "tailwindcss";
  * raw hex. Legacy color names (secondary/purpleTheme/grayTheme) remain
  * only for the pre-redesign pages still live outside src/legacy/.
  */
+/**
+ * Token colors support Tailwind alpha modifiers (bg-info/10, border-warn/40)
+ * via color-mix — a plain var() string silently drops the modifier, which
+ * left every Figma tint surface transparent. <alpha-value> resolves to 1
+ * when no modifier is given, so solid usage is unchanged.
+ */
+const token = (name: string) =>
+  `color-mix(in srgb, var(--color-${name}) calc(<alpha-value> * 100%), transparent)`;
+
 const config: Config = {
   content: ["./src/**/*.{html,js,jsx,ts,tsx}"],
   theme: {
     extend: {
       colors: {
-        bg: "var(--color-bg)",
-        "bg-editorial": "var(--color-bg-editorial)",
-        "bg-elev": "var(--color-bg-elev)",
-        border: "var(--color-border)",
-        text: "var(--color-text)",
-        "text-2": "var(--color-text-2)",
-        accent: "var(--color-accent)",
-        "on-accent": "var(--color-on-accent)",
-        income: "var(--color-income)",
-        expense: "var(--color-expense)",
-        warn: "var(--color-warn)",
-        info: "var(--color-info)",
+        bg: token("bg"),
+        "bg-editorial": token("bg-editorial"),
+        "bg-elev": token("bg-elev"),
+        border: token("border"),
+        text: token("text"),
+        "text-2": token("text-2"),
+        accent: token("accent"),
+        "on-accent": token("on-accent"),
+        income: token("income"),
+        expense: token("expense"),
+        warn: token("warn"),
+        info: token("info"),
         // Legacy palette (MUI-era pages; retired with them at W3).
         secondary: "#121212",
         purpleTheme: "#A259FF",


### PR DESCRIPTION
Audit → fix → verify loop over the `/dev/components` gallery vs the Figma Components page (`P2lGfKFLJPS9k9kTKlii1n`: Stage 0 `51:4`, Stage 1 Atoms `51:5`, Stage 2 Molecules `51:6`, Stage 2b Financial Kit `93:561`, Stage 3 App Chrome `111:740`, Stage 3b Rows/Charts/Marketing `111:741`), both themes, element screenshots via playwright vs `get_screenshot` frames.

## Systemic finds

| Find | Impact | Fix |
| --- | --- | --- |
| Tailwind token colors were plain `var()` strings, so **every alpha modifier (`bg-info/10`, `border-warn/35`, `stroke-income/45`) emitted no CSS** | All tint surfaces in the kit rendered transparent (Banner fills, badge tints, active nav, selected rows, gauge band…) | `color-mix(in srgb, var(--color-*) calc(<alpha-value> * 100%), transparent)` in `tailwind.config.ts` — solid usage unchanged |
| UA button chrome centers text (no preflight reset) | Nav items / row buttons rendered centered labels | `@layer base { button { text-align: inherit } }` + explicit `text-left` where the kit is left-aligned |
| Legacy unlayered `body { font-family: Poppins }` bleeds into **portaled** surfaces (cross-product finding from the upstat sibling) | Modal/Tooltip content rendered in Poppins | `font-sans` on portal roots; verified live — dialog computes Inter; MUI/emotion injects nothing on the gallery route (0 `data-emotion` styles) |
| Duplicate React keys (`key={link.href}` with repeated `#`) | Console errors + dev-overlay badge on the gallery | Key by label in MarketingNav/MarketingFooter |

## Per-component fidelity fixes

- **Button** — quiet borderless; 36/28px; danger-armed = ⚠ icon + `Ns` countdown pill (was `(N)` text); loading keeps full fill; spinner currentColor (visible on quiet)
- **Input** — 36px; disabled 40% on white (was grey fill); `kbdHint` (`⌘K`) slot, hidden on focus/filled
- **MoneyCell** — sign-only (kit shows no arrows; icons now opt-in); Table/13 Medium; stat = Display/32 Bold, tnum
- **CategoryChip** — pill, 13 Medium; editing = in-cell combobox input (2px accent) + 180px menu with accent check
- **AnomalyBadge** — tint by *type* (spike=expense, unusual category=info, large txn/duplicate=warn); inline pill w/ short labels; feed = card w/ 32px icon well, description, timestamp
- **Toast** — check/triangle/x icons; Body/14 Medium; accent action slot (Download/Retry); kit shadow
- **Banner** — 10% tint + 35% edge; body-colored message; sparkles/calendar/landmark icons; expense action on error
- **StatCard** — white card; Display/32 value; tinted trending-delta pill + `vs Jun` caption; delta+sparkline meta row; loading keeps label
- **TxnTableRow** — checkbox column always on; short date (`14 Jun`, fixes 2-line wrap); source icon after date; duplicate/anomaly pill before chip; accent/warn row tints (opacity-60 removed); hover actions as bare icons
- **UploadDropzone** — kit copy (`Drop statements here or browse`, `CSV, PDF, or receipt images · up to 20 MB`); percent readout beside the ring
- **LinkAccountCard** — white card; status pill top-right (**reauth = warn**, was expense); 32px icon well; per-status captions (`Waiting for Mono consent`, `Last synced … · n transactions`, …)
- **RatioGauge** — exact kit geometry (182×100, r=70/12px arcs, band r=81/3px @45% income); **needle removed** (arc eases 600ms, MI-8); value in text color Display/32; delta line (`+0.21 vs Q1`); benchmark/formula caption; n/a dash
- **EmptyState** — solid hairline card; title + hint copy per kit; sm CTA; `Preview with demo data` + tinted ✨ `synthetic` pill
- **TaxCalendarRow** — calendar icon; `VAT · 2026-06`; `Due 21 Jul 2026`; chips `Due in 30 days`/`Due in 7 days`/`Due tomorrow`; **T-1 stays warn** (was expense)
- **RemitToCard** — icon well; kit titles (`Companies Income Tax + Development Levy`); `Amount due` + Display/32; due line w/ optional T-x chip; single `Pay via A / B` chip
- **Tag** — borderless 12%-tint pills, both sizes
- **Select** — 36/28px; single chevron; accent border while open; disabled 40%
- **PeriodPicker** — 32px trigger; humanized display (`Q2 2026`, `Jun 2026`, `1 Apr – 30 Jun 2026`) over the grammar value
- **AppNav/NavItem** — left-aligned labels; active tint now visible; warn count pill
- **OrgSwitcher** — bordered trigger (accent when open); tinted org tiles (accent initials / info building); selected-row state; `Create organization` row
- **Avatar** — initials disc = 15% accent tint + accent text
- **ImportJobRow** — kit structure: title + caption line (`209 transactions · 5 duplicates · 1 anomalies found`), status Tags (Processing/Completed/Empty/Failed), timestamp
- **FilingHistoryRow** — stamped-✓ left; `PIT · FY2026` + `LIRS · TaxPro-Max · Filed 15 Jan 2027` caption; amount + `Receipt` download; draft = neutral tag
- **Skeleton** — stat variant value-bar-first (matches StatCard loading)

## Intentional adaptations (not divergences)

- Focus = 2px accent **ring** with offset (Figma draws focus as a border swap) — web a11y convention
- `Select searchable` keeps its menu-anchored search input (kit types into the trigger); behavior-equivalent
- UploadDropzone models ai-sweep/complete/error **per-file** (MI-2 as-built note); kit draws them zone-level
- PeriodPicker custom-range calendar popover is not built at W1 (text entry + presets); kit shows a calendar grid
- ChartLine series colors stay prop-bound to income/expense/accent tokens (kit sample shows a single accent series)
- Relative timestamps (`2h ago`) render as short dates until a shared relative-time util lands

## Verification

- Gallery re-captured light+dark after each fix; tints/geometry now match frame-for-frame
- Live checks: portal font = Inter, 0 console errors, 0 emotion styles on the gallery route
- `npm run lint` 0 errors · `typecheck` clean · **271 vitest + 2 jest tests pass** (tests updated where the kit legitimately changed contracts) · `next build` green

Do not merge — QA loop review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)