### PR TITLE
feat(web): W2 home — landing from component registry

### DIFF
--- a/web/__tests__/index.test.tsx
+++ b/web/__tests__/index.test.tsx
@@ -17,10 +17,16 @@ jest.mock("next/navigation", () => ({
 }));
 
 describe("HomePage", () => {
-  it("renders the landing page hero", () => {
+  // W2: `/` is the Part A Brex-editorial home (pages.md); the legacy
+  // marketing sections await their W3 quarantine tranche.
+  it("renders the Part A hero", () => {
     render(<Home />);
 
-    const hero = screen.getByTestId("hero-section");
-    expect(hero).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "See every naira. File every tax.",
+      }),
+    ).toBeInTheDocument();
   });
 });

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * W2 — "Marketing site" journey (design.md §8.4): the Part A scroll page
+ * renders every section, the A5 persona tabs switch the demo datasets,
+ * the FAQ opens one item at a time, and the CTAs hand off cross-page
+ * into /signin. Runs in TEST_MODE (no network beyond the app).
+ */
+
+test.describe("public home `/` (Part A)", () => {
+  test("all Part A sections render", async ({ page }) => {
+    await page.goto("/");
+
+    // A2 hero
+    await expect(
+      page.getByRole("heading", { name: "See every naira. File every tax." }),
+    ).toBeVisible();
+    // A3 logos strip
+    await expect(page.getByText("Moniepoint")).toBeVisible();
+    // A4 pillars + A4a deep-dives
+    await expect(
+      page.getByText("One ledger. Three superpowers."),
+    ).toBeVisible();
+    await expect(page.getByText("Every statement, one pipeline")).toBeVisible();
+    // A5 demo + badge + A5a how-it-works
+    await expect(page.getByText("Explore the live demo")).toBeVisible();
+    await expect(page.getByText("This is demo data")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "How it works" }),
+    ).toBeVisible();
+    // A6 AI disclosure + A7 security
+    await expect(page.getByText("AI that shows its work")).toBeVisible();
+    await expect(
+      page.getByText("Security & privacy, in plain language"),
+    ).toBeVisible();
+    // A8 contribute (+ arch diagram) + A8a self-host snippet
+    await expect(
+      page.getByText("For developers — come build the hard parts"),
+    ).toBeVisible();
+    await expect(page.getByText("api · Go/Gin")).toBeVisible();
+    await expect(
+      page.getByText("Self-host: your books never leave your building"),
+    ).toBeVisible();
+    // A9 community + A10 comparison + caption
+    await expect(
+      page.getByRole("heading", { name: "Community", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Cloud or self-host — same product"),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Announced at GA", { exact: true }),
+    ).toBeVisible();
+    // A10a FAQ + A10b final CTA + A11 footer
+    await expect(page.getByText("Questions, answered")).toBeVisible();
+    await expect(
+      page.getByText("Your numbers are ready to talk."),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByRole("contentinfo")
+        .getByRole("link", { name: "View Security Policy" }),
+    ).toBeVisible();
+  });
+
+  test("A5: persona tabs switch the demo dataset", async ({ page }) => {
+    await page.goto("/");
+    // Scope to the A5 section — the A5a thumbs reuse the same demo pool.
+    const demo = page.locator("#demo");
+    // Freelancer boots (Figma A5 strip verbatim).
+    await expect(demo.getByText("₦1,480,000.00")).toBeVisible();
+    await expect(demo.getByText("MTN — data bundle top-up")).toBeVisible();
+
+    await demo.getByRole("tab", { name: "SME" }).click();
+    await expect(demo.getByText("₦4,150,000.00")).toBeVisible();
+    await expect(demo.getByText("Retainer — Halcyon Studios")).toBeVisible();
+
+    await demo.getByRole("tab", { name: "Company" }).click();
+    await expect(demo.getByText("₦8,435,200.00")).toBeVisible();
+    await expect(demo.getByText("Retainer — Kudaworks")).toBeVisible();
+    await expect(demo.getByText("MTN — data bundle top-up")).toHaveCount(0);
+
+    // demo_interact landed on the analytics queue (TEST_MODE seam).
+    const events = await page.evaluate(() =>
+      (
+        window as unknown as { __expenditEvents?: { event: string }[] }
+      ).__expenditEvents?.map((record) => record.event),
+    );
+    expect(events).toContain("page_view");
+    expect(events).toContain("demo_interact");
+  });
+
+  test("A10a: FAQ toggles, one item open at a time", async ({ page }) => {
+    await page.goto("/");
+    const first = page.getByRole("button", {
+      name: "Is it safe to connect my bank?",
+    });
+    // Default-open answer (Figma).
+    await expect(
+      page.getByText(/Bank sign-in happens inside Mono/),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "What’s the license?" }).click();
+    await expect(page.getByText(/MIT\. Cloud and self-host/)).toBeVisible();
+    await expect(
+      page.getByText(/Bank sign-in happens inside Mono/),
+    ).toBeHidden();
+    await expect(first).toHaveAttribute("aria-expanded", "false");
+
+    const events = await page.evaluate(() =>
+      (
+        window as unknown as { __expenditEvents?: { event: string }[] }
+      ).__expenditEvents?.map((record) => record.event),
+    );
+    expect(events).toContain("faq_open");
+  });
+
+  test("CTAs hand off into /signin (hero + nav + final CTA)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    // Hero Try Cloud (the A2 CTA — second Try Cloud on the page).
+    await page.getByRole("button", { name: "Try Cloud" }).nth(1).click();
+    await page.waitForURL("**/signin");
+    await expect(
+      page.getByRole("button", { name: "Continue with Google" }),
+    ).toBeVisible();
+
+    // Final CTA band re-emits the A2 handoff.
+    await page.goto("/");
+    await page.getByRole("button", { name: "Try Cloud" }).last().click();
+    await page.waitForURL("**/signin");
+
+    // Nav Sign in.
+    await page.goto("/");
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await page.waitForURL("**/signin");
+  });
+
+  test("A2: Self Host CTA scrolls to the A8a section", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Self Host" }).first().click();
+    await expect(page.locator("#self-host")).toBeInViewport();
+  });
+
+  test("renders at 375w (responsive floor)", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: "See every naira. File every tax." }),
+    ).toBeVisible();
+    await expect(page.getByText("Explore the live demo")).toBeVisible();
+    // No horizontal overflow at the mobile floor.
+    const overflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth -
+        document.documentElement.clientWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+});

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -4,7 +4,12 @@ import { defineConfig, devices } from "@playwright/test";
  * Playwright e2e — TEST_MODE journeys against the in-app mock server
  * (design.md §8.4 prototype journeys; W0 ships the signin → dashboard
  * smoke). CI builds first, then runs against `next start`.
+ *
+ * PW_PORT overrides the dev-server port (default 3100) so local runs can
+ * dodge port collisions with sibling projects; CI stays on the default.
  */
