### PR TITLE
fix(web): live-site QA — containers, semantic landmarks, CSS hygiene

### DIFF
--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -143,6 +143,119 @@ test.describe("public home `/` (Part A)", () => {
     await expect(page.locator("#self-host")).toBeInViewport();
   });
 
+  test("one centered 1200px container aligns every band (1440 + 2400)", async ({
+    page,
+  }) => {
+    // design.md §2 container pin [Decided 2026-07-19]: content x 120–1320
+    // on the 1440 frame; the wide viewport is where drift shows clearest.
+    for (const width of [1440, 2400]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto("/");
+      const edges = await page.evaluate(() => {
+        const boxes: { name: string; left: number; right: number }[] = [];
+        for (const el of document.querySelectorAll("[data-section-inner]")) {
+          const rect = el.getBoundingClientRect();
+          const style = getComputedStyle(el);
+          boxes.push({
+            name: `section-inner:${el.closest("section")?.id || "band"}`,
+            left: rect.left + parseFloat(style.paddingLeft),
+            right: rect.right - parseFloat(style.paddingRight),
+          });
+        }
+        const navInner = document.querySelector(
+          'nav[aria-label="Marketing"] > div',
+        );
+        const footerInner = document.querySelector("footer > div");
+        for (const [name, el] of [
+          ["nav", navInner],
+          ["footer", footerInner],
+        ] as const) {
+          if (!el) continue;
+          const rect = el.getBoundingClientRect();
+          boxes.push({ name, left: rect.left, right: rect.right });
+        }
+        return boxes;
+      });
+      expect(edges.length).toBeGreaterThanOrEqual(15);
+      const expectedLeft = (width - 1200) / 2;
+      for (const box of edges) {
+        expect
+          .soft(Math.abs(box.left - expectedLeft), `${box.name} left @${width}`)
+          .toBeLessThanOrEqual(1);
+        expect
+          .soft(
+            Math.abs(box.right - (width - expectedLeft)),
+            `${box.name} right @${width}`,
+          )
+          .toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  test("3-up card rows share the 384px/24px rhythm at 1440", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/");
+    // Pillars (A4) and demo stat cards (A5) — 384px cards, 24px gutters.
+    const widths = await page.evaluate(() => {
+      const rows = [
+        document.querySelector("#product [data-section-inner] > div.grid"),
+        document.querySelector("#demo .grid.sm\\:grid-cols-3"),
+      ];
+      return rows.flatMap((row) =>
+        row
+          ? [...row.children].map((card) =>
+              Math.round(card.getBoundingClientRect().width),
+            )
+          : [],
+      );
+    });
+    expect(widths.length).toBe(6);
+    for (const width of widths) {
+      expect(Math.abs(width - 384)).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test("landmarks + demo table semantics", async ({ page }) => {
+    await page.goto("/");
+    // Exactly one main and one h1; footer is the contentinfo.
+    await expect(page.locator("main")).toHaveCount(1);
+    await expect(page.locator("h1")).toHaveCount(1);
+    await expect(page.getByRole("contentinfo")).toHaveCount(1);
+
+    // Demo table: a real <table> (W3 semantic refactor) whose rows
+    // contain only cells / columnheaders — native or ARIA (live QA
+    // 2026-07-19: rows were orphaned, cells bare).
+    const table = page.getByRole("table", { name: "Demo transactions" });
+    await expect(table).toBeVisible();
+    expect(
+      await table.getByRole("columnheader").count(),
+    ).toBeGreaterThanOrEqual(4);
+    expect(await table.getByRole("row").count()).toBeGreaterThanOrEqual(5);
+    const orphanChildren = await table.evaluate(
+      (node) =>
+        [...node.querySelectorAll("tr,[role=row]")].filter((row) =>
+          [...row.children].some(
+            (cell) => !cell.matches("td,th,[role=cell],[role=columnheader]"),
+          ),
+        ).length,
+    );
+    expect(orphanChildren).toBe(0);
+
+    // No row (native or ARIA) outside a table/grid context anywhere
+    // non-decorative.
+    const orphanRows = await page.evaluate(
+      () =>
+        [...document.querySelectorAll("tr,[role=row]")].filter(
+          (row) =>
+            !row.closest("[role=table],[role=grid],table") &&
+            !row.closest("[inert]"),
+        ).length,
+    );
+    expect(orphanRows).toBe(0);
+  });
+
   test("renders at 375w (responsive floor)", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 800 });
     await page.goto("/");

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -114,7 +114,12 @@ const Variant: React.FC<{ label: string; children: React.ReactNode }> = ({
     <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-text-2">
       {label}
     </div>
-    <div className="flex flex-wrap items-start gap-3">{children}</div>
+    {/* overflow-x-auto: fixed-width previews (rows, wizard, tables)
+        scroll inside the variant instead of pushing the page wide on
+        mobile (390w overflowed by ~245px — live QA 2026-07-19). */}
+    <div className="flex flex-wrap items-start gap-3 overflow-x-auto">
+      {children}
+    </div>
   </div>
 );
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -14,17 +14,26 @@
     text-align: inherit;
   }
 
+  /* Anchor scrolling is smooth unless the user opts out (design.md §5). */
   html {
     scroll-behavior: smooth;
   }
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  }
 
+  /*
+   * No overflow-x mask on body (live QA 2026-07-19): it hid container
+   * misfits instead of surfacing them — overflow gets fixed, not clipped.
+   */
   body {
     font-family: var(--font-inter), Inter, system-ui, sans-serif;
     background-color: var(--color-bg);
     color: var(--color-text);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    overflow-x: hidden;
   }
 }
 

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -1,26 +1,40 @@
 import React from "react";
+import Link from "next/link";
 
+// Legacy-styled 404 (redesign lands with its own tranche). Live QA
+// 2026-07-19: single h1 + a main landmark (it rendered two h1s and no
+// landmarks), and the dead HOME/Contact Us buttons are real links now.
 const NotFound = () => {
   return (
     <div className="bg-gradient-to-r from-purple-300 to-blue-200">
-      <div className="w-9/12 m-auto py-16 min-h-screen flex items-center justify-center">
+      <main className="w-9/12 m-auto py-16 min-h-screen flex items-center justify-center">
         <div className="bg-white shadow overflow-hidden sm:rounded-lg pb-8">
           <div className="border-t border-gray-200 text-center pt-8">
-            <h1 className="text-9xl font-bold text-purple-400">404</h1>
+            <p aria-hidden className="text-9xl font-bold text-purple-400">
+              404
+            </p>
             <h1 className="text-6xl font-medium py-8">oops! Page not found</h1>
             <p className="text-2xl pb-8 px-12 font-medium">
               Oops! The page you are looking for does not exist. It might have
               been moved or deleted.
             </p>
-            <button className="bg-gradient-to-r from-purple-400 to-blue-500 hover:from-pink-500 hover:to-orange-500 text-white font-semibold px-6 py-3 rounded-md mr-6">
+            <Link
+              href="/"
+              className="bg-gradient-to-r from-purple-400 to-blue-500 hover:from-pink-500 hover:to-orange-500 text-white font-semibold px-6 py-3 rounded-md mr-6 inline-block"
+            >
               HOME
-            </button>
-            <button className="bg-gradient-to-r from-red-400 to-red-500 hover:from-red-500 hover:to-red-500 text-white font-semibold px-6 py-3 rounded-md">
+            </Link>
+            <a
+              href="https://github.com/cuesoftinc/expendit/issues"
+              target="_blank"
+              rel="noreferrer"
+              className="bg-gradient-to-r from-red-400 to-red-500 hover:from-red-500 hover:to-red-500 text-white font-semibold px-6 py-3 rounded-md inline-block"
+            >
               Contact Us
-            </button>
+            </a>
           </div>
         </div>
-      </div>
+      </main>
     </div>
   );
 };

--- a/web/src/components/home/CompareFaqCta.tsx
+++ b/web/src/components/home/CompareFaqCta.tsx
@@ -53,7 +53,7 @@ export const CompareSection: React.FC<{
   onTryCloud: () => void;
   onSelfHost: () => void;
 }> = ({ onTryCloud, onSelfHost }) => (
-  <section id={ANCHORS.compare} className="bg-bg py-20">
+  <section id={ANCHORS.compare} className="scroll-mt-16 bg-bg py-20">
     <SectionInner>
       <SectionHeading>Cloud or self-host — same product</SectionHeading>
       <div className="mx-auto mt-10 max-w-2xl">
@@ -117,7 +117,7 @@ const FAQ_ITEMS = [
 export const FaqSection: React.FC = () => {
   const { track } = useAnalyticsController();
   return (
-    <section id={ANCHORS.faq} className="bg-bg pb-24 pt-16">
+    <section id={ANCHORS.faq} className="scroll-mt-16 bg-bg pb-24 pt-16">
       <SectionInner>
         <SectionHeading>Questions, answered</SectionHeading>
         <div className="mx-auto mt-8 max-w-[720px]">

--- a/web/src/components/home/ContributeSection.tsx
+++ b/web/src/components/home/ContributeSection.tsx
@@ -49,30 +49,44 @@ const GitHubMark: React.FC<{ className?: string }> = ({ className }) => (
 
 /** A8 architecture mini-diagram — web → api → mongo/redis (tokens only). */
 const ArchDiagram: React.FC = () => {
+  // shrink-0: the fixed 160px boxes must never squeeze (their labels
+  // spilled through the borders at 390w — live QA 2026-07-19); below sm
+  // the whole diagram stacks vertically instead (fork flattens to a
+  // chain, connectors turn vertical).
   const box =
-    "flex h-11 w-40 items-center justify-center rounded border border-border bg-bg-elev font-mono text-[13px] text-text";
+    "flex h-11 w-40 shrink-0 items-center justify-center rounded border border-border bg-bg-elev font-mono text-[13px] text-text";
   const connector = "bg-border";
   return (
     <figure
       aria-label="Architecture: web (Next.js) talks to api (Go/Gin), which uses Mongo and Redis"
       className="mx-auto mt-8 w-full max-w-[720px] rounded border border-border p-8"
     >
-      <div className="flex items-center justify-center">
+      <div className="flex flex-col items-center justify-center sm:flex-row">
         <div className={box}>web · Next.js</div>
-        <div aria-hidden className={`h-px w-8 sm:w-16 ${connector}`} />
+        <div aria-hidden className={`h-6 w-px sm:h-px sm:w-16 ${connector}`} />
         <div className={box}>api · Go/Gin</div>
-        <div aria-hidden className={`h-px w-4 sm:w-8 ${connector}`} />
-        <div aria-hidden className="flex flex-col items-start self-stretch">
+        <div aria-hidden className={`h-6 w-px sm:h-px sm:w-8 ${connector}`} />
+        {/* Fork column — desktop only; the mobile chain runs straight. */}
+        <div
+          aria-hidden
+          className="hidden flex-col items-start self-stretch sm:flex"
+        >
           <div className={`w-px flex-1 ${connector}`} />
           <div className={`w-px flex-1 ${connector}`} />
         </div>
-        <div className="flex flex-col gap-6">
-          <div className="flex items-center">
-            <div aria-hidden className={`h-px w-4 sm:w-8 ${connector}`} />
+        <div className="flex flex-col items-center gap-0 sm:items-stretch sm:gap-6">
+          <div className="flex flex-col items-center sm:flex-row">
+            <div
+              aria-hidden
+              className={`hidden h-px w-4 sm:block sm:w-8 ${connector}`}
+            />
             <div className={box}>mongo</div>
           </div>
-          <div className="flex items-center">
-            <div aria-hidden className={`h-px w-4 sm:w-8 ${connector}`} />
+          <div className="flex flex-col items-center sm:flex-row">
+            <div
+              aria-hidden
+              className={`h-6 w-px sm:h-px sm:w-8 ${connector}`}
+            />
             <div className={box}>redis</div>
           </div>
         </div>
@@ -86,7 +100,7 @@ export const ContributeSection: React.FC = () => {
   const { track } = useAnalyticsController();
 
   return (
-    <section id={ANCHORS.contribute} className="bg-bg py-20">
+    <section id={ANCHORS.contribute} className="scroll-mt-16 bg-bg py-20">
       <SectionInner>
         <SectionHeading>
           For developers — come build the hard parts
@@ -97,7 +111,9 @@ export const ContributeSection: React.FC = () => {
 
         <ArchDiagram />
 
-        <div className="mx-auto mt-12 grid max-w-4xl grid-cols-1 gap-10 md:grid-cols-2">
+        {/* Dev-row spans the full 1200px container (§2 pin) — the old
+            max-w-4xl was one of the phantom containers. */}
+        <div className="mt-12 grid grid-cols-1 gap-10 md:grid-cols-2 md:gap-6">
           <div>
             <h3 className="text-base font-semibold text-text">
               Problems worth your weekend

--- a/web/src/components/home/DeepDivesSection.tsx
+++ b/web/src/components/home/DeepDivesSection.tsx
@@ -149,15 +149,17 @@ const DEEP_DIVES: DeepDive[] = [
 export const DeepDivesSection: React.FC = () => (
   <section className="bg-bg pb-24">
     <SectionInner className="space-y-20">
+      {/* Space-between splits (§2 pin): copy and visual pin to the
+          container edges of their sides. */}
       {DEEP_DIVES.map((dive) => (
         <div
           key={dive.title}
-          className="grid grid-cols-1 items-center gap-10 md:grid-cols-2"
+          className="grid grid-cols-1 items-center gap-10 md:grid-cols-2 md:gap-6"
         >
           <div
             className={cn(
               "max-w-[480px]",
-              dive.copySide === "right" && "md:order-2",
+              dive.copySide === "right" && "md:order-2 md:justify-self-end",
             )}
           >
             <div className="text-[11px] font-semibold uppercase tracking-wider text-accent">
@@ -170,13 +172,20 @@ export const DeepDivesSection: React.FC = () => (
               {dive.body}
             </p>
           </div>
-          <Reveal
-            className={cn(
-              "flex justify-center",
-              dive.copySide === "right" && "md:order-1",
-            )}
-          >
-            {dive.visual}
+          <Reveal className={cn(dive.copySide === "right" && "md:order-1")}>
+            {/* Decorative still (like the hero embed / A5a thumbs):
+                inert keeps its dead controls out of tab order + AX tree. */}
+            <div
+              inert
+              className={cn(
+                "flex select-none justify-center",
+                dive.copySide === "right"
+                  ? "md:justify-start"
+                  : "md:justify-end",
+              )}
+            >
+              {dive.visual}
+            </div>
           </Reveal>
         </div>
       ))}

--- a/web/src/components/home/DemoSection.tsx
+++ b/web/src/components/home/DemoSection.tsx
@@ -64,7 +64,9 @@ export const DemoSection: React.FC = () => {
             <TabPanel key={key} value={key} className="w-full pt-8">
               {key !== persona ? null : (
                 <>
-                  <div className="mx-auto grid max-w-4xl grid-cols-1 gap-4 sm:grid-cols-3">
+                  {/* 3-up stat row on the 384px-card / 24px-gutter rhythm,
+                      spanning the 1200px container (design.md §2 pin). */}
+                  <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
                     <StatCard
                       label={stats.net.label}
                       value={stats.net.value}
@@ -91,7 +93,7 @@ export const DemoSection: React.FC = () => {
                     />
                   </div>
 
-                  <div className="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-[3fr_2fr]">
+                  <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[3fr_2fr]">
                     <div className="rounded border border-border bg-bg p-4">
                       <div className="mb-3 flex items-center justify-between">
                         <span className="text-[13px] font-medium text-text">
@@ -180,7 +182,10 @@ export const DemoSection: React.FC = () => {
                     data-testid="demo-table"
                     className="mt-6 overflow-x-auto rounded border border-border bg-bg"
                   >
-                    <table className="w-full min-w-[720px]">
+                    <table
+                      aria-label="Demo transactions"
+                      className="w-full min-w-[720px]"
+                    >
                       <TableHeader
                         columns={TXN_COLUMNS}
                         sort={{ columnId: "date", direction: "desc" }}

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -125,39 +125,36 @@ export const HomeView: React.FC = () => {
         </div>
       ) : null}
 
-      <div ref={heroRef}>
-        <HeroSection
-          nav={
-            <MarketingNav
-              variant="on-dark"
-              {...navProps}
-              className="mx-auto max-w-[1248px]"
-            />
-          }
-          onTryCloud={() => tryCloud("hero")}
-          onSelfHost={() => selfHost("hero")}
-        />
-      </div>
+      {/* The page's one main landmark — everything but the nav + footer. */}
+      <main>
+        <div ref={heroRef}>
+          <HeroSection
+            nav={<MarketingNav variant="on-dark" {...navProps} />}
+            onTryCloud={() => tryCloud("hero")}
+            onSelfHost={() => selfHost("hero")}
+          />
+        </div>
 
-      <LogoStrip />
-      <PillarsSection />
-      <DeepDivesSection />
-      <DemoSection />
-      <HowItWorksSection />
-      <AiSection />
-      <SecuritySection />
-      <ContributeSection />
-      <SelfHostSection />
-      <CommunitySection />
-      <CompareSection
-        onTryCloud={() => tryCloud("compare")}
-        onSelfHost={() => selfHost("compare")}
-      />
-      <FaqSection />
-      <FinalCtaSection
-        onTryCloud={() => tryCloud("final_cta")}
-        onSelfHost={() => selfHost("final_cta")}
-      />
+        <LogoStrip />
+        <PillarsSection />
+        <DeepDivesSection />
+        <DemoSection />
+        <HowItWorksSection />
+        <AiSection />
+        <SecuritySection />
+        <ContributeSection />
+        <SelfHostSection />
+        <CommunitySection />
+        <CompareSection
+          onTryCloud={() => tryCloud("compare")}
+          onSelfHost={() => selfHost("compare")}
+        />
+        <FaqSection />
+        <FinalCtaSection
+          onTryCloud={() => tryCloud("final_cta")}
+          onSelfHost={() => selfHost("final_cta")}
+        />
+      </main>
 
       <MarketingFooter
         columns={FOOTER_COLUMNS}

--- a/web/src/components/home/HowItWorksSection.tsx
+++ b/web/src/components/home/HowItWorksSection.tsx
@@ -76,10 +76,11 @@ export const HowItWorksSection: React.FC = () => {
   };
 
   return (
-    <section id={ANCHORS.howItWorks} className="bg-bg py-20">
+    <section id={ANCHORS.howItWorks} className="scroll-mt-16 bg-bg py-20">
       <SectionInner>
         <SectionHeading>How it works</SectionHeading>
-        <ol className="mt-12 grid grid-cols-1 gap-10 md:grid-cols-3">
+        {/* 3-up steps on the container-wide 384/24 rhythm (§2 pin). */}
+        <ol className="mt-12 grid grid-cols-1 gap-10 md:grid-cols-3 md:gap-6">
           {STEPS.map((step) => (
             <li key={step.number}>
               {/* Thumb: inert composition + link overlay (no nested

--- a/web/src/components/home/PillarsSection.tsx
+++ b/web/src/components/home/PillarsSection.tsx
@@ -62,7 +62,7 @@ const PILLARS = [
 ];
 
 export const PillarsSection: React.FC = () => (
-  <section id={ANCHORS.product} className="bg-bg pb-20 pt-10">
+  <section id={ANCHORS.product} className="scroll-mt-16 bg-bg pb-20 pt-10">
     <SectionInner>
       <SectionHeading>One ledger. Three superpowers.</SectionHeading>
       <div className="mt-10 grid grid-cols-1 gap-6 md:grid-cols-3">

--- a/web/src/components/home/Section.tsx
+++ b/web/src/components/home/Section.tsx
@@ -5,6 +5,11 @@
  * plus the Afrocentric line motif at 4% opacity on dark editorial
  * surfaces (design.md §2 — an asset, drawn inline as a token-free SVG
  * pattern; documented exception, decorative only).
+ *
+ * Container pin [Decided 2026-07-19, design.md §2]: every band lays its
+ * content in the single centered 1200px container (x 120–1320 on the
+ * 1440 frame, min 24px gutters) — hence max-w-[1248px] + px-6 here, so
+ * the content box is exactly 1200px wherever the viewport allows.
  */
 
 import React from "react";
@@ -32,7 +37,10 @@ export const SectionInner: React.FC<{
   className?: string;
   children: React.ReactNode;
 }> = ({ className, children }) => (
-  <div className={cn("mx-auto w-full max-w-[1200px] px-6", className)}>
+  <div
+    data-section-inner
+    className={cn("mx-auto w-full max-w-[1248px] px-6", className)}
+  >
     {children}
   </div>
 );

--- a/web/src/components/home/TrustSections.tsx
+++ b/web/src/components/home/TrustSections.tsx
@@ -46,7 +46,8 @@ export const SecuritySection: React.FC = () => (
   <section className="bg-bg py-20">
     <SectionInner>
       <SectionHeading>Security &amp; privacy, in plain language</SectionHeading>
-      <div className="mx-auto mt-10 grid max-w-4xl gap-8 md:grid-cols-3">
+      {/* 3-up columns on the container-wide 384/24 rhythm (§2 pin). */}
+      <div className="mt-10 grid gap-8 md:grid-cols-3 md:gap-6">
         {SECURITY_COLUMNS.map((column) => (
           <div key={column.title}>
             <h3 className="text-base font-semibold text-text">

--- a/web/src/components/home/links.ts
+++ b/web/src/components/home/links.ts
@@ -5,6 +5,8 @@
  * the privacy hub is the D3 ecosystem surface, architecture.md §2).
  */
 
+import { prefersReducedMotion } from "@/lib/use-reduced-motion";
+
 export const GITHUB_URL = "https://github.com/cuesoftinc/expendit";
 export const GITHUB_ISSUES_URL = `${GITHUB_URL}/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`;
 export const CONTRIBUTING_URL = `${GITHUB_URL}/blob/main/CONTRIBUTING.md`;
@@ -18,9 +20,11 @@ export const PRIVACY_HUB_URL = "https://privacy.cuesoft.io";
 /** Smooth-scrolls to a section anchor (no-op where unimplemented). */
 export const scrollToAnchor = (id: string): void => {
   try {
-    document
-      .getElementById(id)
-      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    document.getElementById(id)?.scrollIntoView({
+      // Instant jump under prefers-reduced-motion (design.md §5).
+      behavior: prefersReducedMotion() ? "auto" : "smooth",
+      block: "start",
+    });
   } catch {
     // jsdom (unit tests) has no scrollIntoView — navigation is cosmetic.
   }

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -73,7 +73,10 @@ export const Button: React.FC<ButtonProps> = ({
       aria-busy={loading}
       onClick={onClick}
       className={cn(
-        "inline-flex items-center justify-center gap-2 rounded font-medium",
+        // whitespace-nowrap: labels never wrap (Figma buttons are
+        // single-line) — a narrow column squeezed "Try the sandbox" out
+        // of its pill on the A10 mobile comparison (live QA 2026-07-19).
+        "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded font-medium",
         "transition-colors duration-fast ease-standard select-none",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
         "disabled:cursor-not-allowed",

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -92,99 +92,103 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
       // on-dark: dark token mode scoped to the nav subtree (both themes).
       data-theme={onDark ? "dark" : undefined}
       className={cn(
-        "flex w-full items-center gap-1 px-6 py-3",
+        "w-full px-6 py-3",
         onDark
           ? "bg-bg-editorial"
           : "sticky top-0 z-sticky border-b border-border bg-bg",
         className,
       )}
     >
-      <Link
-        href="/"
-        className="mr-4 rounded text-sm font-semibold tracking-tight text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-      >
-        expendit
-      </Link>
+      {/* Bar background is full-bleed; content sits in the one centered
+          1200px landing container (design.md §2 container pin). */}
+      <div className="mx-auto flex w-full max-w-[1200px] items-center gap-1">
+        <Link
+          href="/"
+          className="mr-4 rounded text-sm font-semibold tracking-tight text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          expendit
+        </Link>
 
-      {solutions.length > 0 ? (
-        // Text items collapse below md (375w floor keeps logo + CTAs).
-        <div ref={solutionsRef} className="relative hidden md:block">
+        {solutions.length > 0 ? (
+          // Text items collapse below md (375w floor keeps logo + CTAs).
+          <div ref={solutionsRef} className="relative hidden md:block">
+            <button
+              type="button"
+              aria-expanded={solutionsOpen}
+              aria-haspopup="menu"
+              onClick={() => setSolutionsOpen((state) => !state)}
+              className={cn(itemClass, "inline-flex items-center gap-1")}
+            >
+              Solutions
+              <ChevronDown
+                aria-hidden
+                className={cn(
+                  "h-3.5 w-3.5 transition-transform duration-fast ease-standard",
+                  solutionsOpen && "rotate-180",
+                )}
+              />
+            </button>
+            {solutionsOpen ? (
+              <div
+                role="menu"
+                className="absolute left-0 top-full z-dropdown mt-1 w-56 rounded border border-border bg-bg py-1 shadow-lg"
+              >
+                {solutions.map((item) => (
+                  <a
+                    key={item.label}
+                    role="menuitem"
+                    href={item.href}
+                    className="block px-3 py-1.5 text-[13px] text-text transition-colors duration-fast ease-standard hover:bg-bg-elev"
+                  >
+                    {item.label}
+                  </a>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {links.map((link) => (
+          <a
+            key={link.label}
+            href={link.href}
+            className={cn(itemClass, "hidden md:inline-block")}
+          >
+            {link.label}
+          </a>
+        ))}
+
+        <div className="ml-auto flex items-center gap-2">
+          {/* GitHub badge — neutral "Star", no count (as built). */}
+          <a
+            href={githubHref}
+            target="_blank"
+            rel="noreferrer"
+            onClick={onGithubClick}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded border border-border px-2.5 py-1 text-[13px] font-medium text-text",
+              "transition-colors duration-fast ease-standard hover:bg-bg-elev",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+            )}
+          >
+            <GitHubMark className="h-3.5 w-3.5" />
+            Star
+          </a>
+          <button type="button" onClick={onSignIn} className={itemClass}>
+            Sign in
+          </button>
           <button
             type="button"
-            aria-expanded={solutionsOpen}
-            aria-haspopup="menu"
-            onClick={() => setSolutionsOpen((state) => !state)}
-            className={cn(itemClass, "inline-flex items-center gap-1")}
+            onClick={onTryCloud}
+            className={cn(
+              "rounded bg-accent px-3 py-1.5 text-[13px] font-medium text-on-accent",
+              "transition-colors duration-fast ease-standard hover:opacity-90",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
+            )}
           >
-            Solutions
-            <ChevronDown
-              aria-hidden
-              className={cn(
-                "h-3.5 w-3.5 transition-transform duration-fast ease-standard",
-                solutionsOpen && "rotate-180",
-              )}
-            />
+            Try Cloud
           </button>
-          {solutionsOpen ? (
-            <div
-              role="menu"
-              className="absolute left-0 top-full z-dropdown mt-1 w-56 rounded border border-border bg-bg py-1 shadow-lg"
-            >
-              {solutions.map((item) => (
-                <a
-                  key={item.label}
-                  role="menuitem"
-                  href={item.href}
-                  className="block px-3 py-1.5 text-[13px] text-text transition-colors duration-fast ease-standard hover:bg-bg-elev"
-                >
-                  {item.label}
-                </a>
-              ))}
-            </div>
-          ) : null}
         </div>
-      ) : null}
-
-      {links.map((link) => (
-        <a
-          key={link.label}
-          href={link.href}
-          className={cn(itemClass, "hidden md:inline-block")}
-        >
-          {link.label}
-        </a>
-      ))}
-
-      <div className="ml-auto flex items-center gap-2">
-        {/* GitHub badge — neutral "Star", no count (as built). */}
-        <a
-          href={githubHref}
-          target="_blank"
-          rel="noreferrer"
-          onClick={onGithubClick}
-          className={cn(
-            "inline-flex items-center gap-1.5 rounded border border-border px-2.5 py-1 text-[13px] font-medium text-text",
-            "transition-colors duration-fast ease-standard hover:bg-bg-elev",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
-          )}
-        >
-          <GitHubMark className="h-3.5 w-3.5" />
-          Star
-        </a>
-        <button type="button" onClick={onSignIn} className={itemClass}>
-          Sign in
-        </button>
-        <button
-          type="button"
-          onClick={onTryCloud}
-          className={cn(
-            "rounded bg-accent px-3 py-1.5 text-[13px] font-medium text-on-accent",
-            "transition-colors duration-fast ease-standard hover:opacity-90",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
-          )}
-        >
-          Try Cloud
-        </button>
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary

Live visual sweep of https://expendit.cuesoft.io at 1440×900, 390×844 and 2400×1200 (Playwright, every reachable route + the landing section-by-section), then fixes verified against a local TEST_MODE prod build. Aligns the site to the **design.md §2 container pin [Decided 2026-07-19]** (#204): one centered 1200px content column, x 120–1320 on the 1440 frame.

### Containers (measured on live: sections at x=144, hero nav at 120, sticky nav at 24, footer at 120 — three different columns)
- `SectionInner`: `max-w-[1200px]` → `max-w-[1248px]` + `px-6`, so the content box is exactly 1200 (all 15 bands)
- `MarketingNav`: bar stays full-bleed; content now sits in a centered 1200px inner container — fixes the sticky post-hero nav, which was full-width
- 3-up rows unified on the 384px-card / 24px-gutter rhythm spanning the container: pillars, demo stats (was `max-w-4xl`/`gap-4`), security columns, how-it-works steps, contribute dev-row
- Deep-dive splits: copy/visual pinned to the container edges (space-between)
- After: every band's content box measures 120–1320 @1440 and 600–1800 @2400; 24px gutters @390

### Semantic HTML
- `/` had **no `<main>`** → one main landmark; 404 had **two h1s, no landmarks** → single h1 + `<main>`, dead HOME/Contact-Us buttons are real links
- Demo table: 30 orphaned `role=row`s / bare cells → owning `role="table"` + `aria-label`, `role="cell"` on `TxnTableRow` children, columnheader wrapper for the `TableHeader` selectAll
- Deep-dive visuals `inert` like the hero embed / A5a thumbs (dead controls out of tab order + AX tree)

### CSS hygiene (unlayered element selectors — the upstat `main{min-width:100vw}` class of bug)
- Legacy `* { …; scroll-behavior:smooth }` and `body { font-family:Poppins; overflow-x:hidden }` removed: **all non-heading landing copy rendered in Poppins on live** (design canon is Inter), and the body overflow mask hid container misfits. Poppins is scoped to `.legacy-root` (PageLayout / 404 shells) until W3 retirement
- Latent bug exposed and fixed: the next/font variables were bound on `<body>` while Tailwind preflight consumes `var(--font-inter)` on `<html>` — without the Poppins mask, body copy fell to the UA serif. Variables now bind on `<html>`
- Smooth scrolling moved to `html` inside `@layer base` with a `prefers-reduced-motion` guard; `scrollToAnchor` respects reduced motion

### Avatars (aspect-locked circles)
- `object-cover` (+ clipping where missing) on the Navbar, UserProfile and ProfileSettings avatar images — the 96px settings avatar rendered `object-fit: fill` (squashes on any non-square source). The registry `Avatar` was already correct

### Tests
- `home.spec.ts` now asserts: the 1200px container across every band at 1440 **and** 2400, the 384/24 card rhythm, one main/h1/contentinfo, and demo-table ARIA semantics (no orphan rows outside inert subtrees)

## Verification
- Local prod build (TEST_MODE): container histogram uniform (16/16 bands), Inter on body/p/buttons, no horizontal overflow at 390/1440/2400 with the mask removed, legacy TEST_MODE pages still Poppins with no overflow
- Gates: eslint 0 errors · prettier clean · typecheck ✓ · Jest 2/2 (legacy) · Vitest 313/313 · Playwright e2e 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)