### PR TITLE
docs(design): pin the 1200px landing container [Decided 2026-07-19]

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -56,6 +56,15 @@
 ### Layout
 
 - Marketing: 12-col, max 1200px; alternating light/dark full-bleed sections.
+  **Container pin [Decided 2026-07-19]:** every landing section lays its inner
+  content in the single centered 1200px container (x 120–1320 on the 1440
+  frame, min 24px gutters) — editorial bands stay full-bleed with their
+  content aligned to it, and narrower blocks center within it. *As built:*
+  the Figma `A — Home` frame was normalized to this rule on 2026-07-19 — the
+  pillar row, all five feature deep-dive splits, the demo stats/charts/table,
+  the how-it-works steps, the security columns, and the contribute dev-row
+  previously implied phantom containers (872–1128px wide); 3-up card rows now
+  share one 384px-card / 24px-gutter rhythm.
 - Dashboard: left nav 240px (collapsible to 64px icon rail) · content
   max 1440px · right inspector panel (400px) slides in for detail views —
   tables never navigate away for a single record. **[Proposed]**


### PR DESCRIPTION
## What

Pins the §2 Layout container contract as a decision: **every landing section lays its inner content in the single centered 1200px container** (x 120–1320 on the 1440 frame, min 24px gutters); editorial bands stay full-bleed with content aligned to it, narrower blocks center within it.

## Why

The Figma Home frame (`A — Home`, 193:14) had drifted into phantom containers — content rows implied section containers at 872, 904, 908, 984, 996, 1084 and 1128px (the built site mirrored the drift). The frame was normalized to the 1200 container on 2026-07-19:

| Section | Row | Before (x / w) | After (x / w) |
| --- | --- | --- | --- |
| A4 Pillars | pillar-row | 156 / 1128 | 120 / 1200 |
| A4a Deep-dives (1,3,5) | deep-dive | 228 / 984 | 120 / 1200 |
| A4a Deep-dives (2,4) | deep-dive | 268 / 904 | 120 / 1200 |
| A5 Demo | demo-stats | 284 / 872 | 120 / 1200 |
| A5 Demo | demo-charts · demo-table | 178 / 1084 | 120 / 1200 |
| A5a How it works | steps | 178 / 1084 | 120 / 1200 |
| A7 Security | sec-cols | 222 / 996 | 120 / 1200 |
| A8 Contribute | dev-row | 266 / 908 | 120 / 1200 |

3-up card rows (pillars, demo stats, steps) now share one 384px-card / 24px-gutter rhythm (4 cols of the 12-col grid). Programmatic re-audit of all 14 sections: zero deviations — every block either spans 120–1320 or is symmetric-centered within it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)