+const PORT = process.env.PW_PORT ?? "3100";
+
 export default defineConfig({
   testDir: "./e2e",
   timeout: 60_000,
@@ -12,15 +17,15 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? "github" : "list",
   use: {
-    baseURL: "http://localhost:3100",
+    baseURL: `http://localhost:${PORT}`,
     trace: "on-first-retry",
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   webServer: {
     command: process.env.CI
-      ? "npm run start -- -p 3100"
-      : "npm run dev -- -p 3100",
-    port: 3100,
+      ? `npm run start -- -p ${PORT}`
+      : `npm run dev -- -p ${PORT}`,
+    port: Number(PORT),
     reuseExistingServer: !process.env.CI,
     env: {
       NEXT_PUBLIC_TEST_MODE: "1",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,26 +1,35 @@
-"use client";
+import React from "react";
+import type { Metadata } from "next";
+import HomeView from "@/components/landing/HomeView";
 
-import { Fragment } from "react";
-import HowItWorks from "@/components/marketing/how-it-works-section/HowItWorksSection";
-import HeroSection from "@/components/marketing/hero-section/HeroSection";
-import FeaturesSection from "@/components/marketing/features-section/FeaturesSection";
-import CTASection from "@/components/marketing/cta-section/CtaSection";
-import Contact from "@/components/marketing/contact-section/ContactSection";
-import Services from "@/components/marketing/service-section/ServiceSection";
-import OpenSourceSection from "@/components/marketing/open-source-section/OpenSourceSection";
-import Footer from "@/components/marketing/footer/Footer";
+/**
+ * `/` — public home (pages.md Part A, Brex-editorial; W2). The legacy
+ * marketing page's section components remain under
+ * src/components/marketing/ until their W3 quarantine tranche.
+ */
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://expendit.cuesoft.io"),
+  title: "Expendit — See every naira. File every tax.",
+  description:
+    "Open-source financial intelligence for Nigerian freelancers, SMEs and companies: upload statements or link your bank, AI categorizes and flags what's off, then see your P&L, ratios and filing-ready taxes. MIT licensed — self-host with one command.",
+  openGraph: {
+    title: "Expendit — See every naira. File every tax.",
+    description:
+      "Upload statements or link your bank — AI categorizes every transaction and flags what's off. Then see your P&L, your ratios, and exactly which tax to pay — and where to remit it.",
+    url: "https://expendit.cuesoft.io",
+    siteName: "Expendit",
+    type: "website",
+    images: [{ url: "/logo.png" }],
+  },
+  twitter: {
+    card: "summary",
+    title: "Expendit — See every naira. File every tax.",
+    description:
+      "Open-source financial intelligence: statements → categorized ledger → ratios → filing-ready taxes. Free forever if you self-host.",
+  },
+};
 
 export default function Home() {
-  return (
-    <Fragment>
-      <HeroSection />
-      <Services />
-      <FeaturesSection />
-      <CTASection />
-      <HowItWorks />
-      <OpenSourceSection />
-      <Contact />
-      <Footer />
-    </Fragment>
-  );
+  return <HomeView />;
 }

--- a/web/src/components/landing/CompareFaqCta.tsx
+++ b/web/src/components/landing/CompareFaqCta.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+/**
+ * A10 — Cloud vs Self-host comparison · A10a — FAQ accordion (one open
+ * at a time, `faq_open` events) · A10b — final CTA band (re-emits the A2
+ * events). Pricing accuracy: the ComparisonTable price row + caption are
+ * the entire pricing story ("Announced at GA" / "Free forever",
+ * design.md §8.2b marketing-accuracy note).
+ */
+
+import React from "react";
+import Accordion from "@/components/ui/Accordion";
+import Button from "@/components/ui/Button";
+import ComparisonTable from "@/components/ui/ComparisonTable";
+import { useAnalyticsController } from "@/controllers/use-analytics";
+import { EditorialDark, SectionHeading, SectionInner } from "./Section";
+import { ANCHORS } from "./links";
+
+const COMPARISON_ROWS = [
+  {
+    feature: "AI categorization",
+    cloud: { kind: "check" as const },
+    selfHost: { kind: "check" as const },
+  },
+  {
+    feature: "Bank linking (Mono)",
+    cloud: { kind: "check" as const },
+    selfHost: { kind: "text" as const, text: "Bring your keys" },
+  },
+  {
+    feature: "Tax filing documents",
+    cloud: { kind: "check" as const },
+    selfHost: { kind: "check" as const },
+  },
+  {
+    feature: "Managed backups & SLA",
+    cloud: { kind: "check" as const },
+    selfHost: { kind: "x" as const },
+  },
+  {
+    feature: "Your infrastructure",
+    cloud: { kind: "x" as const },
+    selfHost: { kind: "check" as const },
+  },
+  {
+    feature: "Price",
+    cloud: { kind: "text" as const, text: "Announced at GA" },
+    selfHost: { kind: "text" as const, text: "Free forever" },
+  },
+];
+
+export const CompareSection: React.FC<{
+  onTryCloud: () => void;
+  onSelfHost: () => void;
+}> = ({ onTryCloud, onSelfHost }) => (
+  <section id={ANCHORS.compare} className="bg-bg py-20">
+    <SectionInner>
+      <SectionHeading>Cloud or self-host — same product</SectionHeading>
+      <div className="mx-auto mt-10 max-w-2xl">
+        <ComparisonTable
+          rows={COMPARISON_ROWS}
+          cloudCta={
+            <Button kind="primary" size="sm" onClick={onTryCloud}>
+              Try the sandbox
+            </Button>
+          }
+          selfHostCta={
+            <Button kind="quiet" size="sm" onClick={onSelfHost}>
+              Self Host
+            </Button>
+          }
+        />
+      </div>
+    </SectionInner>
+  </section>
+);
+
+/**
+ * FAQ content — Figma questions; answer 1 verbatim from the frame,
+ * answers 2–5 written to the pages.md A10a contract (consent-gated AI ·
+ * self-host completeness · v1 "filing-ready + guided handoff" · rights)
+ * and the marketing-accuracy standard.
+ */
+const FAQ_ITEMS = [
+  {
+    id: "bank-safety",
+    title: "Is it safe to connect my bank?",
+    content:
+      "Bank sign-in happens inside Mono’s hosted widget — your credentials never touch Expendit’s servers. Links are read-only, and you can pause or unlink any time.",
+  },
+  {
+    id: "ai-data",
+    title: "What does the AI actually see?",
+    content:
+      "Nothing until you consent: AI processing is gated on an explicit consent record, and the providers we use are disclosed in Settings → Data & privacy. Suggestions stay marked ✨ until a human confirms them — and if you self-host, you can run without AI entirely.",
+  },
+  {
+    id: "filing",
+    title: "Does Expendit file my taxes for me?",
+    content:
+      "In v1, Expendit computes PIT, CIT and VAT from your ledger and produces filing-ready documents — including a remittance sheet that names the authority (FIRS or your State IRS), the amount, the deadline and the payment channel — with a guided handoff. Direct e-filing comes later where authority APIs exist.",
+  },
+  {
+    id: "data-out",
+    title: "Can I take my data out?",
+    content:
+      "Yes. Export everything — reports, statements and a full account export — whenever you want. Delete-all is a first-class right: typed confirmation, a grace window, then a complete purge.",
+  },
+  {
+    id: "license",
+    title: "What’s the license?",
+    content:
+      "MIT. Cloud and self-host run the same open-source code — self-hosting is free forever.",
+  },
+];
+
+export const FaqSection: React.FC = () => {
+  const { track } = useAnalyticsController();
+  return (
+    <section id={ANCHORS.faq} className="bg-bg pb-24 pt-16">
+      <SectionInner>
+        <SectionHeading>Questions, answered</SectionHeading>
+        <div className="mx-auto mt-8 max-w-[720px]">
+          <Accordion
+            mode="single"
+            defaultOpen={["bank-safety"]}
+            onOpenChange={(openIds) => {
+              if (openIds[0]) track("faq_open", { question: openIds[0] });
+            }}
+            items={FAQ_ITEMS.map((item) => ({
+              id: item.id,
+              title: item.title,
+              content: <span className="text-text-2">{item.content}</span>,
+            }))}
+          />
+        </div>
+      </SectionInner>
+    </section>
+  );
+};
+
+export const FinalCtaSection: React.FC<{
+  onTryCloud: () => void;
+  onSelfHost: () => void;
+}> = ({ onTryCloud, onSelfHost }) => (
+  <EditorialDark className="py-24" motif>
+    <SectionInner className="text-center">
+      <h2 className="mx-auto max-w-3xl font-display text-4xl font-bold tracking-tight text-text md:text-5xl">
+        Your numbers are ready to talk.
+      </h2>
+      <p className="mt-5 text-sm text-text-2">
+        Start in the sandbox today — free forever if you self-host.
+      </p>
+      <div className="mt-8 flex items-center justify-center gap-3">
+        <Button kind="primary" onClick={onTryCloud}>
+          Try Cloud
+        </Button>
+        <Button kind="quiet" onClick={onSelfHost}>
+          Self Host
+        </Button>
+      </div>
+    </SectionInner>
+  </EditorialDark>
+);

--- a/web/src/components/landing/ContributeSection.tsx
+++ b/web/src/components/landing/ContributeSection.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+/**
+ * A8 — For developers / Contribute: stack line, architecture
+ * mini-diagram, "interesting problems" list, good-first-issue tags,
+ * CONTRIBUTING + Discord links, GitHub badge with runtime star count
+ * (neutral "Star on GitHub" fallback — no number is ever hard-coded,
+ * pages.md A8).
+ */
+
+import React from "react";
+import Tag from "@/components/ui/Tag";
+import {
+  formatStars,
+  useGithubStarsController,
+} from "@/controllers/use-github-stars";
+import { useAnalyticsController } from "@/controllers/use-analytics";
+import { SectionHeading, SectionInner } from "./Section";
+import {
+  ANCHORS,
+  CONTRIBUTING_URL,
+  GITHUB_ISSUES_URL,
+  GITHUB_URL,
+} from "./links";
+
+const PROBLEMS = [
+  "A rules-as-data tax engine — changing a threshold is a docs PR, not a deploy",
+  "Statement parsers that survive messy bank CSVs and scanned PDFs",
+  "Anomaly math: trailing medians, z-scores and duplicate detection",
+  "Canonical line-item mapping with a ±1% identity cross-check",
+];
+
+const GOOD_FIRST_ISSUES = [
+  "good first issue · CSV edge cases",
+  "good first issue · ratio traces",
+];
+
+const GitHubMark: React.FC<{ className?: string }> = ({ className }) => (
+  // Brand glyph (icon/brand-github, design.md §8.1) — not Lucide.
+  <svg
+    viewBox="0 0 16 16"
+    aria-hidden
+    className={className}
+    fill="currentColor"
+  >
+    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.42 7.42 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+  </svg>
+);
+
+/** A8 architecture mini-diagram — web → api → mongo/redis (tokens only). */
+const ArchDiagram: React.FC = () => {
+  const box =
+    "flex h-11 w-40 items-center justify-center rounded border border-border bg-bg-elev font-mono text-[13px] text-text";
+  const connector = "bg-border";
+  return (
+    <figure
+      aria-label="Architecture: web (Next.js) talks to api (Go/Gin), which uses Mongo and Redis"
+      className="mx-auto mt-8 w-full max-w-[720px] rounded border border-border p-8"
+    >
+      <div className="flex items-center justify-center">
+        <div className={box}>web · Next.js</div>
+        <div aria-hidden className={`h-px w-8 sm:w-16 ${connector}`} />
+        <div className={box}>api · Go/Gin</div>
+        <div aria-hidden className={`h-px w-4 sm:w-8 ${connector}`} />
+        <div aria-hidden className="flex flex-col items-start self-stretch">
+          <div className={`w-px flex-1 ${connector}`} />
+          <div className={`w-px flex-1 ${connector}`} />
+        </div>
+        <div className="flex flex-col gap-6">
+          <div className="flex items-center">
+            <div aria-hidden className={`h-px w-4 sm:w-8 ${connector}`} />
+            <div className={box}>mongo</div>
+          </div>
+          <div className="flex items-center">
+            <div aria-hidden className={`h-px w-4 sm:w-8 ${connector}`} />
+            <div className={box}>redis</div>
+          </div>
+        </div>
+      </div>
+    </figure>
+  );
+};
+
+export const ContributeSection: React.FC = () => {
+  const { stars } = useGithubStarsController();
+  const { track } = useAnalyticsController();
+
+  return (
+    <section id={ANCHORS.contribute} className="bg-bg py-20">
+      <SectionInner>
+        <SectionHeading>
+          For developers — come build the hard parts
+        </SectionHeading>
+        <p className="mt-4 text-center font-mono text-[13px] text-text-2">
+          Go/Gin API · Next.js web · Mongo/Postgres/Redis
+        </p>
+
+        <ArchDiagram />
+
+        <div className="mx-auto mt-12 grid max-w-4xl grid-cols-1 gap-10 md:grid-cols-2">
+          <div>
+            <h3 className="text-base font-semibold text-text">
+              Problems worth your weekend
+            </h3>
+            <ul className="mt-4 space-y-3">
+              {PROBLEMS.map((problem) => (
+                <li
+                  key={problem}
+                  className="flex gap-2 text-[13px] leading-relaxed"
+                >
+                  <span aria-hidden className="text-accent">
+                    →
+                  </span>
+                  <span className="text-text-2">{problem}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="space-y-5">
+            <div className="flex flex-wrap gap-2">
+              {GOOD_FIRST_ISSUES.map((label) => (
+                <a
+                  key={label}
+                  href={GITHUB_ISSUES_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() =>
+                    track("contribute_click", { target: "good_first_issue" })
+                  }
+                  className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                >
+                  <Tag tint="neutral" size="md">
+                    {label}
+                  </Tag>
+                </a>
+              ))}
+            </div>
+            <div className="flex flex-wrap items-center gap-5">
+              <a
+                href={CONTRIBUTING_URL}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() =>
+                  track("contribute_click", { target: "contributing_md" })
+                }
+                className="rounded text-sm font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                CONTRIBUTING.md →
+              </a>
+              {/* Runtime star count; neutral label when unknown. */}
+              <a
+                href={GITHUB_URL}
+                target="_blank"
+                rel="noreferrer"
+                data-testid="github-star-badge"
+                onClick={() => track("github_click", { source: "contribute" })}
+                className="inline-flex items-center gap-1.5 rounded border border-border px-3 py-1.5 text-[13px] font-medium text-text transition-colors duration-fast ease-standard hover:bg-bg-elev focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                <GitHubMark className="h-4 w-4" />
+                {stars === null
+                  ? "Star on GitHub"
+                  : `Star on GitHub · ${formatStars(stars)}`}
+              </a>
+            </div>
+          </div>
+        </div>
+      </SectionInner>
+    </section>
+  );
+};
+
+export default ContributeSection;

--- a/web/src/components/landing/DeepDivesSection.tsx
+++ b/web/src/components/landing/DeepDivesSection.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+/**
+ * A4a — Feature deep-dives: benefit-led rows in alternating editorial
+ * splits (claim → outcome copy → product still). Stills are live registry
+ * compositions (the Figma frame instances), revealed on scroll-into-view
+ * and static under reduced motion.
+ */
+
+import React from "react";
+import { CircleCheck } from "lucide-react";
+import AnomalyBadge from "@/components/ui/AnomalyBadge";
+import Button from "@/components/ui/Button";
+import RatioGauge from "@/components/ui/RatioGauge";
+import RemitToCard from "@/components/ui/RemitToCard";
+import ReportArtifactRow from "@/components/ui/ReportArtifactRow";
+import { SectionInner } from "./Section";
+import Reveal from "./Reveal";
+import { cn } from "@/lib/cn";
+
+interface DeepDive {
+  eyebrow: string;
+  title: string;
+  body: string;
+  visual: React.ReactNode;
+  /** Figma alternation: copy left (visual right) or copy right. */
+  copySide: "left" | "right";
+}
+
+/** A4a row 1 visual — the MI-2 completion card (Figma 201:2210 override). */
+const ImportCompleteCard: React.FC = () => (
+  <div className="flex w-full flex-col items-center gap-2 rounded border border-border bg-bg p-8 text-center">
+    <span className="flex h-9 w-9 items-center justify-center rounded-full bg-income/[0.12] text-income">
+      <CircleCheck aria-hidden className="h-5 w-5" />
+    </span>
+    <p className="text-sm font-semibold text-text">214 transactions found</p>
+    <p className="text-[13px] text-text-2">
+      209 ready · 5 possible duplicates flagged
+    </p>
+    <Button kind="primary" size="sm">
+      Review import
+    </Button>
+  </div>
+);
+
+const DEEP_DIVES: DeepDive[] = [
+  {
+    eyebrow: "Capture",
+    title: "Every statement, one pipeline",
+    body: "Drop CSVs, PDFs, even photographed receipts — or link GTBank, Access, Zenith and 100+ banks through Mono’s secure widget. Everything lands in one staged review before it touches your ledger, so nothing imports behind your back.",
+    copySide: "left",
+    visual: <ImportCompleteCard />,
+  },
+  {
+    eyebrow: "Intelligence",
+    title: "AI that categorizes — and flags what’s off",
+    body: "Every transaction gets a category, marked ✨ until you confirm it. Anomaly rules catch outsized payments, category spikes and double-billing — and each flag shows the math behind it.",
+    copySide: "right",
+    visual: (
+      <div className="w-full max-w-sm space-y-3">
+        <AnomalyBadge
+          type="spending_spike"
+          severity="warn"
+          variant="feed"
+          description="Dining out is up 62% vs last month"
+          timestamp="2h"
+        />
+        <AnomalyBadge
+          type="duplicate_charge"
+          severity="info"
+          variant="feed"
+          description="Same amount & merchant as txn 2 minutes earlier"
+          timestamp="2h"
+        />
+      </div>
+    ),
+  },
+  {
+    eyebrow: "Company financials",
+    title: "From balance sheet to boardroom answers",
+    body: "Map statements to a canonical line-item model and get 22 ratios and metrics across liquidity, solvency, profitability, efficiency and cash flow. Every figure is traceable to its source lines, with benchmark bands for context.",
+    copySide: "left",
+    visual: (
+      <div className="w-full max-w-[260px] rounded border border-border bg-bg p-4">
+        <RatioGauge
+          label="Current ratio"
+          value={1.82}
+          display="1.82"
+          min={0}
+          max={3.5}
+          status="healthy"
+          band={{ from: 1.5, to: 3.0 }}
+          delta={0.21}
+          deltaCaption="vs Q1"
+          caption="Benchmark 1.5–3.0 · general guidance"
+          formula="Current ratio = current assets ÷ current liabilities"
+        />
+      </div>
+    ),
+  },
+  {
+    eyebrow: "Nigerian taxes",
+    title: "PIT, CIT and VAT — computed, not guessed",
+    body: "Tax rules ship as data: rates, bands and deadlines for FIRS and every State IRS. Expendit computes what you owe from your actual ledger, then prints the remittance sheet that names the authority, the amount and the payment channel.",
+    copySide: "right",
+    visual: (
+      <div className="w-full max-w-sm">
+        <RemitToCard
+          kind="vat"
+          authority={{
+            code: "FIRS",
+            name: "Federal Inland Revenue Service",
+            payment_channels: ["TaxPro-Max", "Remita"],
+          }}
+          amountDue={550_600}
+          dueDate="2026-07-21"
+          daysToDue={1}
+        />
+      </div>
+    ),
+  },
+  {
+    eyebrow: "Reports",
+    title: "Exports your accountant will actually open",
+    body: "Monthly summaries, cash-movement reports and category deep-dives as PDF or CSV — plus full financial statements. Generate on demand; regenerate any time.",
+    copySide: "left",
+    visual: (
+      <div className="w-full max-w-md rounded border border-border bg-bg">
+        <ReportArtifactRow
+          artifact={{
+            id: "ra-monthly-2026-06",
+            org_id: "demo",
+            kind: "monthly_summary",
+            format: "pdf",
+            period: "2026-06",
+            params: {},
+            status: "ready",
+            signed_url: "#",
+            created_at: "2026-07-18T09:00:00.000Z",
+            expires_at: "2026-08-17T09:00:00.000Z",
+          }}
+          isNew
+        />
+      </div>
+    ),
+  },
+];
+
+export const DeepDivesSection: React.FC = () => (
+  <section className="bg-bg pb-24">
+    <SectionInner className="space-y-20">
+      {DEEP_DIVES.map((dive) => (
+        <div
+          key={dive.title}
+          className="grid grid-cols-1 items-center gap-10 md:grid-cols-2"
+        >
+          <div
+            className={cn(
+              "max-w-[480px]",
+              dive.copySide === "right" && "md:order-2",
+            )}
+          >
+            <div className="text-[11px] font-semibold uppercase tracking-wider text-accent">
+              {dive.eyebrow}
+            </div>
+            <h3 className="mt-3 font-display text-2xl font-bold tracking-tight text-text">
+              {dive.title}
+            </h3>
+            <p className="mt-4 text-sm leading-relaxed text-text-2">
+              {dive.body}
+            </p>
+          </div>
+          <Reveal
+            className={cn(
+              "flex justify-center",
+              dive.copySide === "right" && "md:order-1",
+            )}
+          >
+            {dive.visual}
+          </Reveal>
+        </div>
+      ))}
+    </SectionInner>
+  </section>
+);
+
+export default DeepDivesSection;

--- a/web/src/components/landing/DemoSection.test.tsx
+++ b/web/src/components/landing/DemoSection.test.tsx
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DemoSection from "./DemoSection";
+
+describe("A5 — interactive demo (persona tabs over the §8.3 datasets)", () => {
+  beforeEach(() => {
+    window.__expenditEvents = [];
+  });
+
+  it("renders the demo badge, persona tabs, and the freelancer dataset", () => {
+    render(<DemoSection />);
+    expect(screen.getByText("This is demo data")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Freelancer" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "SME" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Company" })).toBeInTheDocument();
+    // Freelancer income stat (Figma A5 strip verbatim).
+    expect(screen.getByText("₦1,480,000.00")).toBeInTheDocument();
+    expect(screen.getByText("MTN — data bundle top-up")).toBeInTheDocument();
+  });
+
+  it("switching persona swaps stats, table rows, and emits demo_interact", async () => {
+    render(<DemoSection />);
+    await userEvent.click(screen.getByRole("tab", { name: "Company" }));
+    expect(screen.getByText("₦8,435,200.00")).toBeInTheDocument();
+    expect(screen.getByText("Retainer — Kudaworks")).toBeInTheDocument();
+    expect(screen.queryByText("MTN — data bundle top-up")).toBeNull();
+    expect(
+      window.__expenditEvents?.some(
+        (record) =>
+          record.event === "demo_interact" &&
+          record.props.action === "switch_persona" &&
+          record.props.persona === "company",
+      ),
+    ).toBe(true);
+  });
+
+  it("data-table toggle swaps the chart for its table (design.md §5)", async () => {
+    render(<DemoSection />);
+    await userEvent.click(screen.getByRole("button", { name: "Data table" }));
+    expect(
+      screen.getByRole("table", { name: "Cash flow by month" }),
+    ).toBeInTheDocument();
+  });
+
+  it("CRUD-light: recategorizing a row clears the ✨ marker (MI-4)", async () => {
+    render(<DemoSection />);
+    const table = screen.getByTestId("demo-table");
+    // First AI-suggested chip: Utilities ✨ on the MTN row.
+    expect(
+      within(table).getAllByTestId("category-ai-mark").length,
+    ).toBeGreaterThan(0);
+    const chip = within(table).getAllByRole("button", {
+      name: /Utilities/,
+    })[0];
+    await userEvent.click(chip);
+    await userEvent.click(screen.getByRole("option", { name: /Other/ }));
+    expect(within(table).getAllByText("Other").length).toBeGreaterThan(0);
+    expect(
+      window.__expenditEvents?.some(
+        (record) =>
+          record.event === "demo_interact" &&
+          record.props.action === "recategorize",
+      ),
+    ).toBe(true);
+  });
+});

--- a/web/src/components/landing/DemoSection.tsx
+++ b/web/src/components/landing/DemoSection.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+/**
+ * A5 — Interactive preview (EXP-001): read-only demo report over the
+ * three §8.3 synthetic datasets. Persona Tabs (pill), "This is demo
+ * data" Tag, MI-7 count-up StatCards, cash-flow line (+ data-table
+ * toggle, design.md §5), category donut, and the synthetic txn table
+ * with CRUD-light inline recategorize (MI-4). Render-only view over
+ * useHomeDemoController.
+ */
+
+import React from "react";
+import Tabs, { TabItem, TabPanel } from "@/components/ui/Tabs";
+import Tag from "@/components/ui/Tag";
+import StatCard from "@/components/ui/StatCard";
+import ChartLine from "@/components/ui/ChartLine";
+import ChartDonut from "@/components/ui/ChartDonut";
+import TableHeader from "@/components/ui/TableHeader";
+import TxnTableRow from "@/components/ui/TxnTableRow";
+import { DEMO_PERSONAS, DEMO_DATASETS, type DemoPersona } from "@/mock/demo";
+import { useHomeDemoController } from "@/controllers/use-home-demo";
+import { formatMoney } from "@/lib/format";
+import { SectionHeading, SectionInner } from "./Section";
+import DonutLegend from "./DonutLegend";
+import { toTxnEntry, TXN_COLUMNS } from "./embeds";
+import { ANCHORS } from "./links";
+
+export const DemoSection: React.FC = () => {
+  const {
+    persona,
+    dataset,
+    txns,
+    showDataTable,
+    switchPersona,
+    recategorize,
+    toggleDataTable,
+  } = useHomeDemoController();
+
+  const { stats } = dataset;
+
+  return (
+    <section id={ANCHORS.demo} className="scroll-mt-16 bg-bg-elev py-20">
+      <SectionInner>
+        <div className="flex items-center justify-center gap-3">
+          <SectionHeading>Explore the live demo</SectionHeading>
+          <Tag tint="info" size="md">
+            This is demo data
+          </Tag>
+        </div>
+
+        <Tabs
+          value={persona}
+          onValueChange={(value) => switchPersona(value as DemoPersona)}
+          kind="pill"
+          aria-label="Demo persona"
+          className="mt-6 flex flex-col items-center"
+          items={DEMO_PERSONAS.map((key) => (
+            <TabItem key={key} value={key} kind="pill">
+              {DEMO_DATASETS[key].label}
+            </TabItem>
+          ))}
+        >
+          {DEMO_PERSONAS.map((key) => (
+            <TabPanel key={key} value={key} className="w-full pt-8">
+              {key !== persona ? null : (
+                <>
+                  <div className="mx-auto grid max-w-4xl grid-cols-1 gap-4 sm:grid-cols-3">
+                    <StatCard
+                      label={stats.net.label}
+                      value={stats.net.value}
+                      format={(value) => formatMoney(value)}
+                      delta={stats.net.delta}
+                      deltaCaption={dataset.deltaCaption}
+                      sparkline={stats.net.sparkline}
+                    />
+                    <StatCard
+                      label={stats.income.label}
+                      value={stats.income.value}
+                      format={(value) => formatMoney(value)}
+                      delta={stats.income.delta}
+                      deltaCaption={dataset.deltaCaption}
+                      sparkline={stats.income.sparkline}
+                    />
+                    <StatCard
+                      label={stats.expenses.label}
+                      value={stats.expenses.value}
+                      format={(value) => formatMoney(value)}
+                      delta={stats.expenses.delta}
+                      deltaCaption={dataset.deltaCaption}
+                      sparkline={stats.expenses.sparkline}
+                    />
+                  </div>
+
+                  <div className="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-[3fr_2fr]">
+                    <div className="rounded border border-border bg-bg p-4">
+                      <div className="mb-3 flex items-center justify-between">
+                        <span className="text-[13px] font-medium text-text">
+                          Cash flow — 12 months
+                        </span>
+                        {/* Chart data-table parity toggle (design.md §5). */}
+                        <button
+                          type="button"
+                          onClick={toggleDataTable}
+                          aria-pressed={showDataTable}
+                          className="rounded border border-border px-2 py-0.5 text-[11px] font-medium text-text-2 transition-colors duration-fast ease-standard hover:bg-bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                        >
+                          Data table
+                        </button>
+                      </div>
+                      {showDataTable ? (
+                        <table className="w-full text-[13px]">
+                          <caption className="sr-only">
+                            Cash flow by month
+                          </caption>
+                          <thead>
+                            <tr className="border-b border-border text-left text-text-2">
+                              <th scope="col" className="py-1 font-medium">
+                                Month
+                              </th>
+                              <th
+                                scope="col"
+                                className="py-1 text-right font-medium"
+                              >
+                                Net cash flow
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {dataset.cashflow.points.map((value, index) => (
+                              // Months run Aug → Jul (trailing 12).
+                              <tr
+                                key={index}
+                                className="border-b border-border last:border-0"
+                              >
+                                <td className="py-1 text-text-2">
+                                  M{index + 1}
+                                </td>
+                                <td className="py-1 text-right tabular-nums text-text">
+                                  {formatMoney(value)}
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      ) : (
+                        <ChartLine
+                          series={[
+                            {
+                              id: "cashflow",
+                              label: "Net cash flow",
+                              color: "accent",
+                              points: dataset.cashflow.points,
+                            },
+                          ]}
+                          xLabels={dataset.cashflow.xLabels}
+                          height={200}
+                        />
+                      )}
+                    </div>
+                    <div className="rounded border border-border bg-bg p-4">
+                      <div className="mb-3 text-[13px] font-medium text-text">
+                        Expenses by category
+                      </div>
+                      <div className="flex flex-wrap items-center gap-5">
+                        <ChartDonut
+                          slices={dataset.donut.slices}
+                          centerTotal={dataset.donut.centerTotal}
+                          centerCaption="Expenses"
+                          legend="none"
+                        />
+                        <DonutLegend
+                          slices={dataset.donut.slices}
+                          className="min-w-[220px] flex-1"
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div
+                    data-testid="demo-table"
+                    className="mt-6 overflow-x-auto rounded border border-border bg-bg"
+                  >
+                    <div className="min-w-[720px]">
+                      <TableHeader
+                        columns={TXN_COLUMNS}
+                        sort={{ columnId: "date", direction: "desc" }}
+                      />
+                      {txns.map((txn) => (
+                        <TxnTableRow
+                          key={txn.id}
+                          txn={toTxnEntry(txn)}
+                          category={
+                            dataset.categories.find(
+                              (category) => category.id === txn.categoryId,
+                            ) ?? dataset.categories[0]
+                          }
+                          categoryOptions={dataset.categories}
+                          onCategorySelect={(categoryId) =>
+                            recategorize(txn.id, categoryId)
+                          }
+                        />
+                      ))}
+                    </div>
+                  </div>
+                </>
+              )}
+            </TabPanel>
+          ))}
+        </Tabs>
+      </SectionInner>
+    </section>
+  );
+};
+
+export default DemoSection;

--- a/web/src/components/landing/DonutLegend.tsx
+++ b/web/src/components/landing/DonutLegend.tsx
@@ -1,0 +1,44 @@
+/**
+ * Donut legend with share + amount readouts (Figma A5/B1 embed legend:
+ * dot · label · percent · mono tabular amount). Slice colors are data
+ * (registry category colors), same as Chart/Donut.
+ */
+
+import React from "react";
+import type { DemoDonutSlice } from "@/mock/demo";
+import { formatMoney } from "@/lib/format";
+import { cn } from "@/lib/cn";
+
+export const DonutLegend: React.FC<{
+  slices: DemoDonutSlice[];
+  className?: string;
+}> = ({ slices, className }) => {
+  const total = slices.reduce((sum, slice) => sum + slice.value, 0) || 1;
+  return (
+    <ul className={cn("space-y-1.5", className)}>
+      {slices.map((slice) => (
+        <li
+          key={slice.id}
+          className="flex items-center gap-2 text-[13px] leading-4"
+        >
+          <span
+            aria-hidden
+            className="h-2 w-2 shrink-0 rounded-full"
+            style={{ backgroundColor: slice.color }}
+          />
+          <span className="min-w-0 flex-1 truncate text-text">
+            {slice.label}
+          </span>
+          <span className="tabular-nums text-text-2">
+            {Math.round((slice.value / total) * 100)}%
+          </span>
+          <span className="font-mono text-[12px] tabular-nums text-text">
+            {formatMoney(slice.value)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default DonutLegend;

--- a/web/src/components/landing/FaqSection.test.tsx
+++ b/web/src/components/landing/FaqSection.test.tsx
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FaqSection } from "./CompareFaqCta";
+
+describe("A10a — FAQ accordion (one open at a time, faq_open events)", () => {
+  beforeEach(() => {
+    window.__expenditEvents = [];
+  });
+
+  it("boots with the bank-safety answer open (Figma default)", () => {
+    render(<FaqSection />);
+    expect(screen.getByText(/Bank sign-in happens inside Mono/)).toBeVisible();
+  });
+
+  it("opens one item at a time and emits faq_open", async () => {
+    render(<FaqSection />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "What’s the license?" }),
+    );
+    expect(screen.getByText(/MIT\. Cloud and self-host/)).toBeVisible();
+    // The previously-open item closed (single mode — Radix unmounts it).
+    expect(screen.queryByText(/Bank sign-in happens inside Mono/)).toBeNull();
+    expect(window.__expenditEvents?.at(-1)).toMatchObject({
+      event: "faq_open",
+      props: { question: "license" },
+    });
+  });
+});

--- a/web/src/components/landing/HeroSection.tsx
+++ b/web/src/components/landing/HeroSection.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+/**
+ * A2 — Hero (dark editorial): Hero/88 display headline, sub, dual CTA
+ * Try Cloud / Self Host, "Open source · MIT licensed" caption, and the
+ * dashboard-in-device-frame visual (the B1 overview embed) with the
+ * one-shot categorization-chip animation (pages.md A2: chips animate
+ * once; static under reduced motion).
+ */
+
+import React from "react";
+import Button from "@/components/ui/Button";
+import CategoryChip from "@/components/ui/CategoryChip";
+import { EditorialDark, SectionInner } from "./Section";
+import ScaledEmbed from "./ScaledEmbed";
+import {
+  DashboardEmbed,
+  DASHBOARD_EMBED_HEIGHT,
+  DASHBOARD_EMBED_WIDTH,
+} from "./embeds";
+
+export interface HeroSectionProps {
+  onTryCloud: () => void;
+  onSelfHost: () => void;
+  /** A1 nav (on-dark variant) rendered over the hero surface. */
+  nav?: React.ReactNode;
+}
+
+/**
+ * One-shot chip animation data (categorization moment, MI-2/MI-4).
+ * Colors are the demo dataset's category colors (user data, not tokens).
+ */
+const HERO_CHIPS = [
+  { id: "utilities", name: "Utilities", color: "#2456D6", ai: true },
+  { id: "sales", name: "Sales", color: "#1B7F4B", ai: false },
+  { id: "transport", name: "Transport", color: "#B26A00", ai: true },
+];
+
+export const HeroSection: React.FC<HeroSectionProps> = ({
+  onTryCloud,
+  onSelfHost,
+  nav,
+}) => (
+  <EditorialDark motif>
+    {nav}
+    <SectionInner className="pb-24 pt-14 text-center md:pt-24">
+      <h1 className="mx-auto max-w-[1100px] font-display text-[44px] font-bold leading-[1.05] tracking-tight text-text sm:text-[56px] lg:text-[80px]">
+        See every naira. File every tax.
+      </h1>
+      <p className="mx-auto mt-6 max-w-3xl text-base leading-relaxed text-text-2">
+        Upload statements or link your bank — AI categorizes every transaction
+        and flags what’s off. Then see your P&amp;L, your ratios, and exactly
+        which tax to pay — and where to remit it.
+      </p>
+      <div className="mt-8 flex items-center justify-center gap-3">
+        <Button kind="primary" onClick={onTryCloud}>
+          Try Cloud
+        </Button>
+        <Button kind="quiet" onClick={onSelfHost}>
+          Self Host
+        </Button>
+      </div>
+      <p className="mt-6 text-[13px] text-text-2">
+        Open source · MIT licensed · Self-host with one command
+      </p>
+
+      {/* Hero visual — the B1 overview in a device frame. */}
+      <div className="relative mx-auto mt-14 max-w-[1037px]">
+        {/* Categorization chips animate in once (MI-4 moment). */}
+        <div
+          aria-hidden
+          data-testid="hero-chips"
+          className="pointer-events-none absolute -top-4 right-6 flex gap-2"
+        >
+          {HERO_CHIPS.map((chip, index) => (
+            <span
+              key={chip.id}
+              className="animate-rise-in motion-reduce:animate-none"
+              style={{ animationDelay: `${200 + index * 150}ms` }}
+            >
+              <CategoryChip category={chip} aiSuggested={chip.ai} disabled />
+            </span>
+          ))}
+        </div>
+        <div
+          data-theme="light"
+          // Decorative composition: inert removes it from tab order and
+          // the accessibility tree (the CTAs above are the real actions).
+          inert
+          className="overflow-hidden rounded-lg border border-border bg-bg text-left"
+        >
+          <ScaledEmbed
+            designWidth={DASHBOARD_EMBED_WIDTH}
+            designHeight={DASHBOARD_EMBED_HEIGHT}
+          >
+            <DashboardEmbed />
+          </ScaledEmbed>
+        </div>
+      </div>
+    </SectionInner>
+  </EditorialDark>
+);
+
+export default HeroSection;

--- a/web/src/components/landing/HomeView.test.tsx
+++ b/web/src/components/landing/HomeView.test.tsx
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import HomeView from "./HomeView";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, prefetch: vi.fn() }),
+}));
+
+describe("public home `/` (pages.md Part A, A1–A11)", () => {
+  beforeEach(() => {
+    push.mockClear();
+    window.__expenditEvents = [];
+  });
+
+  it("renders every Part A section", () => {
+    render(<HomeView />);
+    // A2 hero
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "See every naira. File every tax.",
+      }),
+    ).toBeInTheDocument();
+    // A4 pillars
+    expect(screen.getByText("One ledger. Three superpowers.")).toBeVisible();
+    // A4a deep-dives
+    expect(screen.getByText("Every statement, one pipeline")).toBeVisible();
+    // A5 demo + A5a how-it-works
+    expect(screen.getByText("Explore the live demo")).toBeVisible();
+    expect(screen.getByText("How it works")).toBeVisible();
+    // A6–A7
+    expect(screen.getByText("AI that shows its work")).toBeVisible();
+    expect(
+      screen.getByText("Security & privacy, in plain language"),
+    ).toBeVisible();
+    // A8/A8a
+    expect(
+      screen.getByText("For developers — come build the hard parts"),
+    ).toBeVisible();
+    expect(
+      screen.getByText("Self-host: your books never leave your building"),
+    ).toBeVisible();
+    // A9–A10b
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Community" }),
+    ).toBeVisible();
+    expect(screen.getByText("Cloud or self-host — same product")).toBeVisible();
+    expect(screen.getByText("Questions, answered")).toBeVisible();
+    expect(screen.getByText("Your numbers are ready to talk.")).toBeVisible();
+    // A11 footer
+    expect(screen.getByText("View Security Policy")).toBeInTheDocument();
+  });
+
+  it("emits page_view on mount", () => {
+    render(<HomeView />);
+    expect(
+      window.__expenditEvents?.some((record) => record.event === "page_view"),
+    ).toBe(true);
+  });
+
+  it("hero Try Cloud emits try_cloud_click and routes to /signin", async () => {
+    render(<HomeView />);
+    // Order on the page: A1 nav CTA, then the A2 hero CTA.
+    const heroTryCloud = screen.getAllByRole("button", {
+      name: "Try Cloud",
+    })[1];
+    await userEvent.click(heroTryCloud);
+    expect(push).toHaveBeenCalledWith("/signin");
+    expect(window.__expenditEvents?.at(-1)).toMatchObject({
+      event: "try_cloud_click",
+      props: { source: "hero" },
+    });
+  });
+
+  it("Self Host CTA emits self_host_click (scrolls to A8a)", async () => {
+    render(<HomeView />);
+    const [heroSelfHost] = screen.getAllByRole("button", {
+      name: "Self Host",
+    });
+    await userEvent.click(heroSelfHost);
+    expect(
+      window.__expenditEvents?.some(
+        (record) => record.event === "self_host_click",
+      ),
+    ).toBe(true);
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("A10b final CTA re-emits the A2 events (pages.md A10b)", async () => {
+    render(<HomeView />);
+    const tryClouds = screen.getAllByRole("button", { name: "Try Cloud" });
+    await userEvent.click(tryClouds[tryClouds.length - 1]);
+    expect(window.__expenditEvents?.at(-1)).toMatchObject({
+      event: "try_cloud_click",
+      props: { source: "final_cta" },
+    });
+    expect(push).toHaveBeenCalledWith("/signin");
+  });
+
+  it("marketing accuracy: pricing is only the GA/self-host line", () => {
+    render(<HomeView />);
+    expect(screen.getByText("Announced at GA")).toBeInTheDocument();
+    expect(screen.getByText("Free forever")).toBeInTheDocument();
+    // Star badge is neutral until a runtime count arrives (TEST_MODE: never).
+    expect(screen.getByTestId("github-star-badge")).toHaveTextContent(
+      "Star on GitHub",
+    );
+    // No currency-priced plan anywhere on the page.
+    expect(screen.queryByText(/\$\d|₦\d+\s*\/\s*mo/)).toBeNull();
+  });
+});

--- a/web/src/components/landing/HomeView.tsx
+++ b/web/src/components/landing/HomeView.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+/**
+ * Public home `/` — pages.md Part A (A1–A11 + A4a/A5a/A8a/A10a/A10b),
+ * Brex-editorial execution over the ui registry (Figma Home frame
+ * 193:14). Render-only composition: analytics + demo state live in
+ * controllers; alternating light/dark sections scope `data-theme="dark"`
+ * on their own subtrees.
+ */
+
+import React, { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import MarketingNav from "@/components/ui/MarketingNav";
+import MarketingFooter from "@/components/ui/MarketingFooter";
+import {
+  useAnalyticsController,
+  usePageView,
+} from "@/controllers/use-analytics";
+import HeroSection from "./HeroSection";
+import { LogoStrip, PillarsSection } from "./PillarsSection";
+import DeepDivesSection from "./DeepDivesSection";
+import DemoSection from "./DemoSection";
+import HowItWorksSection from "./HowItWorksSection";
+import { AiSection, SecuritySection } from "./TrustSections";
+import ContributeSection from "./ContributeSection";
+import { CommunitySection, SelfHostSection } from "./SelfHostCommunity";
+import { CompareSection, FaqSection, FinalCtaSection } from "./CompareFaqCta";
+import {
+  ANCHORS,
+  scrollToAnchor,
+  DISCORD_URL,
+  DOCS_URL,
+  GITHUB_URL,
+  PRIVACY_HUB_URL,
+  ROADMAP_URL,
+  SECURITY_POLICY_URL,
+} from "./links";
+
+const NAV_LINKS = [
+  { label: "Product", href: `#${ANCHORS.product}` },
+  { label: "Docs", href: DOCS_URL },
+  { label: "Community", href: `#${ANCHORS.community}` },
+];
+
+const SOLUTIONS = [
+  { label: "Individuals", href: `#${ANCHORS.demo}` },
+  { label: "SMEs", href: `#${ANCHORS.demo}` },
+  { label: "Companies", href: `#${ANCHORS.demo}` },
+];
+
+const FOOTER_COLUMNS = [
+  {
+    heading: "Product",
+    links: [
+      { label: "Features", href: `#${ANCHORS.product}` },
+      { label: "Pricing", href: `#${ANCHORS.compare}` },
+      { label: "Try Cloud", href: "/signin" },
+      { label: "Self Host", href: `#${ANCHORS.selfHost}` },
+    ],
+  },
+  {
+    heading: "Resources",
+    links: [
+      { label: "Docs", href: DOCS_URL },
+      { label: "GitHub", href: GITHUB_URL },
+      { label: "Discord", href: DISCORD_URL },
+      { label: "Roadmap", href: ROADMAP_URL },
+    ],
+  },
+  {
+    heading: "Legal",
+    links: [
+      { label: "Privacy", href: PRIVACY_HUB_URL },
+      { label: "Terms", href: PRIVACY_HUB_URL },
+      { label: "Data rights", href: PRIVACY_HUB_URL },
+    ],
+  },
+];
+
+export const HomeView: React.FC = () => {
+  const router = useRouter();
+  const { track } = useAnalyticsController();
+  usePageView("home");
+
+  // A1: on-dark over the hero → sticky dark-on-light after hero scroll.
+  const heroRef = useRef<HTMLDivElement>(null);
+  const [pastHero, setPastHero] = useState(false);
+
+  useEffect(() => {
+    const hero = heroRef.current;
+    if (!hero || typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setPastHero(!(entry?.isIntersecting ?? true)),
+      { rootMargin: "-64px 0px 0px 0px", threshold: 0 },
+    );
+    observer.observe(hero);
+    return () => observer.disconnect();
+  }, []);
+
+  const tryCloud = (source: string) => {
+    track("try_cloud_click", { source });
+    router.push("/signin");
+  };
+
+  const selfHost = (source: string) => {
+    track("self_host_click", { source });
+    scrollToAnchor(ANCHORS.selfHost);
+  };
+
+  const navProps = {
+    links: NAV_LINKS,
+    solutions: SOLUTIONS,
+    githubHref: GITHUB_URL,
+    onGithubClick: () => track("github_click", { source: "nav" }),
+    onSignIn: () => router.push("/signin"),
+    onTryCloud: () => tryCloud("nav"),
+  };
+
+  return (
+    <div className="bg-bg">
+      {/* Sticky dark-on-light nav appears once the hero is scrolled. */}
+      {pastHero ? (
+        <div className="fixed inset-x-0 top-0 z-sticky animate-fade-in motion-reduce:animate-none">
+          <MarketingNav variant="dark-on-light" {...navProps} />
+        </div>
+      ) : null}
+
+      <div ref={heroRef}>
+        <HeroSection
+          nav={
+            <MarketingNav
+              variant="on-dark"
+              {...navProps}
+              className="mx-auto max-w-[1248px]"
+            />
+          }
+          onTryCloud={() => tryCloud("hero")}
+          onSelfHost={() => selfHost("hero")}
+        />
+      </div>
+
+      <LogoStrip />
+      <PillarsSection />
+      <DeepDivesSection />
+      <DemoSection />
+      <HowItWorksSection />
+      <AiSection />
+      <SecuritySection />
+      <ContributeSection />
+      <SelfHostSection />
+      <CommunitySection />
+      <CompareSection
+        onTryCloud={() => tryCloud("compare")}
+        onSelfHost={() => selfHost("compare")}
+      />
+      <FaqSection />
+      <FinalCtaSection
+        onTryCloud={() => tryCloud("final_cta")}
+        onSelfHost={() => selfHost("final_cta")}
+      />
+
+      <MarketingFooter
+        columns={FOOTER_COLUMNS}
+        securityPolicyHref={SECURITY_POLICY_URL}
+        note="© 2026 Cuesoft Inc."
+        brand={
+          <div>
+            <div className="text-lg font-semibold tracking-tight text-text">
+              expendit<span className="text-accent">.</span>
+            </div>
+            <p className="mt-2 text-[13px] text-text-2">
+              Financial intelligence for modern growth.
+            </p>
+          </div>
+        }
+        meta={<span className="text-[13px] text-text-2">English</span>}
+      />
+    </div>
+  );
+};
+
+export default HomeView;

--- a/web/src/components/landing/HowItWorksSection.tsx
+++ b/web/src/components/landing/HowItWorksSection.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+/**
+ * A5a — How it works: three numbered steps, each carrying a real screen
+ * thumbnail (live registry compositions of the Stage-4 templates — B3b
+ * staged review, B1 overview, B7 tax center). Thumbnail click scrolls to
+ * the A5 live demo (pages.md A5a).
+ */
+
+import React from "react";
+import { useAnalyticsController } from "@/controllers/use-analytics";
+import { SectionHeading, SectionInner } from "./Section";
+import ScaledEmbed from "./ScaledEmbed";
+import {
+  DashboardEmbed,
+  DASHBOARD_EMBED_HEIGHT,
+  DASHBOARD_EMBED_WIDTH,
+  ImportReviewEmbed,
+  IMPORT_EMBED_HEIGHT,
+  IMPORT_EMBED_WIDTH,
+  TaxCenterEmbed,
+  TAX_EMBED_HEIGHT,
+  TAX_EMBED_WIDTH,
+} from "./embeds";
+import { ANCHORS, scrollToAnchor } from "./links";
+
+const STEPS = [
+  {
+    number: 1,
+    title: "Import your statements",
+    body: "Connect your bank through Mono or drop in CSVs and PDFs — every line is parsed and staged for review.",
+    thumb: (
+      <ScaledEmbed
+        designWidth={IMPORT_EMBED_WIDTH}
+        designHeight={IMPORT_EMBED_HEIGHT}
+      >
+        <ImportReviewEmbed />
+      </ScaledEmbed>
+    ),
+  },
+  {
+    number: 2,
+    title: "See where money goes",
+    body: "Overview turns the ledger into cash flow, category breakdowns and anomaly flags as transactions land.",
+    thumb: (
+      <ScaledEmbed
+        designWidth={DASHBOARD_EMBED_WIDTH}
+        designHeight={DASHBOARD_EMBED_HEIGHT}
+      >
+        <DashboardEmbed />
+      </ScaledEmbed>
+    ),
+  },
+  {
+    number: 3,
+    title: "File with confidence",
+    body: "The tax center computes PIT, CIT and VAT — every figure traceable down to its transactions.",
+    thumb: (
+      <ScaledEmbed
+        designWidth={TAX_EMBED_WIDTH}
+        designHeight={TAX_EMBED_HEIGHT}
+      >
+        <TaxCenterEmbed />
+      </ScaledEmbed>
+    ),
+  },
+];
+
+export const HowItWorksSection: React.FC = () => {
+  const { track } = useAnalyticsController();
+
+  const scrollToDemo = (event: React.MouseEvent) => {
+    event.preventDefault();
+    track("demo_interact", { action: "how_it_works_thumbnail" });
+    scrollToAnchor(ANCHORS.demo);
+  };
+
+  return (
+    <section id={ANCHORS.howItWorks} className="bg-bg py-20">
+      <SectionInner>
+        <SectionHeading>How it works</SectionHeading>
+        <ol className="mt-12 grid grid-cols-1 gap-10 md:grid-cols-3">
+          {STEPS.map((step) => (
+            <li key={step.number}>
+              {/* Thumb: inert composition + link overlay (no nested
+                  interactive elements — the embed is decorative). */}
+              <div className="relative overflow-hidden rounded border border-border bg-bg transition-transform duration-base ease-standard hover:-translate-y-0.5 motion-reduce:hover:translate-y-0">
+                <div inert className="pointer-events-none select-none">
+                  {step.thumb}
+                </div>
+                <a
+                  href={`#${ANCHORS.demo}`}
+                  onClick={scrollToDemo}
+                  aria-label={`${step.title} — jump to the live demo`}
+                  className="absolute inset-0 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent"
+                />
+              </div>
+              <div className="mt-5 flex items-center gap-3">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-accent text-[13px] font-semibold text-on-accent">
+                  {step.number}
+                </span>
+                <h3 className="text-base font-semibold text-text">
+                  {step.title}
+                </h3>
+              </div>
+              <p className="mt-3 text-[13px] leading-relaxed text-text-2">
+                {step.body}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </SectionInner>
+    </section>
+  );
+};
+
+export default HowItWorksSection;

--- a/web/src/components/landing/PillarsSection.tsx
+++ b/web/src/components/landing/PillarsSection.tsx
@@ -1,0 +1,85 @@
+/**
+ * A3 — Logos strip + A4 — Product pillars. Logos are text placeholders
+ * for the PRD §6 case-study slots (Figma A3 as built: name-only row —
+ * "banks and tools Nigerian businesses already use", not endorsements).
+ */
+
+import React from "react";
+import { Calculator, FileSpreadsheet, Gauge } from "lucide-react";
+import EditorialCard from "@/components/ui/EditorialCard";
+import { SectionHeading, SectionInner } from "./Section";
+import { ANCHORS } from "./links";
+
+const LOGOS = [
+  "Paystack",
+  "Kuda",
+  "Moniepoint",
+  "PiggyVest",
+  "Helium Health",
+  "Buycoins",
+];
+
+export const LogoStrip: React.FC = () => (
+  <section aria-label="Works with" className="bg-bg py-14">
+    <SectionInner className="text-center">
+      <p className="text-[13px] text-text-2">
+        Reads statements and exports from the banks and tools Nigerian
+        businesses already use
+      </p>
+      <ul className="mt-4 flex flex-wrap items-center justify-center gap-x-12 gap-y-3">
+        {LOGOS.map((name) => (
+          <li
+            key={name}
+            className="text-base font-semibold tracking-tight text-text-2"
+          >
+            {name}
+          </li>
+        ))}
+      </ul>
+    </SectionInner>
+  </section>
+);
+
+const PILLARS = [
+  {
+    icon: FileSpreadsheet,
+    title: "Statements → intelligence",
+    body: "Upload or link. AI categorizes every transaction and flags what doesn’t belong.",
+    cta: "Explore imports",
+  },
+  {
+    icon: Gauge,
+    title: "Company financials",
+    body: "Balance sheet to ratio grid — liquidity, solvency and profitability with formula traces.",
+    cta: "Explore ratios",
+  },
+  {
+    icon: Calculator,
+    title: "Taxes — calculate and file",
+    body: "VAT, PIT and CIT from your ledger; filing-ready documents for FIRS and LIRS.",
+    cta: "Open tax center",
+  },
+];
+
+export const PillarsSection: React.FC = () => (
+  <section id={ANCHORS.product} className="bg-bg pb-20 pt-10">
+    <SectionInner>
+      <SectionHeading>One ledger. Three superpowers.</SectionHeading>
+      <div className="mt-10 grid grid-cols-1 gap-6 md:grid-cols-3">
+        {PILLARS.map((pillar) => (
+          <EditorialCard
+            key={pillar.title}
+            kind="pillar"
+            icon={pillar.icon}
+            title={pillar.title}
+            body={pillar.body}
+            cta={pillar.cta}
+            href="/signin"
+          />
+        ))}
+      </div>
+    </SectionInner>
+  </section>
+);
+
+export default PillarsSection;

--- a/web/src/components/landing/Reveal.tsx
+++ b/web/src/components/landing/Reveal.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+/**
+ * Reveal — one-shot fade-in when scrolled into view (A4a: stills swap on
+ * scroll-into-view; static under reduced motion, design.md §5). Content
+ * is always in the DOM; only opacity animates, so no-JS/reduced-motion
+ * render identically.
+ */
+
+import React, { useEffect, useRef, useState } from "react";
+import { prefersReducedMotion } from "@/lib/use-reduced-motion";
+import { cn } from "@/lib/cn";
+
+export const Reveal: React.FC<{
+  className?: string;
+  children: React.ReactNode;
+}> = ({ className, children }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [shown, setShown] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    if (prefersReducedMotion() || typeof IntersectionObserver === "undefined") {
+      setShown(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setShown(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.2 },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      data-shown={shown}
+      className={cn(
+        "transition-opacity duration-entrance ease-standard motion-reduce:transition-none",
+        shown ? "opacity-100" : "opacity-0",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Reveal;

--- a/web/src/components/landing/ScaledEmbed.tsx
+++ b/web/src/components/landing/ScaledEmbed.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+/**
+ * ScaledEmbed — renders a fixed-design-width composition (the hero B1
+ * embed, the A5a screen thumbnails) scaled to its container, the same
+ * way the Figma Home frame scales real component instances into device
+ * frames and thumbs. Pure CSS transform; no re-layout of the child.
+ */
+
+import React, { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/cn";
+
+export interface ScaledEmbedProps {
+  /** The child composition's natural width in px. */
+  designWidth: number;
+  /** The child composition's natural height in px. */
+  designHeight: number;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const ScaledEmbed: React.FC<ScaledEmbedProps> = ({
+  designWidth,
+  designHeight,
+  className,
+  children,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(([entry]) => {
+      const width = entry?.contentRect.width ?? designWidth;
+      setScale(width / designWidth);
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [designWidth]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("w-full overflow-hidden", className)}
+      style={{ height: designHeight * scale }}
+    >
+      <div
+        style={{
+          width: designWidth,
+          height: designHeight,
+          transform: `scale(${scale})`,
+          transformOrigin: "top left",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default ScaledEmbed;

--- a/web/src/components/landing/Section.tsx
+++ b/web/src/components/landing/Section.tsx
@@ -1,0 +1,78 @@
+/**
+ * Marketing section scaffolding — the design.md §2 marketing layout
+ * (12-col, max 1200px, alternating light/dark full-bleed sections; dark
+ * sections scope `data-theme="dark"` so every child binds tokens only)
+ * plus the Afrocentric line motif at 4% opacity on dark editorial
+ * surfaces (design.md §2 — an asset, drawn inline as a token-free SVG
+ * pattern; documented exception, decorative only).
+ */
+
+import React from "react";
+import { cn } from "@/lib/cn";
+
+/** Dark editorial section: #0C0C0E in both themes via bg-editorial. */
+export const EditorialDark: React.FC<{
+  id?: string;
+  className?: string;
+  children: React.ReactNode;
+  /** Line motif (4% opacity) — dark editorial sections only. */
+  motif?: boolean;
+}> = ({ id, className, children, motif = false }) => (
+  <section
+    id={id}
+    data-theme="dark"
+    className={cn("relative overflow-hidden bg-bg-editorial", className)}
+  >
+    {motif ? <LineMotif /> : null}
+    <div className="relative">{children}</div>
+  </section>
+);
+
+export const SectionInner: React.FC<{
+  className?: string;
+  children: React.ReactNode;
+}> = ({ className, children }) => (
+  <div className={cn("mx-auto w-full max-w-[1200px] px-6", className)}>
+    {children}
+  </div>
+);
+
+/** Section heading — Display/32 Bold, centered (Figma A3–A10 pattern). */
+export const SectionHeading: React.FC<{
+  children: React.ReactNode;
+  className?: string;
+}> = ({ children, className }) => (
+  <h2
+    className={cn(
+      "text-center font-display text-[28px] font-bold leading-tight tracking-tight text-text md:text-[32px]",
+      className,
+    )}
+  >
+    {children}
+  </h2>
+);
+
+/**
+ * Afrocentric line motif — concentric arc strokes at 4% opacity
+ * (design.md §2: dark editorial sections only, decorative).
+ */
+const LineMotif: React.FC = () => (
+  <svg
+    aria-hidden
+    data-testid="line-motif"
+    className="pointer-events-none absolute -right-40 -top-40 h-[640px] w-[640px] opacity-[0.04]"
+    viewBox="0 0 640 640"
+    fill="none"
+  >
+    {Array.from({ length: 12 }, (_, index) => (
+      <circle
+        key={index}
+        cx="320"
+        cy="320"
+        r={40 + index * 24}
+        className="stroke-text"
+        strokeWidth="1.5"
+      />
+    ))}
+  </svg>
+);

--- a/web/src/components/landing/SelfHostCommunity.tsx
+++ b/web/src/components/landing/SelfHostCommunity.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+/**
+ * A8a — Self-host (dark editorial): data-ownership pitch, docker compose
+ * one-liner (CodeSnippet copy ✓ morph), what ships, docs links.
+ * A9 — Community: Discord card + roadmap link.
+ */
+
+import React from "react";
+import { Users } from "lucide-react";
+import CodeSnippet from "@/components/ui/CodeSnippet";
+import EditorialCard from "@/components/ui/EditorialCard";
+import { useAnalyticsController } from "@/controllers/use-analytics";
+import { EditorialDark, SectionHeading, SectionInner } from "./Section";
+import {
+  ANCHORS,
+  DISCORD_URL,
+  GITHUB_URL,
+  ROADMAP_URL,
+  SELF_HOST_DOCS_URL,
+} from "./links";
+
+export const SelfHostSection: React.FC = () => {
+  const { track } = useAnalyticsController();
+  return (
+    <EditorialDark id={ANCHORS.selfHost} className="scroll-mt-16 py-20" motif>
+      <SectionInner className="text-center">
+        <SectionHeading>
+          Self-host: your books never leave your building
+        </SectionHeading>
+        <div className="mx-auto mt-8 max-w-[460px] text-left">
+          <p className="mb-2 font-mono text-[13px] text-text-2">
+            self-host · docker
+          </p>
+          <CodeSnippet
+            code="$ docker compose up -d   # api · web · mongo · redis"
+            label="Self-host command"
+          />
+        </div>
+        <p className="mx-auto mt-8 max-w-3xl text-sm leading-relaxed text-text-2">
+          Built for firms and accountants who can’t ship financial data to
+          someone else’s cloud. One command brings up the API, web app, Mongo
+          and Redis — bring your own Groq or Gemini key, or run without AI
+          entirely.
+        </p>
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-6">
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noreferrer"
+            onClick={() => track("github_click", { source: "self_host" })}
+            className="rounded text-sm font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            github.com/cuesoftinc/expendit →
+          </a>
+          <a
+            href={SELF_HOST_DOCS_URL}
+            target="_blank"
+            rel="noreferrer"
+            onClick={() => track("self_host_click", { target: "docs" })}
+            className="rounded text-sm font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            Self-hosting docs →
+          </a>
+        </div>
+      </SectionInner>
+    </EditorialDark>
+  );
+};
+
+export const CommunitySection: React.FC = () => (
+  <section id={ANCHORS.community} className="scroll-mt-16 bg-bg py-20">
+    <SectionInner>
+      <SectionHeading>Community</SectionHeading>
+      <div className="mx-auto mt-10 flex max-w-2xl flex-col items-center gap-8 md:flex-row">
+        <EditorialCard
+          kind="community"
+          icon={Users}
+          title="Build with us on Discord"
+          body="Shape the roadmap with us — RFCs, previews and support, all in the open."
+          cta="Join Discord"
+          href={DISCORD_URL}
+          className="w-full max-w-md"
+        />
+        <a
+          href={ROADMAP_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="shrink-0 rounded text-sm font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          See the public roadmap →
+        </a>
+      </div>
+    </SectionInner>
+  </section>
+);

--- a/web/src/components/landing/TrustSections.tsx
+++ b/web/src/components/landing/TrustSections.tsx
@@ -1,0 +1,81 @@
+/**
+ * A6 — AI disclosure (dark editorial) · A7 — Security & privacy.
+ * Accuracy: AI providers are the architecture.md §4.1 registry (Groq →
+ * Gemini, or none); no invented claims.
+ */
+
+import React from "react";
+import Tag from "@/components/ui/Tag";
+import { EditorialDark, SectionHeading, SectionInner } from "./Section";
+import { PRIVACY_HUB_URL, SECURITY_POLICY_URL } from "./links";
+
+export const AiSection: React.FC = () => (
+  <EditorialDark className="py-20">
+    <SectionInner className="text-center">
+      <SectionHeading>AI that shows its work</SectionHeading>
+      <p className="mx-auto mt-4 max-w-3xl text-sm leading-relaxed text-text-2">
+        Categorization and anomaly detection run on disclosed providers — listed
+        here, not buried. ✨ marks every AI suggestion until a human confirms
+        it. Nothing files itself.
+      </p>
+      <div className="mt-6 flex justify-center">
+        <Tag tint="info" size="md">
+          AI providers are listed in Settings → Data &amp; privacy
+        </Tag>
+      </div>
+    </SectionInner>
+  </EditorialDark>
+);
+
+const SECURITY_COLUMNS = [
+  {
+    title: "Encrypted",
+    body: "At rest and in transit. Bank links are read-only via Mono.",
+  },
+  {
+    title: "Retention you control",
+    body: "Statements and artifacts have TTLs; exports are yours.",
+  },
+  {
+    title: "Delete-all rights",
+    body: "Export everything, then purge with typed confirmation.",
+  },
+];
+
+export const SecuritySection: React.FC = () => (
+  <section className="bg-bg py-20">
+    <SectionInner>
+      <SectionHeading>Security &amp; privacy, in plain language</SectionHeading>
+      <div className="mx-auto mt-10 grid max-w-4xl gap-8 md:grid-cols-3">
+        {SECURITY_COLUMNS.map((column) => (
+          <div key={column.title}>
+            <h3 className="text-base font-semibold text-text">
+              {column.title}
+            </h3>
+            <p className="mt-2 text-[13px] leading-relaxed text-text-2">
+              {column.body}
+            </p>
+          </div>
+        ))}
+      </div>
+      <div className="mt-10 flex flex-wrap items-center justify-center gap-6">
+        <a
+          href={SECURITY_POLICY_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="rounded text-sm font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          View Security Policy →
+        </a>
+        <a
+          href={PRIVACY_HUB_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="rounded text-sm font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Privacy hub →
+        </a>
+      </div>
+    </SectionInner>
+  </section>
+);

--- a/web/src/components/landing/embeds.tsx
+++ b/web/src/components/landing/embeds.tsx
@@ -1,0 +1,504 @@
+"use client";
+
+/**
+ * Product embeds — real registry compositions the marketing page frames
+ * as visuals, exactly like the Figma Home frame does (A2 hero = the B1
+ * overview template; A5a thumbs = B3b staged review / B1 overview / B7
+ * tax center minis — "real screen thumbnails", pages.md A5a). The data
+ * mirrors the seed.ts Cuesoft Ltd narrative so the visuals match the
+ * TEST_MODE dashboard the CTAs lead to.
+ *
+ * Static, render-only compositions: decorative chrome for marketing —
+ * interactive controls inside are inert (aria-hidden at the call site
+ * happens via the device frame; keyboard users tab past them).
+ */
+
+import React from "react";
+import {
+  ArrowLeftRight,
+  Calculator,
+  FileSpreadsheet,
+  FileText,
+  Gauge,
+  Landmark,
+  LayoutDashboard,
+  Settings,
+  Tag as TagIcon,
+  Upload,
+} from "lucide-react";
+import type { Org, TxnEntry } from "@/models";
+import { DEMO_DATASETS, type DemoTxn } from "@/mock/demo";
+import { formatMoney } from "@/lib/format";
+import AppNav, { NavGroupLabel, NavItem } from "@/components/ui/AppNav";
+import OrgSwitcher from "@/components/ui/OrgSwitcher";
+import PeriodPicker from "@/components/ui/PeriodPicker";
+import Banner from "@/components/ui/Banner";
+import StatCard from "@/components/ui/StatCard";
+import ChartLine from "@/components/ui/ChartLine";
+import ChartDonut from "@/components/ui/ChartDonut";
+import AnomalyBadge from "@/components/ui/AnomalyBadge";
+import TableHeader from "@/components/ui/TableHeader";
+import TxnTableRow from "@/components/ui/TxnTableRow";
+import StagedReviewHeader from "@/components/ui/StagedReviewHeader";
+import RemitToCard from "@/components/ui/RemitToCard";
+import TaxCalendarRow from "@/components/ui/TaxCalendarRow";
+import FilingHistoryRow from "@/components/ui/FilingHistoryRow";
+import DonutLegend from "./DonutLegend";
+
+/** Seed-narrative orgs (seed.ts): the embed shows the company org. */
+const EMBED_ORGS: Org[] = [
+  {
+    id: "org-cuesoft",
+    name: "Cuesoft Ltd",
+    kind: "company",
+    currency: "NGN",
+    country: "NG",
+    fiscal_year_end: "12-31",
+    created_at: "2025-11-03T09:05:00.000Z",
+  },
+];
+
+/** Converts a demo txn to the ledger entity TxnTableRow renders. */
+export const toTxnEntry = (txn: DemoTxn): TxnEntry => ({
+  id: txn.id,
+  org_id: "demo",
+  description: txn.description,
+  amount: txn.amount,
+  direction: txn.direction,
+  category_id: txn.categoryId,
+  txn_date: txn.date,
+  source: txn.source,
+  source_link_id: null,
+  ai_categorized: txn.ai ?? false,
+  excluded_from_reports: false,
+  anomalies: [],
+  created_at: txn.date,
+});
+
+const TXN_COLUMNS = [
+  { id: "date", label: "Date", sortable: true, widthClass: "w-14" },
+  { id: "src", label: "Src", widthClass: "w-8" },
+  { id: "description", label: "Description" },
+  { id: "category", label: "Category", sortable: true, widthClass: "w-28" },
+  {
+    id: "amount",
+    label: "Amount",
+    numeric: true,
+    sortable: true,
+    widthClass: "w-32",
+  },
+];
+
+export { TXN_COLUMNS };
+
+const NAV = (
+  <AppNav
+    orgSwitcher={<OrgSwitcher orgs={EMBED_ORGS} currentOrgId="org-cuesoft" />}
+  >
+    <NavItem icon={LayoutDashboard} label="Overview" active />
+    <NavItem icon={ArrowLeftRight} label="Transactions" />
+    <NavItem icon={Upload} label="Imports" />
+    <NavItem icon={Landmark} label="Accounts" />
+    <NavItem icon={FileText} label="Reports" />
+    <NavGroupLabel>Company</NavGroupLabel>
+    <NavItem icon={FileSpreadsheet} label="Statements" />
+    <NavItem icon={Gauge} label="Ratios" badgeCount={3} />
+    <NavGroupLabel>Taxes</NavGroupLabel>
+    <NavItem icon={Calculator} label="Tax center" />
+    <NavItem icon={TagIcon} label="Categories" />
+    <NavItem icon={Settings} label="Settings" />
+  </AppNav>
+);
+
+/** Latest-transactions rows in the hero embed (seed July narrative). */
+const HERO_TXNS: DemoTxn[] = [
+  {
+    id: "hero-1",
+    date: "2026-07-16",
+    description: "MTN Business — data bundles",
+    amount: 120_000,
+    direction: "expense",
+    categoryId: "utilities",
+    source: "bank",
+  },
+  {
+    id: "hero-2",
+    date: "2026-07-15",
+    description: "Paystack payout — web sales",
+    amount: 1_845_000,
+    direction: "income",
+    categoryId: "product",
+    source: "bank",
+  },
+  {
+    id: "hero-3",
+    date: "2026-07-15",
+    description: "Consulting — BlueRidge Capital",
+    amount: 1_585_200,
+    direction: "income",
+    categoryId: "consulting",
+    source: "bank",
+  },
+  {
+    id: "hero-4",
+    date: "2026-07-06",
+    description: "AWS hosting",
+    amount: 438_700,
+    direction: "expense",
+    categoryId: "cloud",
+    source: "bank",
+    ai: true,
+  },
+  {
+    id: "hero-5",
+    date: "2026-07-01",
+    description: "Office rent — July",
+    amount: 650_000,
+    direction: "expense",
+    categoryId: "rent",
+    source: "bank",
+  },
+];
+
+const HERO_CATEGORIES = {
+  utilities: { id: "utilities", name: "Utilities", color: "#B26A00" },
+  product: { id: "product", name: "Sales", color: "#1B7F4B" },
+  consulting: { id: "consulting", name: "Consulting", color: "#1B7F4B" },
+  cloud: { id: "cloud", name: "Cloud & software", color: "#6E6E76" },
+  rent: { id: "rent", name: "Rent", color: "#2456D6" },
+} as const;
+
+/*
+ * Embed design sizes mirror the Stage-4 templates (1440-wide frames);
+ * ScaledEmbed then reproduces the Figma embed scales exactly — the hero
+ * shows B1 at 1037/1440 ≈ 0.72 (Figma hero-visual 706px tall), and the
+ * A5a thumbs land at the Figma thumb heights (231 / 175 / 217 at 340w).
+ */
+export const DASHBOARD_EMBED_WIDTH = 1440;
+export const DASHBOARD_EMBED_HEIGHT = 980;
+
+/**
+ * B1 overview embed (A2 hero visual + A5a step-2 thumb) — the Figma
+ * "hero-visual — B1 embed" frame: nav rail · header + period · deadline
+ * banner · stat row (incl. runway) · cash-flow line + donut + anomaly
+ * feed · latest transactions.
+ */
+export const DashboardEmbed: React.FC = () => {
+  const company = DEMO_DATASETS.company;
+  return (
+    <div
+      className="flex h-full w-full overflow-hidden bg-bg text-left"
+      style={{ width: DASHBOARD_EMBED_WIDTH, height: DASHBOARD_EMBED_HEIGHT }}
+    >
+      {NAV}
+      <div className="min-w-0 flex-1 space-y-4 overflow-hidden p-5">
+        <div className="flex items-center justify-between gap-4">
+          <h3 className="text-lg font-semibold tracking-tight text-text">
+            Overview
+          </h3>
+          <div className="w-40">
+            <PeriodPicker mode="month" value="2026-07" />
+          </div>
+        </div>
+        <Banner
+          kind="warn"
+          action={
+            <span className="text-[13px] font-medium text-accent">
+              Prepare filing
+            </span>
+          }
+        >
+          VAT return due tomorrow — 21 Jul 2026
+        </Banner>
+        <div className="grid grid-cols-4 gap-3">
+          <StatCard
+            label="Net cash flow"
+            value={company.stats.net.value}
+            format={(value) => formatMoney(value)}
+            delta={company.stats.net.delta}
+            deltaCaption="vs Jun"
+            sparkline={company.stats.net.sparkline}
+          />
+          <StatCard
+            label="Income"
+            value={company.stats.income.value}
+            format={(value) => formatMoney(value)}
+            delta={company.stats.income.delta}
+            deltaCaption="vs Jun"
+            sparkline={company.stats.income.sparkline}
+          />
+          <StatCard
+            label="Expenses"
+            value={company.stats.expenses.value}
+            format={(value) => formatMoney(value)}
+            delta={company.stats.expenses.delta}
+            deltaCaption="vs Jun"
+            sparkline={company.stats.expenses.sparkline}
+          />
+          <StatCard
+            label="Runway"
+            value={7.2}
+            format={(value) => `${value.toFixed(1)} months`}
+            delta={0.004}
+            deltaCaption="vs Jun"
+            sparkline={[6.4, 6.6, 6.5, 6.8, 6.9, 7.0, 7.1, 7.2]}
+          />
+        </div>
+        <div className="grid grid-cols-[3fr_2fr] gap-4">
+          <div className="rounded border border-border p-4">
+            <div className="mb-2 text-[13px] font-medium text-text">
+              Cash flow — 12 months
+            </div>
+            <ChartLine
+              series={[
+                {
+                  id: "cashflow",
+                  label: "Net cash flow",
+                  color: "accent",
+                  points: company.cashflow.points,
+                },
+              ]}
+              xLabels={company.cashflow.xLabels}
+              height={180}
+            />
+          </div>
+          <div className="space-y-3">
+            <div className="rounded border border-border p-4">
+              <div className="mb-2 text-[11px] font-medium uppercase tracking-wide text-text-2">
+                Expenses by category — Jul 2026
+              </div>
+              <div className="flex items-center gap-4">
+                <ChartDonut
+                  slices={company.donut.slices}
+                  centerTotal={company.donut.centerTotal}
+                  centerCaption="Expenses"
+                  legend="none"
+                />
+                <DonutLegend
+                  slices={company.donut.slices}
+                  className="min-w-0 flex-1"
+                />
+              </div>
+            </div>
+            <div className="rounded border border-border p-3">
+              <div className="mb-2 text-[11px] font-medium uppercase tracking-wide text-text-2">
+                Anomalies
+              </div>
+              <div className="space-y-2">
+                <AnomalyBadge
+                  type="large_transaction"
+                  severity="warn"
+                  variant="feed"
+                  description="₦480,000.00 is 3.4× your median for Equipment"
+                  timestamp="6d"
+                />
+                <AnomalyBadge
+                  type="duplicate_charge"
+                  severity="info"
+                  variant="feed"
+                  description="Same amount & merchant as txn 2 minutes earlier"
+                  timestamp="12d"
+                />
+              </div>
+              <div className="mt-2 text-[11px] font-medium text-accent">
+                Explain in ledger →
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-[13px] font-medium text-text">
+              Latest transactions
+            </span>
+            <span className="text-[11px] font-medium text-accent">
+              View all →
+            </span>
+          </div>
+          <TableHeader
+            columns={TXN_COLUMNS}
+            density="compact"
+            sort={{ columnId: "date", direction: "desc" }}
+          />
+          {HERO_TXNS.map((txn) => (
+            <TxnTableRow
+              key={txn.id}
+              txn={toTxnEntry(txn)}
+              category={
+                HERO_CATEGORIES[txn.categoryId as keyof typeof HERO_CATEGORIES]
+              }
+              density="compact"
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const IMPORT_EMBED_WIDTH = 1440;
+export const IMPORT_EMBED_HEIGHT = 740;
+
+/** B3b staged-review mini (A5a step-1 thumb). */
+export const ImportReviewEmbed: React.FC = () => {
+  const freelancer = DEMO_DATASETS.freelancer;
+  return (
+    <div
+      className="flex h-full w-full overflow-hidden bg-bg text-left"
+      style={{ width: IMPORT_EMBED_WIDTH, height: IMPORT_EMBED_HEIGHT }}
+    >
+      {NAV}
+      <div className="min-w-0 flex-1 space-y-3 overflow-hidden p-5">
+        <StagedReviewHeader importCount={209} duplicateCount={5} />
+        <div>
+          <TableHeader
+            columns={TXN_COLUMNS}
+            density="compact"
+            sort={{ columnId: "date", direction: "desc" }}
+          />
+          {freelancer.txns.map((txn, index) => (
+            <TxnTableRow
+              key={txn.id}
+              txn={toTxnEntry(txn)}
+              category={
+                freelancer.categories.find(
+                  (category) => category.id === txn.categoryId,
+                ) ?? freelancer.categories[0]
+              }
+              density="compact"
+              stagedDuplicate={index === freelancer.txns.length - 1}
+            />
+          ))}
+        </div>
+        <p className="text-[13px] text-text-2">
+          209 rows will join your ledger. Discarded duplicates stay recoverable
+          for 30 days.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export const TAX_EMBED_WIDTH = 1440;
+export const TAX_EMBED_HEIGHT = 920;
+
+const FIRS = {
+  code: "FIRS",
+  name: "Federal Inland Revenue Service",
+  payment_channels: ["TaxPro-Max", "Remita"],
+};
+
+const LIRS = {
+  code: "LIRS",
+  name: "Lagos State Internal Revenue Service",
+  payment_channels: ["eTax portal"],
+};
+
+/** B7 tax-center mini (A5a step-3 thumb) — seed tax narrative. */
+export const TaxCenterEmbed: React.FC = () => (
+  <div
+    className="flex h-full w-full overflow-hidden bg-bg text-left"
+    style={{ width: TAX_EMBED_WIDTH, height: TAX_EMBED_HEIGHT }}
+  >
+    {NAV}
+    <div className="min-w-0 flex-1 space-y-4 overflow-hidden p-5">
+      <div className="flex items-center justify-between gap-4">
+        <h3 className="text-lg font-semibold tracking-tight text-text">
+          Tax center
+        </h3>
+        <span className="truncate text-[11px] text-text-2">
+          Jurisdiction: Nigeria · Lagos State · TIN 1042-6683-01 · RC 1782344
+        </span>
+      </div>
+      <Banner kind="warn">VAT return due tomorrow — 21 Jul 2026</Banner>
+      <div className="grid max-w-xl grid-cols-2 gap-3">
+        <RemitToCard
+          kind="vat"
+          authority={FIRS}
+          amountDue={550_600}
+          dueDate="2026-07-21"
+          daysToDue={1}
+        />
+        <RemitToCard
+          kind="cit"
+          authority={FIRS}
+          amountDue={6_214_900}
+          dueDate="2027-06-30"
+        />
+      </div>
+      <div>
+        <div className="mb-2 text-[11px] font-medium uppercase tracking-wide text-text-2">
+          Filing calendar
+        </div>
+        <div className="space-y-1.5">
+          <TaxCalendarRow
+            entry={{
+              kind: "vat",
+              period: "2026-06",
+              due_date: "2026-07-21",
+              authority: FIRS,
+            }}
+            daysToDue={1}
+          />
+          <TaxCalendarRow
+            entry={{
+              kind: "vat",
+              period: "2026-07",
+              due_date: "2026-08-21",
+              authority: FIRS,
+            }}
+            daysToDue={32}
+          />
+          <TaxCalendarRow
+            entry={{
+              kind: "pit",
+              period: "FY2026",
+              due_date: "2027-03-31",
+              authority: LIRS,
+            }}
+            daysToDue={254}
+          />
+        </div>
+      </div>
+      <div>
+        <div className="mb-2 text-[11px] font-medium uppercase tracking-wide text-text-2">
+          Filing history
+        </div>
+        <div className="rounded border border-border">
+          <FilingHistoryRow
+            filing={{
+              id: "tf-vat-2026-05",
+              org_id: "org-cuesoft",
+              kind: "vat",
+              period: "2026-05",
+              status: "accepted",
+              amount_due: 421_300,
+              due_date: "2026-06-21",
+              computed_fields: [],
+              authority: FIRS,
+              artifact_key: "receipts/tf-vat-2026-05.pdf",
+              filed_at: "2026-06-18T10:00:00.000Z",
+              created_at: "2026-06-15T10:00:00.000Z",
+            }}
+          />
+          <FilingHistoryRow
+            filing={{
+              id: "tf-vat-2026-04",
+              org_id: "org-cuesoft",
+              kind: "vat",
+              period: "2026-04",
+              status: "accepted",
+              amount_due: 386_750,
+              due_date: "2026-05-21",
+              computed_fields: [],
+              authority: FIRS,
+              artifact_key: "receipts/tf-vat-2026-04.pdf",
+              filed_at: "2026-05-19T10:00:00.000Z",
+              created_at: "2026-05-15T10:00:00.000Z",
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+);

--- a/web/src/components/landing/links.ts
+++ b/web/src/components/landing/links.ts
@@ -1,0 +1,39 @@
+/**
+ * Home-page link register — every external destination the Part A
+ * sections reference, in one place (no fabricated URLs: GitHub/docs come
+ * from the repo + overview.md; Discord is the CueLABS ecosystem invite;
+ * the privacy hub is the D3 ecosystem surface, architecture.md §2).
+ */
+
+export const GITHUB_URL = "https://github.com/cuesoftinc/expendit";
+export const GITHUB_ISSUES_URL = `${GITHUB_URL}/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`;
+export const CONTRIBUTING_URL = `${GITHUB_URL}/blob/main/CONTRIBUTING.md`;
+export const SECURITY_POLICY_URL = `${GITHUB_URL}/blob/main/SECURITY.md`;
+export const ROADMAP_URL = `${GITHUB_URL}/blob/main/docs/roadmap.md`;
+export const SELF_HOST_DOCS_URL = `${GITHUB_URL}/blob/main/docs/setup.md`;
+export const DOCS_URL = "https://cuesoft.gitbook.io/expendit";
+export const DISCORD_URL = "https://discord.gg/cuesoft";
+export const PRIVACY_HUB_URL = "https://privacy.cuesoft.io";
+
+/** Smooth-scrolls to a section anchor (no-op where unimplemented). */
+export const scrollToAnchor = (id: string): void => {
+  try {
+    document
+      .getElementById(id)
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+  } catch {
+    // jsdom (unit tests) has no scrollIntoView — navigation is cosmetic.
+  }
+};
+
+/** In-page section anchors (A1 nav + CTA scroll targets). */
+export const ANCHORS = {
+  product: "product",
+  demo: "demo",
+  howItWorks: "how-it-works",
+  contribute: "contribute",
+  selfHost: "self-host",
+  community: "community",
+  compare: "compare",
+  faq: "faq",
+} as const;

--- a/web/src/components/ui/Accordion.test.tsx
+++ b/web/src/components/ui/Accordion.test.tsx
@@ -32,4 +32,32 @@ describe("Accordion (design.md §8.2b, MI-8/MI-10)", () => {
     const body = screen.getByText("net_income ÷ revenue");
     expect(body.closest(".font-mono")).not.toBeNull();
   });
+
+  it("single mode keeps one item open at a time (pages.md A10a)", async () => {
+    render(<Accordion items={items} mode="single" defaultOpen={["one"]} />);
+    expect(screen.getByText("net_income ÷ revenue")).toBeVisible();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Plain section" }),
+    );
+    expect(screen.getByText("Body text")).toBeVisible();
+    expect(screen.queryByText("net_income ÷ revenue")).not.toBeInTheDocument();
+  });
+
+  it("onOpenChange reports the open set (faq_open source)", async () => {
+    const openIds: string[][] = [];
+    render(
+      <Accordion
+        items={items}
+        mode="single"
+        onOpenChange={(ids) => openIds.push(ids)}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Plain section" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Plain section" }),
+    );
+    expect(openIds).toEqual([["two"], []]);
+  });
 });

--- a/web/src/components/ui/Accordion.tsx
+++ b/web/src/components/ui/Accordion.tsx
@@ -3,7 +3,9 @@
 /**
  * Accordion — design.md §8.2b: closed / open · variant "how we got this"
  * line-item trace with a mono formula body (MI-8/MI-10). Radix Accordion
- * supplies disclosure semantics (reuse policy).
+ * supplies disclosure semantics (reuse policy). `mode="single"` keeps one
+ * item open at a time (pages.md A10a FAQ); `onOpenChange` reports the open
+ * set (the home page emits `faq_open` from it).
  */
 
 import React from "react";
@@ -23,17 +25,34 @@ export interface AccordionProps {
   items: AccordionItem[];
   /** Item ids expanded initially. */
   defaultOpen?: string[];
+  /** single = one item open at a time (A10a FAQ); default multiple. */
+  mode?: "multiple" | "single";
+  /** Fires with the currently-open item ids on every toggle. */
+  onOpenChange?: (openIds: string[]) => void;
   className?: string;
 }
 
 export const Accordion: React.FC<AccordionProps> = ({
   items,
   defaultOpen = [],
+  mode = "multiple",
+  onOpenChange,
   className,
 }) => (
   <RadixAccordion.Root
-    type="multiple"
-    defaultValue={defaultOpen}
+    {...(mode === "single"
+      ? {
+          type: "single" as const,
+          collapsible: true,
+          defaultValue: defaultOpen[0],
+          onValueChange: (value: string) =>
+            onOpenChange?.(value ? [value] : []),
+        }
+      : {
+          type: "multiple" as const,
+          defaultValue: defaultOpen,
+          onValueChange: (value: string[]) => onOpenChange?.(value),
+        })}
     className={cn(
       "divide-y divide-border rounded border border-border",
       className,

--- a/web/src/components/ui/EditorialCard.test.tsx
+++ b/web/src/components/ui/EditorialCard.test.tsx
@@ -34,4 +34,16 @@ describe("EditorialCard (design.md §8.2b)", () => {
     expect(card).toHaveAttribute("data-kind", "community");
     expect(card).toHaveClass("hover:-translate-y-0.5");
   });
+
+  it("renders the optional accent CTA line (Figma A4/A9 instances)", () => {
+    render(
+      <EditorialCard
+        title="Statements → intelligence"
+        body="Upload or link."
+        cta="Explore imports"
+        href="/signin"
+      />,
+    );
+    expect(screen.getByText("Explore imports")).toHaveClass("text-accent");
+  });
 });

--- a/web/src/components/ui/EditorialCard.tsx
+++ b/web/src/components/ui/EditorialCard.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowUpRight, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 export interface EditorialCardProps {
@@ -15,6 +15,8 @@ export interface EditorialCardProps {
   body: string;
   href?: string;
   icon?: React.ComponentType<{ className?: string }>;
+  /** Accent CTA line at the card foot (Figma A4/A9 instances). */
+  cta?: string;
   className?: string;
 }
 
@@ -25,6 +27,7 @@ export const EditorialCard: React.FC<EditorialCardProps> = ({
   body,
   href,
   icon: Icon,
+  cta,
   className,
 }) => {
   const Root: React.ElementType = href ? "a" : "div";
@@ -72,6 +75,12 @@ export const EditorialCard: React.FC<EditorialCardProps> = ({
         ) : null}
       </h3>
       <p className="mt-2 text-sm leading-relaxed text-text-2">{body}</p>
+      {cta ? (
+        <span className="mt-4 inline-flex items-center gap-1 text-[13px] font-medium text-accent">
+          {cta}
+          <ChevronRight aria-hidden className="h-3.5 w-3.5" />
+        </span>
+      ) : null}
     </Root>
   );
 };

--- a/web/src/components/ui/MarketingFooter.test.tsx
+++ b/web/src/components/ui/MarketingFooter.test.tsx
@@ -41,4 +41,16 @@ describe("MarketingFooter (design.md §8.2b)", () => {
       screen.getByRole("link", { name: /View Security Policy/ }),
     ).toHaveAttribute("href", "/security");
   });
+
+  it("renders optional brand and meta slots (Figma A11 instance)", () => {
+    render(
+      <MarketingFooter
+        columns={columns}
+        brand={<span>expendit — tagline</span>}
+        meta={<span>English</span>}
+      />,
+    );
+    expect(screen.getByText("expendit — tagline")).toBeInTheDocument();
+    expect(screen.getByText("English")).toBeInTheDocument();
+  });
 });

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -17,6 +17,10 @@ export interface MarketingFooterProps {
   columns: FooterColumn[];
   securityPolicyHref?: string;
   note?: string;
+  /** Brand block (logo + tagline) — leads the link columns (Figma A11). */
+  brand?: React.ReactNode;
+  /** Bottom-right slot beside the security CTA (e.g. language control). */
+  meta?: React.ReactNode;
   className?: string;
 }
 
@@ -24,46 +28,59 @@ export const MarketingFooter: React.FC<MarketingFooterProps> = ({
   columns,
   securityPolicyHref = "/security",
   note = "© Expendit. Open source under Cuesoft.",
+  brand,
+  meta,
   className,
 }) => (
   <footer
     data-theme="dark"
     className={cn("bg-bg-editorial px-6 py-12", className)}
   >
-    <div className="mx-auto grid max-w-[1200px] grid-cols-2 gap-8 md:grid-cols-4">
-      {columns.map((column) => (
-        <nav key={column.heading} aria-label={column.heading}>
-          <h3 className="mb-3 text-[11px] font-medium uppercase tracking-wide text-text-2">
-            {column.heading}
-          </h3>
-          <ul className="space-y-2">
-            {column.links.map((link) => (
-              <li key={link.label}>
-                <a
-                  href={link.href}
-                  className="rounded text-[13px] text-text transition-colors duration-fast ease-standard hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                >
-                  {link.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
-      ))}
+    <div
+      className={cn(
+        "mx-auto flex max-w-[1200px] flex-col gap-10",
+        brand && "md:flex-row md:justify-between",
+      )}
+    >
+      {brand ? <div className="max-w-xs">{brand}</div> : null}
+      <div className="grid grid-cols-2 gap-8 md:grid-cols-4">
+        {columns.map((column) => (
+          <nav key={column.heading} aria-label={column.heading}>
+            <h3 className="mb-3 text-[11px] font-medium uppercase tracking-wide text-text-2">
+              {column.heading}
+            </h3>
+            <ul className="space-y-2">
+              {column.links.map((link) => (
+                <li key={link.label}>
+                  <a
+                    href={link.href}
+                    className="rounded text-[13px] text-text transition-colors duration-fast ease-standard hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  >
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        ))}
+      </div>
     </div>
-    <div className="mx-auto mt-10 flex max-w-[1200px] items-center justify-between gap-4 border-t border-border pt-6">
+    <div className="mx-auto mt-10 flex max-w-[1200px] flex-wrap items-center justify-between gap-4 border-t border-border pt-6">
       <p className="text-[13px] text-text-2">{note}</p>
-      <a
-        href={securityPolicyHref}
-        className={cn(
-          "inline-flex items-center gap-1.5 rounded border border-border px-3 py-1.5 text-[13px] font-medium text-text",
-          "transition-colors duration-fast ease-standard hover:bg-bg-elev",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
-        )}
-      >
-        <ShieldCheck aria-hidden className="h-4 w-4" />
-        View Security Policy
-      </a>
+      <div className="flex items-center gap-4">
+        <a
+          href={securityPolicyHref}
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded border border-border px-3 py-1.5 text-[13px] font-medium text-text",
+            "transition-colors duration-fast ease-standard hover:bg-bg-elev",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+          )}
+        >
+          <ShieldCheck aria-hidden className="h-4 w-4" />
+          View Security Policy
+        </a>
+        {meta}
+      </div>
     </div>
   </footer>
 );

--- a/web/src/components/ui/MarketingNav.test.tsx
+++ b/web/src/components/ui/MarketingNav.test.tsx
@@ -46,6 +46,15 @@ describe("MarketingNav (design.md §8.2b)", () => {
     expect(badge.textContent).toBe("Star");
   });
 
+  it("GitHub badge click reports for analytics (github_click)", async () => {
+    const onGithubClick = vi.fn();
+    render(<MarketingNav {...props} onGithubClick={onGithubClick} />);
+    const badge = screen.getByRole("link", { name: /Star/ });
+    badge.addEventListener("click", (event) => event.preventDefault());
+    await userEvent.click(badge);
+    expect(onGithubClick).toHaveBeenCalled();
+  });
+
   it("Sign in + Try Cloud CTAs fire", async () => {
     const onSignIn = vi.fn();
     const onTryCloud = vi.fn();

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -28,6 +28,8 @@ export interface MarketingNavProps {
   links?: MarketingNavLink[];
   solutions?: MarketingNavLink[];
   githubHref?: string;
+  /** Analytics hook for the GitHub badge (pages.md `github_click`). */
+  onGithubClick?: () => void;
   onSignIn?: () => void;
   onTryCloud?: () => void;
   className?: string;
@@ -50,6 +52,7 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
   links = [],
   solutions = [],
   githubHref = "https://github.com/cuesoftinc/expendit",
+  onGithubClick,
   onSignIn,
   onTryCloud,
   className,
@@ -104,7 +107,8 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
       </Link>
 
       {solutions.length > 0 ? (
-        <div ref={solutionsRef} className="relative">
+        // Text items collapse below md (375w floor keeps logo + CTAs).
+        <div ref={solutionsRef} className="relative hidden md:block">
           <button
             type="button"
             aria-expanded={solutionsOpen}
@@ -142,7 +146,11 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
       ) : null}
 
       {links.map((link) => (
-        <a key={link.label} href={link.href} className={itemClass}>
+        <a
+          key={link.label}
+          href={link.href}
+          className={cn(itemClass, "hidden md:inline-block")}
+        >
           {link.label}
         </a>
       ))}
@@ -153,6 +161,7 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
           href={githubHref}
           target="_blank"
           rel="noreferrer"
+          onClick={onGithubClick}
           className={cn(
             "inline-flex items-center gap-1.5 rounded border border-border px-2.5 py-1 text-[13px] font-medium text-text",
             "transition-colors duration-fast ease-standard hover:bg-bg-elev",

--- a/web/src/controllers/use-analytics.test.ts
+++ b/web/src/controllers/use-analytics.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  trackEvent,
+  useAnalyticsController,
+  usePageView,
+} from "./use-analytics";
+
+describe("analytics controller (pages.md Part A events, TEST_MODE-safe)", () => {
+  beforeEach(() => {
+    window.__expenditEvents = [];
+  });
+
+  it("queues events on window.__expenditEvents", () => {
+    trackEvent("try_cloud_click", { source: "hero" });
+    expect(window.__expenditEvents).toHaveLength(1);
+    expect(window.__expenditEvents?.[0]).toMatchObject({
+      event: "try_cloud_click",
+      props: { source: "hero" },
+    });
+  });
+
+  it("does not beacon in TEST_MODE (the only network seam)", () => {
+    const sendBeacon = vi.fn();
+    Object.defineProperty(navigator, "sendBeacon", {
+      value: sendBeacon,
+      writable: true,
+      configurable: true,
+    });
+    trackEvent("github_click");
+    expect(sendBeacon).not.toHaveBeenCalled();
+  });
+
+  it("controller track() lands on the queue", () => {
+    const { result } = renderHook(() => useAnalyticsController());
+    result.current.track("faq_open", { question: "license" });
+    expect(window.__expenditEvents?.at(-1)).toMatchObject({
+      event: "faq_open",
+      props: { question: "license" },
+    });
+  });
+
+  it("usePageView emits page_view once per mount", () => {
+    const { rerender } = renderHook(() => usePageView("home"));
+    rerender();
+    const pageViews = window.__expenditEvents?.filter(
+      (record) => record.event === "page_view",
+    );
+    expect(pageViews).toHaveLength(1);
+    expect(pageViews?.[0]?.props).toEqual({ page: "home" });
+  });
+});

--- a/web/src/controllers/use-analytics.ts
+++ b/web/src/controllers/use-analytics.ts
@@ -1,0 +1,82 @@
+"use client";
+
+/**
+ * Analytics controller — the pages.md Part A event register, emitted
+ * toward Upstat (D2, architecture.md §7). Payloads are counters + coarse
+ * dimensions only — never amounts, descriptions, or categories
+ * (data-model.md privacy rule).
+ *
+ * TEST_MODE-safe seam: events always land on an in-page queue
+ * (window.__expenditEvents) that unit/e2e tests assert against; the
+ * network beacon fires only outside TEST_MODE and only when the Upstat
+ * ingestion endpoint is configured (NEXT_PUBLIC_UPSTAT_EVENTS_URL — the
+ * D2 contract is not yet ratified, so the default build ships queue-only).
+ */
+
+import { useCallback, useEffect } from "react";
+import { isTestMode } from "@/config/env";
+
+export type AnalyticsEvent =
+  | "page_view"
+  | "try_cloud_click"
+  | "self_host_click"
+  | "github_click"
+  | "demo_interact"
+  | "contribute_click"
+  | "faq_open";
+
+/** Coarse dimensions only (strings) — the D2 privacy rule. */
+export type AnalyticsProps = Record<string, string>;
+
+export interface AnalyticsRecord {
+  event: AnalyticsEvent;
+  props: AnalyticsProps;
+  ts: number;
+}
+
+declare global {
+  interface Window {
+    __expenditEvents?: AnalyticsRecord[];
+  }
+}
+
+const QUEUE_LIMIT = 200;
+
+const upstatUrl = (): string | undefined =>
+  process.env.NEXT_PUBLIC_UPSTAT_EVENTS_URL;
+
+export const trackEvent = (
+  event: AnalyticsEvent,
+  props: AnalyticsProps = {},
+): void => {
+  if (typeof window === "undefined") return;
+  const record: AnalyticsRecord = { event, props, ts: Date.now() };
+
+  const queue = (window.__expenditEvents ??= []);
+  queue.push(record);
+  if (queue.length > QUEUE_LIMIT) queue.splice(0, queue.length - QUEUE_LIMIT);
+
+  const url = upstatUrl();
+  if (!isTestMode() && url && typeof navigator.sendBeacon === "function") {
+    navigator.sendBeacon(url, JSON.stringify(record));
+  }
+};
+
+export interface AnalyticsController {
+  track: (event: AnalyticsEvent, props?: AnalyticsProps) => void;
+}
+
+export const useAnalyticsController = (): AnalyticsController => ({
+  track: useCallback(
+    (event: AnalyticsEvent, props: AnalyticsProps = {}) =>
+      trackEvent(event, props),
+    [],
+  ),
+});
+
+/** Emits `page_view` once per mount (pages.md Part A event register). */
+export const usePageView = (page: string): void => {
+  useEffect(() => {
+    trackEvent("page_view", { page });
+  }, [page]);
+};

--- a/web/src/controllers/use-github-stars.test.ts
+++ b/web/src/controllers/use-github-stars.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { formatStars, useGithubStarsController } from "./use-github-stars";
+
+describe("github stars controller (A8 runtime count + neutral fallback)", () => {
+  it("TEST_MODE: never fetches; badge stays neutral (stars = null)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { result } = renderHook(() => useGithubStarsController());
+    // Effect ran; TEST_MODE short-circuits before any network call.
+    await waitFor(() => expect(result.current.stars).toBeNull());
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("formatStars renders compact counts", () => {
+    expect(formatStars(87)).toBe("87");
+    expect(formatStars(1000)).toBe("1k");
+    expect(formatStars(1234)).toBe("1.2k");
+  });
+});

--- a/web/src/controllers/use-github-stars.ts
+++ b/web/src/controllers/use-github-stars.ts
@@ -1,0 +1,64 @@
+"use client";
+
+/**
+ * GitHub stars controller — the A8 badge count is populated at runtime,
+ * never baked into designs or copy (pages.md A8; the A1 nav badge stays
+ * neutral "Star" — design.md §8.2b as-built). Falls back to the neutral
+ * label when the fetch fails or in TEST_MODE (Playwright must not hit
+ * the network).
+ */
+
+import { useEffect, useState } from "react";
+import { isTestMode } from "@/config/env";
+
+export const GITHUB_REPO = "cuesoftinc/expendit";
+
+/** Module cache — one fetch per session. */
+let cachedStars: number | null | undefined;
+
+export const formatStars = (stars: number): string =>
+  stars >= 1000
+    ? `${(stars / 1000).toFixed(1).replace(/\.0$/, "")}k`
+    : `${stars}`;
+
+export interface GithubStarsController {
+  /** null = unknown → callers render the neutral "Star on GitHub". */
+  stars: number | null;
+}
+
+export const useGithubStarsController = (
+  repo: string = GITHUB_REPO,
+): GithubStarsController => {
+  const [stars, setStars] = useState<number | null>(
+    typeof cachedStars === "number" ? cachedStars : null,
+  );
+
+  useEffect(() => {
+    if (
+      isTestMode() ||
+      cachedStars !== undefined ||
+      typeof fetch !== "function"
+    )
+      return;
+    let cancelled = false;
+    fetch(`https://api.github.com/repos/${repo}`)
+      .then((response) => (response.ok ? response.json() : null))
+      .then((data: { stargazers_count?: unknown } | null) => {
+        const count =
+          typeof data?.stargazers_count === "number"
+            ? data.stargazers_count
+            : null;
+        cachedStars = count;
+        if (!cancelled && count !== null) setStars(count);
+      })
+      .catch(() => {
+        // Neutral fallback — the badge stays "Star on GitHub".
+        cachedStars = null;
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo]);
+
+  return { stars };
+};

--- a/web/src/controllers/use-home-demo.test.ts
+++ b/web/src/controllers/use-home-demo.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useHomeDemoController } from "./use-home-demo";
+
+const events = () => window.__expenditEvents ?? [];
+
+describe("home demo controller (A5 — personas over the §8.3 datasets)", () => {
+  beforeEach(() => {
+    window.__expenditEvents = [];
+  });
+
+  it("boots on the freelancer dataset (the Figma A5 strip)", () => {
+    const { result } = renderHook(() => useHomeDemoController());
+    expect(result.current.persona).toBe("freelancer");
+    expect(result.current.dataset.stats.income.value).toBe(1_480_000);
+  });
+
+  it("switching persona swaps the dataset and emits demo_interact", () => {
+    const { result } = renderHook(() => useHomeDemoController());
+    act(() => result.current.switchPersona("company"));
+    expect(result.current.dataset.stats.income.value).toBe(8_435_200);
+    expect(events().at(-1)).toMatchObject({
+      event: "demo_interact",
+      props: { action: "switch_persona", persona: "company" },
+    });
+  });
+
+  it("recategorize applies a local override, clears ✨, and emits", () => {
+    const { result } = renderHook(() => useHomeDemoController());
+    const aiTxn = result.current.txns.find((txn) => txn.ai);
+    expect(aiTxn).toBeDefined();
+    act(() => result.current.recategorize(aiTxn!.id, "other"));
+    const updated = result.current.txns.find((txn) => txn.id === aiTxn!.id);
+    expect(updated?.categoryId).toBe("other");
+    expect(updated?.ai).toBe(false);
+    expect(events().at(-1)).toMatchObject({
+      event: "demo_interact",
+      props: { action: "recategorize", persona: "freelancer" },
+    });
+  });
+
+  it("overrides are per-persona and survive a round-trip", () => {
+    const { result } = renderHook(() => useHomeDemoController());
+    act(() => result.current.recategorize("fl-1", "other"));
+    act(() => result.current.switchPersona("sme"));
+    expect(
+      result.current.txns.find((txn) => txn.id === "fl-1"),
+    ).toBeUndefined();
+    act(() => result.current.switchPersona("freelancer"));
+    expect(
+      result.current.txns.find((txn) => txn.id === "fl-1")?.categoryId,
+    ).toBe("other");
+  });
+
+  it("data-table toggle flips and emits demo_interact", () => {
+    const { result } = renderHook(() => useHomeDemoController());
+    expect(result.current.showDataTable).toBe(false);
+    act(() => result.current.toggleDataTable());
+    expect(result.current.showDataTable).toBe(true);
+    expect(events().at(-1)).toMatchObject({
+      event: "demo_interact",
+      props: { action: "toggle_data_table", state: "table" },
+    });
+  });
+});

--- a/web/src/controllers/use-home-demo.ts
+++ b/web/src/controllers/use-home-demo.ts
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Home demo controller — the A5 interactive preview (EXP-001): persona
+ * tabs over the three §8.3 synthetic datasets, CRUD-light recategorize
+ * on the demo rows (MI-4 chip combobox), and the data-table toggle for
+ * the cash-flow chart (design.md §5 chart parity). Views render only;
+ * every interaction emits `demo_interact` (pages.md event register).
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  DEMO_DATASETS,
+  type DemoDataset,
+  type DemoPersona,
+  type DemoTxn,
+} from "@/mock/demo";
+import { useAnalyticsController } from "./use-analytics";
+
+/** Per-persona category overrides from demo recategorize actions. */
+type Overrides = Partial<Record<DemoPersona, Record<string, string>>>;
+
+export interface HomeDemoController {
+  persona: DemoPersona;
+  dataset: DemoDataset;
+  /** Demo txns with local recategorize overrides applied. */
+  txns: DemoTxn[];
+  showDataTable: boolean;
+  switchPersona: (persona: DemoPersona) => void;
+  recategorize: (txnId: string, categoryId: string) => void;
+  toggleDataTable: () => void;
+}
+
+export const useHomeDemoController = (): HomeDemoController => {
+  const { track } = useAnalyticsController();
+  const [persona, setPersona] = useState<DemoPersona>("freelancer");
+  const [overrides, setOverrides] = useState<Overrides>({});
+  const [showDataTable, setShowDataTable] = useState(false);
+
+  const dataset = DEMO_DATASETS[persona];
+
+  const txns = useMemo(() => {
+    const personaOverrides = overrides[persona] ?? {};
+    return dataset.txns.map((txn) => {
+      const categoryId = personaOverrides[txn.id];
+      // Human confirm clears the ✨ (MI-4).
+      return categoryId ? { ...txn, categoryId, ai: false } : txn;
+    });
+  }, [dataset, overrides, persona]);
+
+  const switchPersona = useCallback(
+    (next: DemoPersona) => {
+      setPersona(next);
+      track("demo_interact", { action: "switch_persona", persona: next });
+    },
+    [track],
+  );
+
+  const recategorize = useCallback(
+    (txnId: string, categoryId: string) => {
+      setOverrides((prev) => ({
+        ...prev,
+        [persona]: { ...prev[persona], [txnId]: categoryId },
+      }));
+      track("demo_interact", { action: "recategorize", persona });
+    },
+    [persona, track],
+  );
+
+  const toggleDataTable = useCallback(() => {
+    // Track outside the updater — updaters must stay pure (Strict Mode
+    // double-invokes them).
+    const next = !showDataTable;
+    setShowDataTable(next);
+    track("demo_interact", {
+      action: "toggle_data_table",
+      state: next ? "table" : "chart",
+    });
+  }, [showDataTable, track]);
+
+  return {
+    persona,
+    dataset,
+    txns,
+    showDataTable,
+    switchPersona,
+    recategorize,
+    toggleDataTable,
+  };
+};

--- a/web/src/design/tokens.css
+++ b/web/src/design/tokens.css
@@ -60,6 +60,26 @@
   --row-comfortable: 44px;
 }
 
+/*
+ * Light re-declaration for nested scoping: a light subtree inside a dark
+ * editorial section (the A2 hero device frame) re-binds the same §2 Light
+ * values. Same collection, no new tokens — scoping mechanics only.
+ */
+[data-theme="light"] {
+  --color-bg: #ffffff;
+  --color-bg-editorial: #0c0c0e;
+  --color-bg-elev: #f7f7f8;
+  --color-border: #e5e5e7;
+  --color-text: #111113;
+  --color-text-2: #6e6e76;
+  --color-accent: #f46a1f;
+  --color-on-accent: #ffffff;
+  --color-income: #1b7f4b;
+  --color-expense: #c6373c;
+  --color-warn: #b26a00;
+  --color-info: #2456d6;
+}
+
 /* Dark theme values (design.md §2, Dark column). */
 [data-theme="dark"] {
   --color-bg: #0c0c0e;

--- a/web/src/mock/demo.test.ts
+++ b/web/src/mock/demo.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { DEMO_DATASETS, DEMO_PERSONAS } from "./demo";
+
+/**
+ * §8.3 synthetic demo datasets — internal-consistency contract: the A5
+ * strip must never show numbers that disagree with each other (design.md
+ * as-built note: per-persona internally consistent datasets).
+ */
+describe("demo datasets (design.md §8.3 ×3)", () => {
+  it("ships all three personas", () => {
+    expect(DEMO_PERSONAS).toEqual(["freelancer", "sme", "company"]);
+    for (const persona of DEMO_PERSONAS) {
+      expect(DEMO_DATASETS[persona].persona).toBe(persona);
+    }
+  });
+
+  it.each(DEMO_PERSONAS)("%s: net = income − expenses", (persona) => {
+    const { stats } = DEMO_DATASETS[persona];
+    expect(stats.net.value).toBe(stats.income.value - stats.expenses.value);
+  });
+
+  it.each(DEMO_PERSONAS)(
+    "%s: donut slices sum to the expenses stat",
+    (persona) => {
+      const { donut, stats } = DEMO_DATASETS[persona];
+      const total = donut.slices.reduce((sum, slice) => sum + slice.value, 0);
+      expect(total).toBe(stats.expenses.value);
+    },
+  );
+
+  it.each(DEMO_PERSONAS)(
+    "%s: every txn references a registry category",
+    (persona) => {
+      const { categories, txns } = DEMO_DATASETS[persona];
+      const ids = new Set(categories.map((category) => category.id));
+      for (const txn of txns) {
+        expect(ids.has(txn.categoryId)).toBe(true);
+      }
+    },
+  );
+
+  it.each(DEMO_PERSONAS)("%s: 12-month cash-flow series", (persona) => {
+    expect(DEMO_DATASETS[persona].cashflow.points).toHaveLength(12);
+  });
+
+  it("company dataset mirrors the seed narrative (seed.ts July 2026 MTD)", () => {
+    const { stats } = DEMO_DATASETS.company;
+    expect(stats.income.value).toBe(8_435_200);
+    expect(stats.expenses.value).toBe(3_614_800);
+    expect(stats.net.value).toBe(4_820_400);
+  });
+});

--- a/web/src/mock/demo.ts
+++ b/web/src/mock/demo.ts
@@ -1,0 +1,386 @@
+/**
+ * A5 demo datasets — the design.md §8.3 synthetic demo pool ×3
+ * (freelancer / SME / company), the same narrative the Figma Home frame
+ * (193:14) and the mock-server seed render. The freelancer dataset is the
+ * Figma A5 strip verbatim; the company dataset mirrors the seed.ts Cuesoft
+ * Ltd July-2026 narrative exactly (income ₦8,435,200 / expenses ₦3,614,800
+ * / runway 7.2 months); the SME dataset is crafted in the same style.
+ *
+ * Static module (no network): the public home renders in both TEST_MODE
+ * and production, so the demo strip cannot depend on the authenticated
+ * mock endpoints. Every dataset is internally consistent (unit-tested):
+ * net = income − expenses and the donut slices sum to the expenses stat.
+ *
+ * Category colors are user data, not design tokens (same rule as seed.ts).
+ */
+
+import type { TxnDirection, TxnSource } from "@/models";
+
+export type DemoPersona = "freelancer" | "sme" | "company";
+
+export const DEMO_PERSONAS: DemoPersona[] = ["freelancer", "sme", "company"];
+
+export interface DemoCategory {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export interface DemoTxn {
+  id: string;
+  /** ISO date. */
+  date: string;
+  description: string;
+  amount: number;
+  direction: TxnDirection;
+  categoryId: string;
+  source: TxnSource;
+  /** AI-suggested, not yet human-confirmed (CategoryChip ✨). */
+  ai?: boolean;
+}
+
+export interface DemoStat {
+  label: string;
+  value: number;
+  /** Delta vs previous month, as a fraction (MI-7 delta chip). */
+  delta: number;
+  sparkline: number[];
+}
+
+export interface DemoDonutSlice {
+  id: string;
+  label: string;
+  value: number;
+  color: string;
+}
+
+export interface DemoDataset {
+  persona: DemoPersona;
+  label: string;
+  currency: "NGN";
+  deltaCaption: string;
+  stats: { net: DemoStat; income: DemoStat; expenses: DemoStat };
+  /** 12-month cash-flow series (single accent line, Figma A5). */
+  cashflow: { points: number[]; xLabels: string[] };
+  donut: { slices: DemoDonutSlice[]; centerTotal: string };
+  categories: DemoCategory[];
+  txns: DemoTxn[];
+}
+
+/** Six x ticks over the trailing 12 months (Figma: Aug…Jun). */
+const X_LABELS = ["Aug", "Oct", "Dec", "Feb", "Apr", "Jun"];
+
+const FREELANCER: DemoDataset = {
+  persona: "freelancer",
+  label: "Freelancer",
+  currency: "NGN",
+  deltaCaption: "vs Jun",
+  stats: {
+    net: {
+      label: "Net cash flow",
+      value: 968_000,
+      delta: 0.124,
+      sparkline: [640, 690, 655, 720, 760, 745, 810, 968],
+    },
+    income: {
+      label: "Income",
+      value: 1_480_000,
+      delta: 0.081,
+      sparkline: [1_120, 1_180, 1_150, 1_240, 1_300, 1_280, 1_369, 1_480],
+    },
+    expenses: {
+      label: "Expenses",
+      value: 512_000,
+      delta: 0.034,
+      sparkline: [430, 445, 460, 452, 470, 488, 495, 512],
+    },
+  },
+  cashflow: {
+    points: [
+      520_000, 610_000, 580_000, 700_000, 760_000, 720_000, 830_000, 905_000,
+      860_000, 940_000, 900_000, 968_000,
+    ],
+    xLabels: X_LABELS,
+  },
+  donut: {
+    slices: [
+      { id: "equipment", label: "Equipment", value: 204_800, color: "#F46A1F" },
+      { id: "utilities", label: "Utilities", value: 128_000, color: "#2456D6" },
+      { id: "transport", label: "Transport", value: 102_400, color: "#B26A00" },
+      { id: "other", label: "Other", value: 76_800, color: "#6E6E76" },
+    ],
+    centerTotal: "₦512K",
+  },
+  categories: [
+    { id: "equipment", name: "Equipment", color: "#F46A1F" },
+    { id: "utilities", name: "Utilities", color: "#2456D6" },
+    { id: "transport", name: "Transport", color: "#B26A00" },
+    { id: "other", name: "Other", color: "#6E6E76" },
+    { id: "sales", name: "Sales", color: "#1B7F4B" },
+  ],
+  txns: [
+    {
+      id: "fl-1",
+      date: "2026-07-16",
+      description: "MTN — data bundle top-up",
+      amount: 24_500,
+      direction: "expense",
+      categoryId: "utilities",
+      source: "bank",
+      ai: true,
+    },
+    {
+      id: "fl-2",
+      date: "2026-07-15",
+      description: "Paystack payout — client invoice #041",
+      amount: 420_000,
+      direction: "income",
+      categoryId: "sales",
+      source: "csv",
+    },
+    {
+      id: "fl-3",
+      date: "2026-07-15",
+      description: "Jumia — laptop stand",
+      amount: 38_500,
+      direction: "expense",
+      categoryId: "equipment",
+      source: "receipt",
+      ai: true,
+    },
+    {
+      id: "fl-4",
+      date: "2026-07-14",
+      description: "Ikeja Electric — studio meter",
+      amount: 18_200,
+      direction: "expense",
+      categoryId: "utilities",
+      source: "bank",
+    },
+    {
+      id: "fl-5",
+      date: "2026-07-12",
+      description: "Bolt — client meetings",
+      amount: 12_300,
+      direction: "expense",
+      categoryId: "transport",
+      source: "manual",
+      ai: true,
+    },
+  ],
+};
+
+const SME: DemoDataset = {
+  persona: "sme",
+  label: "SME",
+  currency: "NGN",
+  deltaCaption: "vs Jun",
+  stats: {
+    net: {
+      label: "Net cash flow",
+      value: 1_770_000,
+      delta: 0.096,
+      sparkline: [1_310, 1_420, 1_380, 1_490, 1_560, 1_540, 1_615, 1_770],
+    },
+    income: {
+      label: "Income",
+      value: 4_150_000,
+      delta: 0.052,
+      sparkline: [3_420, 3_510, 3_480, 3_640, 3_760, 3_820, 3_945, 4_150],
+    },
+    expenses: {
+      label: "Expenses",
+      value: 2_380_000,
+      delta: 0.021,
+      sparkline: [2_140, 2_180, 2_210, 2_190, 2_260, 2_300, 2_331, 2_380],
+    },
+  },
+  cashflow: {
+    points: [
+      1_050_000, 1_240_000, 1_180_000, 1_360_000, 1_450_000, 1_400_000,
+      1_520_000, 1_610_000, 1_560_000, 1_680_000, 1_640_000, 1_770_000,
+    ],
+    xLabels: X_LABELS,
+  },
+  donut: {
+    slices: [
+      { id: "payroll", label: "Payroll", value: 1_047_200, color: "#F46A1F" },
+      { id: "rent", label: "Rent", value: 595_000, color: "#2456D6" },
+      {
+        id: "cloud",
+        label: "Cloud & software",
+        value: 452_200,
+        color: "#B26A00",
+      },
+      { id: "other", label: "Other", value: 285_600, color: "#6E6E76" },
+    ],
+    centerTotal: "₦2.38M",
+  },
+  categories: [
+    { id: "payroll", name: "Payroll", color: "#F46A1F" },
+    { id: "rent", name: "Rent", color: "#2456D6" },
+    { id: "cloud", name: "Cloud & software", color: "#B26A00" },
+    { id: "other", name: "Other", color: "#6E6E76" },
+    { id: "client-income", name: "Client income", color: "#1B7F4B" },
+  ],
+  txns: [
+    {
+      id: "sme-1",
+      date: "2026-07-17",
+      description: "Retainer — Halcyon Studios",
+      amount: 1_500_000,
+      direction: "income",
+      categoryId: "client-income",
+      source: "bank",
+    },
+    {
+      id: "sme-2",
+      date: "2026-07-15",
+      description: "Payroll — July, 6 staff",
+      amount: 1_047_200,
+      direction: "expense",
+      categoryId: "payroll",
+      source: "bank",
+    },
+    {
+      id: "sme-3",
+      date: "2026-07-11",
+      description: "Figma — annual seats",
+      amount: 214_000,
+      direction: "expense",
+      categoryId: "cloud",
+      source: "csv",
+      ai: true,
+    },
+    {
+      id: "sme-4",
+      date: "2026-07-08",
+      description: "Invoice #118 — Larder & Co",
+      amount: 850_000,
+      direction: "income",
+      categoryId: "client-income",
+      source: "csv",
+    },
+    {
+      id: "sme-5",
+      date: "2026-07-01",
+      description: "Office rent — Yaba",
+      amount: 595_000,
+      direction: "expense",
+      categoryId: "rent",
+      source: "bank",
+      ai: true,
+    },
+  ],
+};
+
+/** Mirrors the seed.ts Cuesoft Ltd narrative (July 2026 MTD). */
+const COMPANY: DemoDataset = {
+  persona: "company",
+  label: "Company",
+  currency: "NGN",
+  deltaCaption: "vs Jun",
+  stats: {
+    net: {
+      label: "Net cash flow",
+      value: 4_820_400,
+      delta: 0.124,
+      sparkline: [3_320, 3_580, 3_460, 3_780, 4_010, 3_940, 4_290, 4_820],
+    },
+    income: {
+      label: "Income",
+      value: 8_435_200,
+      delta: 0.081,
+      sparkline: [6_540, 6_820, 6_700, 7_180, 7_460, 7_380, 7_803, 8_435],
+    },
+    expenses: {
+      label: "Expenses",
+      value: 3_614_800,
+      delta: 0.034,
+      sparkline: [3_180, 3_240, 3_300, 3_280, 3_390, 3_460, 3_496, 3_615],
+    },
+  },
+  cashflow: {
+    points: [
+      2_450_000, 2_980_000, 2_760_000, 3_340_000, 3_620_000, 3_410_000,
+      3_890_000, 4_240_000, 4_050_000, 4_510_000, 4_380_000, 4_820_400,
+    ],
+    xLabels: X_LABELS,
+  },
+  donut: {
+    slices: [
+      {
+        id: "inventory",
+        label: "Inventory",
+        value: 1_373_600,
+        color: "#F46A1F",
+      },
+      { id: "rent", label: "Rent", value: 1_012_100, color: "#2456D6" },
+      { id: "utilities", label: "Utilities", value: 795_300, color: "#B26A00" },
+      { id: "other", label: "Other", value: 433_800, color: "#6E6E76" },
+    ],
+    centerTotal: "₦3.61M",
+  },
+  categories: [
+    { id: "inventory", name: "Inventory", color: "#F46A1F" },
+    { id: "rent", name: "Rent", color: "#2456D6" },
+    { id: "utilities", name: "Utilities", color: "#B26A00" },
+    { id: "cloud", name: "Cloud & software", color: "#6E6E76" },
+    { id: "consulting", name: "Consulting income", color: "#1B7F4B" },
+    { id: "product", name: "Product income", color: "#1B7F4B" },
+  ],
+  txns: [
+    {
+      id: "co-1",
+      date: "2026-07-18",
+      description: "Retainer — Kudaworks",
+      amount: 3_200_000,
+      direction: "income",
+      categoryId: "consulting",
+      source: "bank",
+    },
+    {
+      id: "co-2",
+      date: "2026-07-15",
+      description: "Consulting — BlueRidge Capital",
+      amount: 1_585_200,
+      direction: "income",
+      categoryId: "consulting",
+      source: "bank",
+    },
+    {
+      id: "co-3",
+      date: "2026-07-08",
+      description: "Invoice #2041 — Nairaflow",
+      amount: 2_850_000,
+      direction: "income",
+      categoryId: "product",
+      source: "csv",
+    },
+    {
+      id: "co-4",
+      date: "2026-07-06",
+      description: "AWS hosting",
+      amount: 438_700,
+      direction: "expense",
+      categoryId: "cloud",
+      source: "bank",
+      ai: true,
+    },
+    {
+      id: "co-5",
+      date: "2026-07-01",
+      description: "Office rent — July",
+      amount: 650_000,
+      direction: "expense",
+      categoryId: "rent",
+      source: "bank",
+    },
+  ],
+};
+
+export const DEMO_DATASETS: Record<DemoPersona, DemoDataset> = {
+  freelancer: FREELANCER,
+  sme: SME,
+  company: COMPANY,
+};


### PR DESCRIPTION
## W2 — Public home `/` (pages.md Part A, Brex-editorial)

Replaces the MUI-era marketing page at `/` with the Part A landing, composed entirely from the W1 ui registry and QA'd against the Figma Home frame (`193:14`).

### Sections (A1 → A11)
- **A1 nav** — MarketingNav on-dark over the hero; sticky dark-on-light variant fades in after hero scroll; neutral **Star** badge (no count).
- **A2 hero** — "See every naira. File every tax." (Hero display type), dual **Try Cloud / Self Host** CTAs, "Open source · MIT licensed" caption, and the **real B1 overview composition** in a device frame at the exact Figma embed scale (1440-wide template × 0.72 via `ScaledEmbed`); one-shot categorization-chip animation, static under reduced motion.
- **A3 logos** — text-only strip ("banks and tools Nigerian businesses already use"), no endorsements implied.
- **A4 pillars** — three EditorialCards with accent CTA lines.
- **A4a deep-dives** — five alternating editorial splits with **live registry stills** (import-complete card, AnomalyBadge feed, RatioGauge, RemitToCard, ReportArtifactRow), scroll-into-view reveal.
- **A5 demo** — persona **Tabs over the three §8.3 synthetic datasets** + "This is demo data" Tag; MI-7 count-up StatCards, cash-flow line **with data-table parity toggle**, donut + amount legend, and a txn table with **CRUD-light inline recategorize** (MI-4, ✨ clears on confirm). Freelancer dataset is the Figma strip verbatim; company mirrors the mock-seed narrative (₦8,435,200 / ₦3,614,800 / net ₦4,820,400); all three are consistency-tested.
- **A5a how-it-works** — three numbered steps with **real screen thumbnails** (B3b staged review / B1 overview / B7 tax center compositions at the Figma thumb scales); thumbnail click scrolls to the A5 demo.
- **A6 AI disclosure** (dark) — Groq/Gemini provider registry per architecture.md; ✨-until-confirmed; "Nothing files itself."
- **A7 security** — encrypted / retention / delete-all columns; Security Policy + privacy-hub links.
- **A8 contribute** — stack line, **architecture mini-diagram** (web → api → mongo/redis, tokens only), problems list, good-first-issue tags, CONTRIBUTING link, GitHub badge with **runtime star count** (neutral fallback; never fetched in TEST_MODE).
- **A8a self-host** (dark) — `docker compose up -d` CodeSnippet (copy ✓ morph), data-ownership pitch, docs links.
- **A9 community** — Discord card + public-roadmap link.
- **A10 comparison** — Cloud vs Self-host; pricing is **only** "Announced at GA" / "Free forever" + caption (marketing-accuracy note).
- **A10a FAQ** — Accordion, **one open at a time**, `faq_open` events.
- **A10b final CTA** — dark band re-emitting the A2 events. **A11** MarketingFooter with brand block + security CTA.

### Analytics (→ Upstat D2, TEST_MODE-safe)
`page_view · try_cloud_click · self_host_click · github_click · demo_interact · contribute_click · faq_open` — always land on an in-page queue (asserted in unit + e2e); the network beacon fires only outside TEST_MODE **and** only when `NEXT_PUBLIC_UPSTAT_EVENTS_URL` is set (D2 contract not yet ratified). Coarse dimensions only — never amounts/descriptions.

### Registry extensions (additive, unit-tested)
- `Accordion`: `mode="single"` (one-open-at-a-time) + `onOpenChange`
- `MarketingFooter`: optional `brand` / `meta` slots (Figma A11 instance)
- `EditorialCard`: optional `cta` accent line (Figma A4/A9 instances)
- `MarketingNav`: `onGithubClick` analytics hook; text links collapse below `md` (375w floor)
- `tokens.css`: `[data-theme="light"]` re-declaration so a light subtree (hero device frame) can nest inside a dark editorial section — scoping mechanics only, no token value changes

### Tests
- Vitest: **313 passing** (demo-dataset consistency, analytics/demo/stars controllers, DemoSection, FaqSection, HomeView, extended registry axes)
- Playwright `e2e/home.spec.ts`: sections render · persona tabs switch datasets · FAQ one-at-a-time · CTA handoff into `/signin` · Self-Host scroll · 375w no-overflow — **9/9 green** with the existing signin journey
- `playwright.config.ts` gains `PW_PORT` override (local port-collision escape hatch; CI unchanged on 3100)
- Legacy Jest `__tests__/index.test.tsx` updated to the new hero (route-level test)

### Orphaned legacy (for the W3 quarantine tranche — not touched here)
`web/src/components/marketing/**`, `web/src/hooks/marketing/**`, marketing-only assets under `web/src/assets/images`, and `web/__tests__/home.test.tsx` (renders the old hero). `slick-carousel` CSS + extra Google Fonts in `layout.tsx` are shared with the legacy dashboard and retire with it.

### Gates
lint 0 errors · typecheck ✓ · `next build` ✓ · Jest 2/2 · Vitest 313/313 · Playwright 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)