### PR TITLE
fix(web): system QA — final usability/accuracy/interaction pass

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -86,6 +86,8 @@
 | Radii (product) | 6px |
 | Product note | density toggle honors the compact row height 32px / comfortable 44px |
 
+- **Cursor affordance**: enabled interactive controls show `cursor: pointer` — one base-layer rule on `button:not(:disabled)`, `[role="button"]:not([aria-disabled="true"])`, `select:not(:disabled)`, `summary`, `label[for]`; links use the native pointer; disabled controls keep the default cursor. [Directive 2026-07-19]
+
 These rows are standardized in the org SKILL.md — a change here is an
 ecosystem change, PR'd to all three design.md files together.
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -4,7 +4,7 @@
 > rules. Ecosystem conventions shared with apparule/upstat (envelope, code
 > discipline, never-log gating — see apparule engineering.md §1 for the
 > envelope definition). The web implementation follows
-> [web-implementation.md](web-implementation.md) — the CueLABS Web
+> [web-implementation.md](web-implementation.md) — the CueLABS™ Web
 > Implementation Standard (W0–W3, TEST_MODE, mock server, legacy policy).
 
 ## 1. Error catalog (product families)

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -11,7 +11,7 @@
 
 ## Part A — Public home page (expendit.cuesoft.io)
 
-Shared CueLABS open-source-site pattern: product presentation → developer
+Shared CueLABS™ open-source-site pattern: product presentation → developer
 setup → Discord + GitHub + preview links → **Try Cloud** / **Self Host** CTAs
 **[Directive]**. Brex-style editorial execution (design.md §1.2).
 

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -1,6 +1,6 @@
 # Expendit — Web Implementation Standard
 
-> How `web/` gets rebuilt: the **CueLABS Web Implementation Standard**
+> How `web/` gets rebuilt: the **CueLABS™ Web Implementation Standard**
 > (ratified 2026-07-18, org-wide **[Directive]**) carried in full, plus the
 > Expendit-specific addendum — stage plan, token mapping, route map,
 > TEST_MODE contract, mock server, test strategy, legacy quarantine plan.

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -182,6 +182,41 @@ design-phase QA loops, design.md §8).
   design.md §2 container pin (PR #204), not a W3 scope item; W3's own
   Figma self-QA (Dashboard frames) is unaffected by it.
 
+**System-QA as-built notes (2026-07-19, `web/system-qa`):** the full-system
+usability/accuracy/interaction pass over the W0–W3 app. Fixes of record:
+
+- **Accuracy:** balance-sheet confirm treats a missing liabilities/equity
+  side as 0 in the identity check (an absent-equity sheet used to confirm
+  silently); `formatMoney` preserves the sign (a negative net month
+  rendered positive); ledger recategorize (row/bulk/manual form) offers
+  same-direction categories only; ratio traces resolve their `inputs` to
+  `{id, canonical_key, amount}` (ids stay the audit pointer); the hero/tax
+  marketing embeds and the A5 company donut now mirror seed.ts verbatim.
+- **Rights:** `GET /account/purge` (200 `null` when none) + a settings
+  mount probe — the grace banner/cancel now survive reloads.
+- **Usability:** BulkActionBar floats at the viewport bottom; import jobs
+  parked in staged review show a warn **Needs review** tag with staged
+  counts (`ImportJobRowStatus` gains `needs-review`); the filing wizard
+  defaults to PIT on personal orgs, surfaces the profile gate at data
+  review, and calls out all-zero drafts; the AppNav auto-collapses to the
+  64px rail below `md`; overview stat grids go 1-col at base; the hidden
+  row-actions cluster is pointer-events-gated (it swallowed clicks).
+- **MI fixes:** MI-14 NEW = `created_at ≥ now − 24h` (pure helper, the
+  clock-skew `|diff|` hack retired); StatCard gains `deltaDirection`
+  ("down-good" for expense-like metrics — color = goodness, sign/icon =
+  direction); the A2 hero chips join the ScaledEmbed composition (they
+  scaled independently and painted under the frame's stacking context).
+- **Parity canon (org SKILL.md 2026-07-19):** marketing nav = Features ·
+  Pricing · Docs · GitHub + ThemeToggle + Sign in CTA; footer = brand + 4
+  columns (Product/Docs/Community/Legal) + verbatim legal bar; the
+  apparule ThemeProvider contract ported (`expendit.theme`, pre-paint
+  init script, toggle in marketing nav + dashboard chrome; the B9 control
+  and `useThemeController` delegate to it). Playwright `parity.spec.ts`
+  pins the canonical hrefs and theme persistence.
+- **Polish:** token-true editorial 404 (both themes); pluralized count
+  captions; the overview donut legend aggregates the tail into "Other";
+  PeriodPicker triggers never wrap.
+
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -216,6 +216,27 @@ usability/accuracy/interaction pass over the W0–W3 app. Fixes of record:
 - **Polish:** token-true editorial 404 (both themes); pluralized count
   captions; the overview donut legend aggregates the tail into "Other";
   PeriodPicker triggers never wrap.
+- **Mobile nav canon (org SKILL.md follow-up):** below `md` the four nav
+  text links collapse into a hamburger disclosure (`aria-expanded`) whose
+  panel carries the same links + ThemeToggle + Sign in — never
+  display-none with no fallback; the 390w Playwright test walks every
+  canonical destination through the menu.
+- **Review-canon mock sweep:** (a) query/parse seams reject malformed
+  input per their documented grammar — the transactions list 422s bad
+  dates/amounts/enums/limits and unknown cursors (an `amount_min=abc`
+  used to NaN-filter every row away), the ratios endpoints enforce the
+  closed period grammar; (b) advertised controls observably change
+  results — the bank-link "Auto-confirm clean syncs" toggle now commits
+  clean syncs straight to the ledger vs staging them (it was never read),
+  and image uploads 403 `consent_required` without the `ai_processing`
+  consent record (flows/import.md §3; the Settings notification switches
+  remain explicitly backend-deferred by copy); (c) derived-metric
+  semantics under bucket changes were already correct (quarterly ×4
+  annualization, actual day counts) and are now pinned by a regression
+  test. The wizard's profile gate and the generate endpoint now share one
+  predicate (`missingTaxIdentifiers`, models/tax.ts), and PIT drafts pick
+  a plain calendar year (the FY#### year picker grammar stays
+  statement-only) — both from the PR #209 Codex review.
 
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the

--- a/web/__tests__/index.test.tsx
+++ b/web/__tests__/index.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import "../src/setup-tests";
 import "@testing-library/jest-dom";
 import Home from "../src/app/page";
+import { ThemeProvider } from "../src/design/ThemeProvider";
 
 jest.mock("next/navigation", () => ({
   useRouter() {
@@ -20,7 +21,12 @@ describe("HomePage", () => {
   // W2: `/` is the Part A Brex-editorial home (pages.md); the legacy
   // marketing sections await their W3 quarantine tranche.
   it("renders the Part A hero", () => {
-    render(<Home />);
+    // Nav theme toggle reads the design-layer provider (parity canon).
+    render(
+      <ThemeProvider>
+        <Home />
+      </ThemeProvider>,
+    );
 
     expect(
       screen.getByRole("heading", {

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -112,7 +112,10 @@ test("core journey — overview, ledger CRUD, import, statements, ratios, tax wi
     .poll(async () => jobRow.getAttribute("data-status"), {
       timeout: 20_000,
     })
-    .toMatch(/completed/);
+    // Parse-complete jobs park in staged review as "needs-review"
+    // (system QA 2026-07-19 — the green Completed tag hid the parked
+    // review); bank/auto-confirmed jobs stay "completed*".
+    .toMatch(/completed|needs-review/);
   await jobRow.click();
   await page.waitForURL("**/dashboard/imports/**");
 

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -121,8 +121,8 @@ test.describe("public home `/` (Part A)", () => {
     page,
   }) => {
     await page.goto("/");
-    // Hero Try Cloud (the A2 CTA — first Try Cloud on the page; the nav
-    // CTA is "Sign in" under the parity canon).
+    // Hero Try Cloud (the A2 CTA — the first Try Cloud BUTTON; the nav
+    // Try Cloud is a link, canon revision 2026-07-19).
     await page.getByRole("button", { name: "Try Cloud" }).first().click();
     await page.waitForURL("**/signin");
     await expect(

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -43,7 +43,9 @@ test.describe("public home `/` (Part A)", () => {
     ).toBeVisible();
     // A9 community + A10 comparison + caption
     await expect(
-      page.getByRole("heading", { name: "Community", exact: true }),
+      // level pins the A9 section h2 (the footer's Community column
+      // heading arrived with the parity canon).
+      page.getByRole("heading", { name: "Community", exact: true, level: 2 }),
     ).toBeVisible();
     await expect(
       page.getByText("Cloud or self-host — same product"),
@@ -119,8 +121,9 @@ test.describe("public home `/` (Part A)", () => {
     page,
   }) => {
     await page.goto("/");
-    // Hero Try Cloud (the A2 CTA — second Try Cloud on the page).
-    await page.getByRole("button", { name: "Try Cloud" }).nth(1).click();
+    // Hero Try Cloud (the A2 CTA — first Try Cloud on the page; the nav
+    // CTA is "Sign in" under the parity canon).
+    await page.getByRole("button", { name: "Try Cloud" }).first().click();
     await page.waitForURL("**/signin");
     await expect(
       page.getByRole("button", { name: "Continue with Google" }),
@@ -131,9 +134,13 @@ test.describe("public home `/` (Part A)", () => {
     await page.getByRole("button", { name: "Try Cloud" }).last().click();
     await page.waitForURL("**/signin");
 
-    // Nav Sign in.
+    // Nav Sign in — a real link to /signin (parity canon).
     await page.goto("/");
-    await page.getByRole("button", { name: "Sign in" }).click();
+    await page
+      .getByRole("navigation", { name: "Marketing" })
+      .first()
+      .getByRole("link", { name: "Sign in" })
+      .click();
     await page.waitForURL("**/signin");
   });
 

--- a/web/e2e/parity.spec.ts
+++ b/web/e2e/parity.spec.ts
@@ -34,7 +34,7 @@ const FOOTER_LINKS: Array<[string, string, string]> = [
   ["Community", "GitHub", GITHUB],
   ["Community", "Discord", "https://discord.gg/CDfZxxrxbb"],
   ["Community", "Roadmap", `${DOCS}/product/roadmap`],
-  ["Community", "CueLABS", "https://cuelabs.cuesoft.io"],
+  ["Community", "CueLABS™", "https://cuelabs.cuesoft.io"],
   ["Legal", "Privacy", "https://privacy.cuesoft.io"],
   ["Legal", "Terms", "https://terms.cuesoft.io"],
   ["Legal", "Status", "https://status.cuesoft.io"],

--- a/web/e2e/parity.spec.ts
+++ b/web/e2e/parity.spec.ts
@@ -82,6 +82,52 @@ test("footer carries the 4-column canonical inventory + legal bar", async ({
   );
 });
 
+test("mobile (390w): the hamburger panel reaches every canonical nav destination", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+  const nav = page.getByRole("navigation", { name: "Marketing" }).first();
+
+  // Text links are collapsed, not lost: the disclosure carries them.
+  const menu = nav.getByRole("button", { name: "Menu" });
+  await expect(menu).toHaveAttribute("aria-expanded", "false");
+  await menu.click();
+  await expect(menu).toHaveAttribute("aria-expanded", "true");
+
+  // The desktop link set stays in the DOM (hidden below md) — scope the
+  // assertions to what is actually visible: the panel copies.
+  for (const [label, href] of NAV_LINKS) {
+    const link = nav
+      .getByRole("link", { name: label })
+      .filter({ visible: true });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", href);
+  }
+  await expect(
+    nav.getByRole("link", { name: "Sign in" }).filter({ visible: true }),
+  ).toHaveAttribute("href", "/signin");
+
+  // Theme toggle works from the panel.
+  await nav
+    .getByRole("button", { name: "Switch to dark theme" })
+    .filter({ visible: true })
+    .click();
+  await expect
+    .poll(() =>
+      page.evaluate(() => document.documentElement.getAttribute("data-theme")),
+    )
+    .toBe("dark");
+
+  // In-page anchors navigate (menu closes, section scrolls into view).
+  await nav
+    .getByRole("link", { name: "Pricing" })
+    .filter({ visible: true })
+    .click();
+  await expect(menu).toHaveAttribute("aria-expanded", "false");
+  await expect(page.locator("#compare")).toBeInViewport();
+});
+
 const expectTheme = async (page: Page, theme: string | null) => {
   await expect
     .poll(() =>

--- a/web/e2e/parity.spec.ts
+++ b/web/e2e/parity.spec.ts
@@ -137,6 +137,14 @@ test("mobile (390w): the hamburger panel reaches every canonical nav destination
     nav.getByRole("link", { name: "Try Cloud" }).filter({ visible: true }),
   ).toHaveAttribute("href", "/signin");
 
+  // The panel's GitHub item is the SAME star badge as desktop (glyph +
+  // neutral "Star" in TEST_MODE — never a plain text link).
+  const panelStar = nav
+    .getByRole("link", { name: STAR_NAME })
+    .filter({ visible: true });
+  await expect(panelStar).toHaveText("Star");
+  await expect(panelStar.locator("svg")).toBeVisible();
+
   // Theme toggle works from the panel.
   await nav
     .getByRole("button", { name: "Switch to dark theme" })

--- a/web/e2e/parity.spec.ts
+++ b/web/e2e/parity.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Marketing nav/footer & theme parity canon (org SKILL.md, 2026-07-19):
+ * canonical link inventory on the A1 nav + A11 footer, and the
+ * ThemeProvider contract (data-theme on <html>, localStorage
+ * `expendit.theme`) flipping + persisting on home AND dashboard.
+ */
+
+const GITHUB = "https://github.com/cuesoftinc/expendit";
+const DOCS = "https://cuesoft.gitbook.io/expendit";
+
+const NAV_LINKS: Array<[string, string]> = [
+  ["Features", "#product"],
+  ["Pricing", "#compare"],
+  ["Docs", DOCS],
+  ["GitHub", GITHUB],
+];
+
+const FOOTER_LINKS: Array<[string, string, string]> = [
+  // [column, label, href]
+  ["Product", "Features", "#product"],
+  ["Product", "Pricing", "#compare"],
+  ["Product", "Try Cloud", "/signin"],
+  ["Product", "Self Host", "#self-host"],
+  ["Docs", "Docs", DOCS],
+  ["Docs", "Quickstart", `${DOCS}/setup`],
+  ["Docs", "API reference", `${DOCS}/system/api-surface`],
+  ["Docs", "Self-host guide", `${DOCS}/system/deployment`],
+  ["Community", "GitHub", GITHUB],
+  ["Community", "Discord", "https://discord.gg/CDfZxxrxbb"],
+  ["Community", "Roadmap", `${DOCS}/product/roadmap`],
+  ["Community", "CueLABS", "https://cuelabs.cuesoft.io"],
+  ["Legal", "Privacy", "https://privacy.cuesoft.io"],
+  ["Legal", "Terms", "https://terms.cuesoft.io"],
+  ["Legal", "Status", "https://status.cuesoft.io"],
+];
+
+test("nav carries the canonical 4 links + Sign in CTA", async ({ page }) => {
+  await page.goto("/");
+  const nav = page.getByRole("navigation", { name: "Marketing" }).first();
+  for (const [label, href] of NAV_LINKS) {
+    await expect(nav.getByRole("link", { name: label })).toHaveAttribute(
+      "href",
+      href,
+    );
+  }
+  await expect(nav.getByRole("link", { name: "Sign in" })).toHaveAttribute(
+    "href",
+    "/signin",
+  );
+});
+
+test("footer carries the 4-column canonical inventory + legal bar", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const footer = page.locator("footer");
+  for (const [column, label, href] of FOOTER_LINKS) {
+    const nav = footer.getByRole("navigation", { name: column });
+    await expect(nav.getByRole("link", { name: label })).toHaveAttribute(
+      "href",
+      href,
+    );
+  }
+  // Legal bar: verbatim line with linked Cuesoft Inc. + MIT License,
+  // Security Policy CTA to SECURITY.md, and a real language control.
+  await expect(
+    footer.getByText(/© Cuesoft Inc\. 2026\. Expendit\. CueLABS™ Division\./),
+  ).toBeVisible();
+  await expect(
+    footer.getByRole("link", { name: "Cuesoft Inc." }),
+  ).toHaveAttribute("href", "https://cuesoft.io");
+  await expect(
+    footer.getByRole("link", { name: "MIT License" }),
+  ).toHaveAttribute("href", `${GITHUB}/blob/main/LICENSE`);
+  await expect(
+    footer.getByRole("link", { name: "View Security Policy" }),
+  ).toHaveAttribute("href", `${GITHUB}/blob/main/SECURITY.md`);
+  await expect(footer.getByRole("combobox", { name: "Language" })).toHaveValue(
+    "en",
+  );
+});
+
+const expectTheme = async (page: Page, theme: string | null) => {
+  await expect
+    .poll(() =>
+      page.evaluate(() => document.documentElement.getAttribute("data-theme")),
+    )
+    .toBe(theme);
+};
+
+test("theme toggle flips and persists on the home page", async ({ page }) => {
+  await page.goto("/");
+  await expectTheme(page, null); // system default — no override attribute
+  await page.getByRole("button", { name: "Switch to dark theme" }).click();
+  await expectTheme(page, "dark");
+  expect(
+    await page.evaluate(() => localStorage.getItem("expendit.theme")),
+  ).toBe("dark");
+
+  // Pre-paint persistence across a reload.
+  await page.reload();
+  await expectTheme(page, "dark");
+
+  await page.getByRole("button", { name: "Switch to light theme" }).click();
+  await expectTheme(page, "light");
+  expect(
+    await page.evaluate(() => localStorage.getItem("expendit.theme")),
+  ).toBe("light");
+});
+
+test("theme toggle lives in the dashboard chrome and persists", async ({
+  page,
+}) => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: "Continue with Google" }).click();
+  await page.waitForURL("**/dashboard");
+  await expect(
+    page.getByRole("heading", { name: "Overview", level: 1 }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Switch to dark theme" }).click();
+  await expectTheme(page, "dark");
+  expect(
+    await page.evaluate(() => localStorage.getItem("expendit.theme")),
+  ).toBe("dark");
+
+  await page.reload();
+  await expectTheme(page, "dark");
+
+  // The B9 settings control reads the same store (one source of truth).
+  await page.goto("/dashboard/settings");
+  await expect(page.getByRole("heading", { name: "Appearance" })).toBeVisible();
+  await page.getByRole("button", { name: "Switch to light theme" }).click();
+  await expectTheme(page, "light");
+});

--- a/web/e2e/parity.spec.ts
+++ b/web/e2e/parity.spec.ts
@@ -10,11 +10,15 @@ import { expect, test, type Page } from "@playwright/test";
 const GITHUB = "https://github.com/cuesoftinc/expendit";
 const DOCS = "https://cuesoft.gitbook.io/expendit";
 
+const STAR_NAME = "Star cuesoftinc/expendit on GitHub";
+
+// The GitHub item renders as the star badge (canon revision 2026-07-19);
+// its accessible name is the badge aria-label.
 const NAV_LINKS: Array<[string, string]> = [
   ["Features", "#product"],
   ["Pricing", "#compare"],
   ["Docs", DOCS],
-  ["GitHub", GITHUB],
+  [STAR_NAME, GITHUB],
 ];
 
 const FOOTER_LINKS: Array<[string, string, string]> = [
@@ -36,7 +40,9 @@ const FOOTER_LINKS: Array<[string, string, string]> = [
   ["Legal", "Status", "https://status.cuesoft.io"],
 ];
 
-test("nav carries the canonical 4 links + Sign in CTA", async ({ page }) => {
+test("nav carries the canonical 4 links + Sign in + Try Cloud CTA", async ({
+  page,
+}) => {
   await page.goto("/");
   const nav = page.getByRole("navigation", { name: "Marketing" }).first();
   for (const [label, href] of NAV_LINKS) {
@@ -45,9 +51,26 @@ test("nav carries the canonical 4 links + Sign in CTA", async ({ page }) => {
       href,
     );
   }
+  // TEST_MODE: the star badge stays neutral — no hardcoded count.
+  await expect(nav.getByRole("link", { name: STAR_NAME })).toHaveText("Star");
   await expect(nav.getByRole("link", { name: "Sign in" })).toHaveAttribute(
     "href",
     "/signin",
+  );
+  await expect(nav.getByRole("link", { name: "Try Cloud" })).toHaveAttribute(
+    "href",
+    "/signin",
+  );
+
+  // Cursor affordance canon [Directive 2026-07-19]: pointer on enabled
+  // controls and links.
+  const cursorOf = (locator: ReturnType<typeof nav.getByRole>) =>
+    locator.evaluate((el) => getComputedStyle(el).cursor);
+  expect(
+    await cursorOf(nav.getByRole("button", { name: /Switch to .* theme/ })),
+  ).toBe("pointer");
+  expect(await cursorOf(nav.getByRole("link", { name: "Docs" }))).toBe(
+    "pointer",
   );
 });
 
@@ -71,6 +94,9 @@ test("footer carries the 4-column canonical inventory + legal bar", async ({
   await expect(
     footer.getByRole("link", { name: "Cuesoft Inc." }),
   ).toHaveAttribute("href", "https://cuesoft.io");
+  await expect(
+    footer.getByRole("link", { name: "CueLABS™ Division" }),
+  ).toHaveAttribute("href", "https://cuelabs.cuesoft.io");
   await expect(
     footer.getByRole("link", { name: "MIT License" }),
   ).toHaveAttribute("href", `${GITHUB}/blob/main/LICENSE`);
@@ -106,6 +132,9 @@ test("mobile (390w): the hamburger panel reaches every canonical nav destination
   }
   await expect(
     nav.getByRole("link", { name: "Sign in" }).filter({ visible: true }),
+  ).toHaveAttribute("href", "/signin");
+  await expect(
+    nav.getByRole("link", { name: "Try Cloud" }).filter({ visible: true }),
   ).toHaveAttribute("href", "/signin");
 
   // Theme toggle works from the panel.

--- a/web/src/app/api/mock/account/purge/route.ts
+++ b/web/src/app/api/mock/account/purge/route.ts
@@ -9,6 +9,21 @@ import { mockNow } from "@/mock/clock";
 import { fail, noContent, ok } from "@/mock/http";
 import { USER_IBUKUN } from "@/mock/seed";
 
+/**
+ * Read the purge state so the grace banner + cancel affordance survive a
+ * reload (system QA 2026-07-19: the pending state was client-session-only —
+ * after a refresh every write 409'd with no visible way to cancel).
+ * 200 `null` when none is on file — the read is a status probe on every
+ * settings mount, and a 404 would log console noise on the happy path.
+ */
+export async function GET() {
+  const db = getDb();
+  if (!db.purgeRequest || db.purgeRequest.status === "cancelled") {
+    return ok(null);
+  }
+  return ok(db.purgeRequest);
+}
+
 export async function POST() {
   const db = getDb();
   if (db.purgeRequest?.status === "pending") {

--- a/web/src/app/api/mock/bank-links/[id]/route.ts
+++ b/web/src/app/api/mock/bank-links/[id]/route.ts
@@ -68,6 +68,19 @@ export async function DELETE(request: Request, context: Context) {
     db.transactions = db.transactions.filter(
       (txn) => txn.source_link_id !== id,
     );
+    // Pending staged syncs go with them — otherwise confirming a parked
+    // bank job later would re-create rows for the purged link that the
+    // purge can no longer delete (Codex round 4 on PR #209).
+    const linkedJobs = Object.entries(db.jobLinks)
+      .filter(([, linkId]) => linkId === id)
+      .map(([jobId]) => jobId);
+    db.importJobs = db.importJobs.filter(
+      (job) => !(linkedJobs.includes(job.id) && !job.confirmed),
+    );
+    db.stagedTxns = db.stagedTxns.filter(
+      (row) => !linkedJobs.includes(row.job_id),
+    );
+    for (const jobId of linkedJobs) delete db.jobLinks[jobId];
   }
   // purge=false (default): imported transactions stay — the user's records.
   db.bankLinks = db.bankLinks.filter((item) => item.id !== id);

--- a/web/src/app/api/mock/bank-links/[id]/sync/route.ts
+++ b/web/src/app/api/mock/bank-links/[id]/sync/route.ts
@@ -66,6 +66,7 @@ export async function POST(request: Request, context: Context) {
   };
   db.importJobs.unshift(job);
   db.processingSince[job.id] = Date.now();
+  db.jobLinks[job.id] = link.id;
   link.last_synced_at = mockNow().toISOString();
 
   return ok({ job_id: job.id }, 202);

--- a/web/src/app/api/mock/import/[jobId]/confirm/route.ts
+++ b/web/src/app/api/mock/import/[jobId]/confirm/route.ts
@@ -66,6 +66,11 @@ export async function POST(request: Request, context: Context) {
 
   // Atomic: all-or-error (single synchronous store mutation).
   db.transactions.unshift(...entries);
+  if (job.source === "bank_sync") {
+    // The LinkAccountCard total tracks committed rows (Codex P2 class).
+    const link = db.bankLinks.find((item) => item.id === db.jobLinks[job.id]);
+    if (link) link.imported_txn_count += entries.length;
+  }
   db.stagedTxns = db.stagedTxns.filter((row) => row.job_id !== jobId);
   job.confirmed = true;
   job.imported = entries.length;

--- a/web/src/app/api/mock/import/[jobId]/confirm/route.ts
+++ b/web/src/app/api/mock/import/[jobId]/confirm/route.ts
@@ -57,7 +57,10 @@ export async function POST(request: Request, context: Context) {
     category_id: row.category_id,
     txn_date: row.txn_date,
     source: fileSource,
-    source_link_id: null,
+    // Bank rows keep their link provenance so DELETE ?purge=true can
+    // remove every transaction from that link (Codex round 3).
+    source_link_id:
+      job.source === "bank_sync" ? (db.jobLinks[job.id] ?? null) : null,
     ai_categorized: row.ai_categorized,
     excluded_from_reports: false,
     anomalies: [],

--- a/web/src/app/api/mock/import/[jobId]/route.ts
+++ b/web/src/app/api/mock/import/[jobId]/route.ts
@@ -93,7 +93,12 @@ export async function GET(request: Request, context: Context) {
         job.duplicates_found = 0;
         job.ai_summary = `${rows.length} transactions synced.`;
         job.completed_at = mockNow().toISOString();
-        if (link?.auto_confirm) {
+        // Purge grace keeps the ledger read-only (flows/rights.md §2) —
+        // the async completion path must not commit what the sync POST
+        // could no longer write (Codex P1 on PR #209): fall back to
+        // staging; confirm-after-cancel goes through the guarded POST.
+        const purgePending = db.purgeRequest?.status === "pending";
+        if (link?.auto_confirm && !purgePending) {
           const entries: TxnEntry[] = rows.map((row) => ({
             id: nextId("txn"),
             org_id: job.org_id,
@@ -112,6 +117,8 @@ export async function GET(request: Request, context: Context) {
           db.transactions.unshift(...entries);
           job.imported = entries.length;
           job.confirmed = true;
+          // The LinkAccountCard total tracks committed rows (Codex P2).
+          link.imported_txn_count += entries.length;
         } else {
           db.stagedTxns.push(...rows);
         }

--- a/web/src/app/api/mock/import/[jobId]/route.ts
+++ b/web/src/app/api/mock/import/[jobId]/route.ts
@@ -3,7 +3,7 @@
  * (DELETE). Processing jobs complete ~1.2s after upload on the next poll.
  */
 
-import type { StagedTransaction } from "@/models";
+import type { StagedTransaction, TxnEntry } from "@/models";
 import { getDb, nextId } from "@/mock/db";
 import { mockNow } from "@/mock/clock";
 import {
@@ -18,8 +18,16 @@ type Context = { params: Promise<{ jobId: string }> };
 
 const PROCESSING_MS = 1200;
 
-/** Deterministic staged rows for jobs created through the mock upload. */
-const generateStagedRows = (jobId: string): StagedTransaction[] => {
+/**
+ * Deterministic staged rows for jobs created through the mock upload.
+ * `clean` skips the duplicate flags — bank feeds are exact copies of the
+ * account, so bank_sync jobs stage clean rows (duplicates come from
+ * re-uploaded files).
+ */
+const generateStagedRows = (
+  jobId: string,
+  options: { clean?: boolean } = {},
+): StagedTransaction[] => {
   const rows: StagedTransaction[] = [];
   const merchants = [
     "POS — Shoprite Lekki",
@@ -39,7 +47,7 @@ const generateStagedRows = (jobId: string): StagedTransaction[] => {
       direction: isIncome ? "income" : "expense",
       category_id: isIncome ? "cat-consulting" : "cat-ops",
       ai_categorized: true,
-      is_duplicate: i % 9 === 8, // 2 of 18 duplicates
+      is_duplicate: options.clean ? false : i % 9 === 8, // 2 of 18 duplicates
       include_duplicate: false,
       txn_date: `2026-07-${String((i % 18) + 1).padStart(2, "0")}`,
     });
@@ -71,6 +79,42 @@ export async function GET(request: Request, context: Context) {
         job.status = "completed"; // completed-empty (no_transactions_found UX)
         job.total_parsed = 0;
         job.completed_at = mockNow().toISOString();
+      } else if (job.source === "bank_sync") {
+        // The link's advertised "Auto-confirm clean syncs" control must
+        // observably change the outcome (review canon 2026-07-19: the
+        // completer never read it — a dead toggle). Clean feed rows:
+        // auto_confirm on → committed straight to the ledger; off → the
+        // usual staged review.
+        const linkId = db.jobLinks[job.id];
+        const link = db.bankLinks.find((item) => item.id === linkId);
+        const rows = generateStagedRows(job.id, { clean: true });
+        job.status = "completed";
+        job.total_parsed = rows.length;
+        job.duplicates_found = 0;
+        job.ai_summary = `${rows.length} transactions synced.`;
+        job.completed_at = mockNow().toISOString();
+        if (link?.auto_confirm) {
+          const entries: TxnEntry[] = rows.map((row) => ({
+            id: nextId("txn"),
+            org_id: job.org_id,
+            description: row.description,
+            amount: row.amount,
+            direction: row.direction,
+            category_id: row.category_id,
+            txn_date: row.txn_date,
+            source: "bank",
+            source_link_id: linkId ?? null,
+            ai_categorized: row.ai_categorized,
+            excluded_from_reports: false,
+            anomalies: [],
+            created_at: mockNow().toISOString(),
+          }));
+          db.transactions.unshift(...entries);
+          job.imported = entries.length;
+          job.confirmed = true;
+        } else {
+          db.stagedTxns.push(...rows);
+        }
       } else {
         const rows = generateStagedRows(job.id);
         db.stagedTxns.push(...rows);

--- a/web/src/app/api/mock/import/upload/route.ts
+++ b/web/src/app/api/mock/import/upload/route.ts
@@ -59,6 +59,23 @@ export async function POST(request: Request) {
     return fail(415, "unsupported_type", "Upload a CSV, PDF, or receipt image");
   }
 
+  // Consent gate (flows/import.md §3): images always need AI to parse —
+  // without an `ai_processing` consent record they are refused with
+  // 403 consent_required (PDFs proceed regex-only; CSV never needs AI).
+  // Review canon 2026-07-19: the advertised consent control must
+  // observably gate results, not decorate them.
+  if (
+    fileType === "image" &&
+    !db.consents.some((record) => record.document === "ai_processing")
+  ) {
+    return fail(
+      403,
+      "consent_required",
+      "Receipt images need AI processing — record the ai_processing consent first",
+      { document: "ai_processing" },
+    );
+  }
+
   const job: ImportJob = {
     id: nextId("job"),
     org_id: orgId,

--- a/web/src/app/api/mock/ratios/[key]/trace/route.ts
+++ b/web/src/app/api/mock/ratios/[key]/trace/route.ts
@@ -1,6 +1,7 @@
 /** Mock: formula trace for one metric (MI-8 "how we got this"). */
 
 import { getOrComputeReport } from "@/mock/ratio-engine";
+import { PERIOD_PATTERN } from "@/models/registry/line-items";
 import { fail, notFound, ok, resolveOrgId } from "@/mock/http";
 
 type Context = { params: Promise<{ key: string }> };
@@ -12,6 +13,11 @@ export async function GET(request: Request, context: Context) {
   const period = new URL(request.url).searchParams.get("period");
   if (!period) {
     return fail(422, "validation_failed", "period query param is required");
+  }
+  if (!PERIOD_PATTERN.test(period)) {
+    return fail(422, "validation_failed", `Malformed period: ${period}`, {
+      param: "period",
+    });
   }
   const report = getOrComputeReport(orgId, period);
   const result = report.ratios.find((ratio) => ratio.key === key);

--- a/web/src/app/api/mock/ratios/route.ts
+++ b/web/src/app/api/mock/ratios/route.ts
@@ -1,6 +1,7 @@
 /** Mock: ratio report for a period (GET ?period=) — computes lazily. */
 
 import { getOrComputeReport } from "@/mock/ratio-engine";
+import { PERIOD_PATTERN } from "@/models/registry/line-items";
 import { fail, ok, resolveOrgId } from "@/mock/http";
 
 export async function GET(request: Request) {
@@ -9,6 +10,14 @@ export async function GET(request: Request) {
   const period = new URL(request.url).searchParams.get("period");
   if (!period) {
     return fail(422, "validation_failed", "period query param is required");
+  }
+  // Closed period grammar (line-items.md §6): malformed values 422
+  // instead of caching an all-n/a report under a garbage key (review
+  // canon 2026-07-19).
+  if (!PERIOD_PATTERN.test(period)) {
+    return fail(422, "validation_failed", `Malformed period: ${period}`, {
+      param: "period",
+    });
   }
   return ok(getOrComputeReport(orgId, period));
 }

--- a/web/src/app/api/mock/transactions/route.ts
+++ b/web/src/app/api/mock/transactions/route.ts
@@ -70,7 +70,12 @@ export async function GET(request: Request) {
     ["amount_min", amountMin],
     ["amount_max", amountMax],
   ] as const) {
-    if (value !== null && !AMOUNT_PATTERN.test(value)) {
+    if (
+      value !== null &&
+      (!AMOUNT_PATTERN.test(value) || !Number.isFinite(Number(value)))
+    ) {
+      // Digit-only but overflowing values become Infinity and silently
+      // unfilter/empty the ledger (Codex round 4).
       return invalidParam(name, value);
     }
   }

--- a/web/src/app/api/mock/transactions/route.ts
+++ b/web/src/app/api/mock/transactions/route.ts
@@ -6,6 +6,18 @@ import { mockNow } from "@/mock/clock";
 import { fail, ok, paginate, resolveOrgId, writeBlocked } from "@/mock/http";
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Shape AND calendar validity — 2026-02-30 is not a date (Codex round 3). */
+const isRealDate = (value: string): boolean => {
+  if (!DATE_PATTERN.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+};
 const AMOUNT_PATTERN = /^\d+(\.\d+)?$/;
 const LIMIT_PATTERN = /^\d+$/;
 const SOURCES: readonly string[] = ["manual", "csv", "pdf", "receipt", "bank"];
@@ -44,7 +56,7 @@ export async function GET(request: Request) {
     ["date_from", dateFrom],
     ["date_to", dateTo],
   ] as const) {
-    if (value !== null && !DATE_PATTERN.test(value)) {
+    if (value !== null && !isRealDate(value)) {
       return invalidParam(name, value);
     }
   }

--- a/web/src/app/api/mock/transactions/route.ts
+++ b/web/src/app/api/mock/transactions/route.ts
@@ -5,6 +5,23 @@ import { getDb, nextId } from "@/mock/db";
 import { mockNow } from "@/mock/clock";
 import { fail, ok, paginate, resolveOrgId, writeBlocked } from "@/mock/http";
 
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const AMOUNT_PATTERN = /^\d+(\.\d+)?$/;
+const LIMIT_PATTERN = /^\d+$/;
+const SOURCES: readonly string[] = ["manual", "csv", "pdf", "receipt", "bank"];
+const DIRECTIONS: readonly string[] = ["income", "expense"];
+
+/**
+ * Query grammar is a boundary (review canon 2026-07-19): malformed values
+ * 422 with the offending param instead of silently filtering — a
+ * `amount_min=abc` used to NaN-compare every row away, reading like an
+ * empty ledger.
+ */
+const invalidParam = (name: string, value: string) =>
+  fail(422, "validation_failed", `Malformed ${name}: ${value}`, {
+    param: name,
+  });
+
 export async function GET(request: Request) {
   const orgId = resolveOrgId(request);
   if (!orgId) return fail(404, "not_found", "Unknown org");
@@ -21,7 +38,37 @@ export async function GET(request: Request) {
   const anomalyOnly = params.get("anomaly_only") === "true";
   const search = params.get("search")?.toLowerCase() ?? null;
   const cursor = params.get("cursor");
-  const limit = Math.min(Number(params.get("limit") ?? 50), 100);
+  const rawLimit = params.get("limit");
+
+  for (const [name, value] of [
+    ["date_from", dateFrom],
+    ["date_to", dateTo],
+  ] as const) {
+    if (value !== null && !DATE_PATTERN.test(value)) {
+      return invalidParam(name, value);
+    }
+  }
+  if (source !== null && !SOURCES.includes(source)) {
+    return invalidParam("source", source);
+  }
+  if (direction !== null && !DIRECTIONS.includes(direction)) {
+    return invalidParam("direction", direction);
+  }
+  for (const [name, value] of [
+    ["amount_min", amountMin],
+    ["amount_max", amountMax],
+  ] as const) {
+    if (value !== null && !AMOUNT_PATTERN.test(value)) {
+      return invalidParam(name, value);
+    }
+  }
+  if (
+    rawLimit !== null &&
+    (!LIMIT_PATTERN.test(rawLimit) || rawLimit === "0")
+  ) {
+    return invalidParam("limit", rawLimit);
+  }
+  const limit = Math.min(Number(rawLimit ?? 50), 100);
 
   const filtered = db.transactions
     .filter((txn) => txn.org_id === orgId)
@@ -38,7 +85,9 @@ export async function GET(request: Request) {
     )
     .sort((a, b) => (a.txn_date < b.txn_date ? 1 : -1));
 
-  return ok(paginate(filtered, cursor, limit));
+  const page = paginate(filtered, cursor, limit);
+  if (!page) return invalidParam("cursor", cursor ?? "");
+  return ok(page);
 }
 
 export async function POST(request: Request) {

--- a/web/src/app/dashboard/DashboardShell.tsx
+++ b/web/src/app/dashboard/DashboardShell.tsx
@@ -3,8 +3,9 @@
 /**
  * Dashboard shell — the Part B app chrome (pages.md Part B): left nav
  * (AppNav 240px ⇄ 64px rail) with the org switcher atop, MI-5 anomaly
- * badge on Transactions, the global ⌘K palette (MI-1), theme application,
- * and the auth + first-run guards. Views render inside; controllers own
+ * badge on Transactions, the global ⌘K palette (MI-1), the chrome theme
+ * toggle (parity canon), and the auth + first-run guards. The theme
+ * itself applies pre-paint via the root-layout ThemeProvider script. Views render inside; controllers own
  * every piece of state.
  */
 
@@ -29,10 +30,11 @@ import {
   useAuthController,
   useOrg,
   useRequireAuth,
-  useThemeController,
 } from "@/controllers";
 import AppNav, { NavGroupLabel, NavItem } from "@/components/ui/AppNav";
+import ThemeToggle from "@/components/ui/ThemeToggle";
 import Avatar from "@/components/ui/Avatar";
+import { cn } from "@/lib/cn";
 import CommandPalette, {
   type CommandItem,
 } from "@/components/ui/CommandPalette";
@@ -104,7 +106,21 @@ const ShellChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { orgs, activeOrg, activeOrgId, switchOrg, loading } = useOrg();
   const { count: anomalyCount } = useAnomalyBadgeController(activeOrgId);
   const [collapsed, setCollapsed] = useState(false);
+  // Below md the nav always rides the 64px icon rail — a fixed 240px
+  // column left ~150px of content at 390w (system QA 2026-07-19).
+  const [isMobile, setIsMobile] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia("(max-width: 767px)");
+    const update = () => setIsMobile(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+
+  const effectiveCollapsed = collapsed || isMobile;
 
   // First-run guard: a signed-in user with no org lands on B0.
   useEffect(() => {
@@ -191,8 +207,8 @@ const ShellChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <div className="flex h-screen overflow-hidden bg-bg text-text">
       <AppNav
-        collapsed={collapsed}
-        onCollapsedChange={onCollapsedChange}
+        collapsed={effectiveCollapsed}
+        onCollapsedChange={isMobile ? undefined : onCollapsedChange}
         orgSwitcher={
           activeOrgId ? (
             <OrgSwitcher
@@ -200,13 +216,18 @@ const ShellChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
               currentOrgId={activeOrgId}
               onSelect={switchOrg}
               onCreate={() => router.push("/onboarding?create=1")}
-              compact={collapsed}
+              compact={effectiveCollapsed}
             />
           ) : null
         }
         footer={
-          <div className="mb-1 flex items-center gap-2 px-2.5 py-1.5">
-            {!collapsed ? (
+          <div
+            className={cn(
+              "mb-1 flex items-center gap-2 px-2.5 py-1.5",
+              effectiveCollapsed && "flex-col",
+            )}
+          >
+            {!effectiveCollapsed ? (
               <>
                 <Avatar name={user?.name ?? "…"} size="sm" />
                 <span className="min-w-0 flex-1 truncate text-[13px] text-text-2">
@@ -214,6 +235,9 @@ const ShellChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
                 </span>
               </>
             ) : null}
+            {/* Theme parity canon (2026-07-19): the toggle lives in the
+                dashboard chrome too, same ThemeProvider contract. */}
+            <ThemeToggle className="p-1" />
             <button
               type="button"
               aria-label="Sign out"
@@ -268,8 +292,6 @@ export const DashboardShell: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const { user, checked } = useRequireAuth();
-  // Theme applies on every dashboard mount (B9 control sets it).
-  useThemeController();
 
   if (!checked || !user) return null;
 

--- a/web/src/app/dashboard/OverviewView.tsx
+++ b/web/src/app/dashboard/OverviewView.tsx
@@ -90,7 +90,7 @@ export const OverviewView: React.FC = () => {
     return (
       <>
         <PageHeader title="Overview" />
-        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {[0, 1, 2, 3].map((i) => (
             <StatCard key={i} label="" value={0} loading />
           ))}
@@ -144,7 +144,7 @@ export const OverviewView: React.FC = () => {
             demoToggle={{ enabled: demoEnabled, onChange: setDemoEnabled }}
           />
         </div>
-        <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {[demo.stats.net, demo.stats.income, demo.stats.expenses].map(
             (stat) => (
               <StatCard
@@ -289,7 +289,7 @@ export const OverviewView: React.FC = () => {
         </div>
       ) : null}
 
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard
           label="Net cash flow"
           value={current ? current.income - current.expense : 0}
@@ -315,6 +315,7 @@ export const OverviewView: React.FC = () => {
         />
         <StatCard
           label="Expenses"
+          deltaDirection="down-good"
           value={current?.expense ?? 0}
           format={(value) => formatMoney(value, currency)}
           delta={
@@ -430,9 +431,27 @@ export const OverviewView: React.FC = () => {
                   centerCaption="Expenses"
                   legend="none"
                 />
-                {/* Screen-level legend with values (Figma B1 template). */}
+                {/* Screen-level legend with values (Figma B1 template):
+                    top 5 slices + an aggregated Other row so the shares
+                    always sum to 100% (system QA 2026-07-19 — the tail
+                    was silently dropped and the legend read 95%). */}
                 <dl className="min-w-0 flex-1 space-y-1.5 text-[12px]">
-                  {donutSlices.slice(0, 5).map((slice) => (
+                  {[
+                    ...donutSlices.slice(0, 5),
+                    ...(donutSlices.length > 5
+                      ? [
+                          {
+                            id: "other",
+                            label: "Other",
+                            // Neutral secondary token color — data tail.
+                            color: "var(--text-2)",
+                            value: donutSlices
+                              .slice(5)
+                              .reduce((sum, slice) => sum + slice.value, 0),
+                          },
+                        ]
+                      : []),
+                  ].map((slice) => (
                     <div
                       key={slice.id}
                       className="flex items-center justify-between gap-2"

--- a/web/src/app/dashboard/company/ratios/RatiosView.tsx
+++ b/web/src/app/dashboard/company/ratios/RatiosView.tsx
@@ -352,9 +352,20 @@ export const RatiosView: React.FC = () => {
                 <h3 className="mb-1 uppercase tracking-wide text-text-2">
                   line-item inputs
                 </h3>
+                {/* Resolved inputs: key + amount readable at a glance, the
+                    LINE_ITEM id kept as the audit pointer (title). */}
                 <ul className="space-y-0.5">
                   {trace.inputs.map((input) => (
-                    <li key={input}>{input}</li>
+                    <li
+                      key={input.id}
+                      title={input.id}
+                      className="flex items-baseline justify-between gap-3"
+                    >
+                      <span>{input.canonical_key}</span>
+                      <span className="tabular-nums text-text">
+                        {formatMoney(input.amount, currency)}
+                      </span>
+                    </li>
                   ))}
                 </ul>
               </section>

--- a/web/src/app/dashboard/reports/ReportsView.tsx
+++ b/web/src/app/dashboard/reports/ReportsView.tsx
@@ -10,7 +10,6 @@
 
 import React, { useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import dayjs from "dayjs";
 import {
   useCategoriesController,
   useOrg,
@@ -24,6 +23,7 @@ import Radio from "@/components/ui/Radio";
 import ReportArtifactRow from "@/components/ui/ReportArtifactRow";
 import Select from "@/components/ui/Select";
 import Skeleton from "@/components/ui/Skeleton";
+import { isArtifactNew } from "@/lib/artifact-new";
 import PageHeader from "../PageHeader";
 import ToastLayer from "../ToastLayer";
 
@@ -221,12 +221,12 @@ export const ReportsView: React.FC = () => {
               <ReportArtifactRow
                 key={artifact.id}
                 artifact={artifact}
-                // MI-14: NEW while ≤24h old (|diff| absorbs the seed's
-                // pinned mock clock vs the real clock).
+                // MI-14: NEW while ≤24h old (created ≥ now−24h — the
+                // pure rule in lib/artifact-new, unit-tested; system QA
+                // 2026-07-19 replaced the clock-skew |diff| hack).
                 isNew={
                   artifact.status === "ready" &&
-                  Math.abs(dayjs().diff(dayjs(artifact.created_at), "hour")) <=
-                    24
+                  isArtifactNew(artifact.created_at)
                 }
                 onDownload={() => download(artifact.signed_url)}
               />

--- a/web/src/app/dashboard/settings/SettingsView.tsx
+++ b/web/src/app/dashboard/settings/SettingsView.tsx
@@ -80,6 +80,24 @@ export const SettingsView: React.FC = () => {
     [],
   );
 
+  // Restore an open grace window on mount — the banner + cancel must
+  // survive reloads (flows/rights.md §2; system QA 2026-07-19).
+  const { purgeStatus } = settings;
+  useEffect(() => {
+    let cancelled = false;
+    void purgeStatus()
+      .then((request) => {
+        if (!cancelled && request?.status === "pending") setPurge(request);
+      })
+      .catch(() => {
+        // Read-only affordance restore — errors stay silent here; writes
+        // still surface purge_pending through their own toasts.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [purgeStatus]);
+
   const aiConsented = settings.consents.some(
     (record) => record.document === "ai_processing",
   );
@@ -149,6 +167,11 @@ export const SettingsView: React.FC = () => {
       if (err instanceof ApiError && err.code === "purge_pending") {
         setToast("A purge is already pending.");
         setPurgeOpen(false);
+        // Surface the existing window's banner + cancel affordance.
+        void purgeStatus().then(
+          (request) => request && setPurge(request),
+          () => {},
+        );
       } else {
         setToast(err instanceof Error ? err.message : "Request failed");
       }

--- a/web/src/app/dashboard/taxes/file/FilingWizardView.tsx
+++ b/web/src/app/dashboard/taxes/file/FilingWizardView.tsx
@@ -11,7 +11,7 @@
  * v1 scope: filing-ready documents + guided handoff.
  */
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useOrg, useTaxController } from "@/controllers";
 import { ApiError } from "@/models/repositories";
@@ -38,6 +38,13 @@ const KIND_OPTIONS = [
 
 const STEP_LABELS = ["Period", "Data review", "Documents", "Submit"];
 
+/** Seeded complete periods per kind (mock period grammar). */
+const DEFAULT_PERIOD: Record<TaxKind, string> = {
+  vat: "2026-06",
+  pit: "2025",
+  cit: "FY2025",
+};
+
 const stepState = (
   index: number,
   current: Step,
@@ -57,12 +64,27 @@ export const FilingWizardView: React.FC = () => {
   const [step, setStep] = useState<Step>(1);
   const [kind, setKind] = useState<TaxKind>("vat");
   const [period, setPeriod] = useState<string | null>("2026-06");
+  const [kindTouched, setKindTouched] = useState(false);
   const [filing, setFiling] = useState<TaxFiling | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [identityBlocked, setIdentityBlocked] = useState(false);
   const [busy, setBusy] = useState(false);
   const [confirmText, setConfirmText] = useState("");
   const [done, setDone] = useState(false);
+
+  // Default the filing kind to the org's shape once it resolves — an
+  // individual workspace opened straight onto a VAT draft (system QA
+  // 2026-07-19); PIT is the personal default, VAT the company one.
+  useEffect(() => {
+    if (kindTouched || step !== 1 || filing) return;
+    if (activeOrg?.kind === "personal" && kind !== "pit") {
+      // Defer to a microtask — effects must not set state synchronously.
+      queueMicrotask(() => {
+        setKind("pit");
+        setPeriod(DEFAULT_PERIOD.pit);
+      });
+    }
+  }, [activeOrg?.kind, kind, kindTouched, step, filing]);
 
   const start = async () => {
     if (!period) return;
@@ -115,6 +137,19 @@ export const FilingWizardView: React.FC = () => {
       setBusy(false);
     }
   };
+
+  // Review-step guards (system QA 2026-07-19): surface the profile gate
+  // before the user walks three steps into a 422, and call out an
+  // all-zero draft (e.g. VAT on a ledger with no vatable activity).
+  const profileIncomplete = filing
+    ? !tax.profile?.tin ||
+      (filing.kind === "cit" && !tax.profile?.rc_number) ||
+      (filing.kind === "pit" && !tax.profile?.state_of_residence)
+    : false;
+  const zeroActivity = filing
+    ? filing.computed_fields.length > 0 &&
+      filing.computed_fields.every((field) => field.value === 0)
+    : false;
 
   const traceItems = (target: TaxFiling) =>
     target.computed_fields
@@ -238,8 +273,9 @@ export const FilingWizardView: React.FC = () => {
               options={KIND_OPTIONS}
               value={kind}
               onValueChange={(value) => {
+                setKindTouched(true);
                 setKind(value as TaxKind);
-                setPeriod(value === "vat" ? "2026-06" : "FY2025");
+                setPeriod(DEFAULT_PERIOD[value as TaxKind]);
               }}
             />
             <PeriodPicker
@@ -253,7 +289,9 @@ export const FilingWizardView: React.FC = () => {
                       { label: "June 2026", value: "2026-06" },
                       { label: "May 2026", value: "2026-05" },
                     ]
-                  : [{ label: "FY2025", value: "FY2025" }]
+                  : kind === "pit"
+                    ? [{ label: "2025", value: "2025" }]
+                    : [{ label: "FY2025", value: "FY2025" }]
               }
             />
             <Button
@@ -268,7 +306,7 @@ export const FilingWizardView: React.FC = () => {
 
         {step === 2 && filing ? (
           <section aria-label="Data review" className="space-y-4">
-            {identityBlocked ? (
+            {identityBlocked || profileIncomplete ? (
               <Banner
                 kind="warn"
                 action={
@@ -281,15 +319,23 @@ export const FilingWizardView: React.FC = () => {
                   </Button>
                 }
               >
-                Complete your tax profile — TIN
-                {filing.kind === "cit" ? " and RC number" : ""} are required
-                before documents can be generated (tax_identity_incomplete).
+                Complete your tax profile —{" "}
+                {filing.kind === "cit" ? "TIN and RC number are" : "TIN is"}{" "}
+                required before documents can be generated
+                (tax_identity_incomplete).
               </Banner>
             ) : null}
             <p className="text-[13px] text-text-2">
               Every computed field carries its “how we got this” trace — the
               exact formula and inputs behind the figure (MI-10).
             </p>
+            {zeroActivity ? (
+              <Banner kind="info">
+                No {filing.kind.toUpperCase()} activity found for{" "}
+                {filing.period} — every computed field is ₦0.00. Generating
+                would produce an empty filing.
+              </Banner>
+            ) : null}
             <Accordion items={traceItems(filing)} />
             <div className="flex gap-2">
               <Button kind="quiet" onClick={() => setStep(1)}>

--- a/web/src/app/dashboard/taxes/file/FilingWizardView.tsx
+++ b/web/src/app/dashboard/taxes/file/FilingWizardView.tsx
@@ -15,6 +15,7 @@ import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useOrg, useTaxController } from "@/controllers";
 import { ApiError } from "@/models/repositories";
+import { missingTaxIdentifiers } from "@/models/tax";
 import type { TaxFiling, TaxKind } from "@/models";
 import { formatMoney } from "@/lib/format";
 import Accordion from "@/components/ui/Accordion";
@@ -37,6 +38,23 @@ const KIND_OPTIONS = [
 ];
 
 const STEP_LABELS = ["Period", "Data review", "Documents", "Submit"];
+
+/** Human labels for the shared missing-identifier keys. */
+const IDENTIFIER_LABELS: Record<string, string> = {
+  tin: "TIN",
+  rc_number: "RC number",
+  registered_address: "registered address",
+  state_of_residence: "state of residence",
+};
+
+const formatMissingIdentifiers = (missing: string[]): string => {
+  const labels = missing.map((key) => IDENTIFIER_LABELS[key] ?? key);
+  const joined =
+    labels.length > 1
+      ? `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`
+      : (labels[0] ?? "profile identifiers");
+  return `${joined} ${labels.length === 1 ? "is" : "are"}`;
+};
 
 /** Seeded complete periods per kind (mock period grammar). */
 const DEFAULT_PERIOD: Record<TaxKind, string> = {
@@ -141,11 +159,12 @@ export const FilingWizardView: React.FC = () => {
   // Review-step guards (system QA 2026-07-19): surface the profile gate
   // before the user walks three steps into a 422, and call out an
   // all-zero draft (e.g. VAT on a ledger with no vatable activity).
-  const profileIncomplete = filing
-    ? !tax.profile?.tin ||
-      (filing.kind === "cit" && !tax.profile?.rc_number) ||
-      (filing.kind === "pit" && !tax.profile?.state_of_residence)
-    : false;
+  // Same completeness predicate the generate endpoint enforces (Codex
+  // review on PR #209) — requirements follow the taxpayer, not the
+  // filing kind.
+  const missingIdentifiers =
+    filing && tax.profile ? missingTaxIdentifiers(tax.profile, activeOrg) : [];
+  const profileIncomplete = missingIdentifiers.length > 0;
   const zeroActivity = filing
     ? filing.computed_fields.length > 0 &&
       filing.computed_fields.every((field) => field.value === 0)
@@ -278,22 +297,36 @@ export const FilingWizardView: React.FC = () => {
                 setPeriod(DEFAULT_PERIOD[value as TaxKind]);
               }}
             />
-            <PeriodPicker
-              mode={kind === "vat" ? "month" : "year"}
-              label="Period"
-              value={period}
-              onValueChange={setPeriod}
-              presets={
-                kind === "vat"
-                  ? [
-                      { label: "June 2026", value: "2026-06" },
-                      { label: "May 2026", value: "2026-05" },
-                    ]
-                  : kind === "pit"
-                    ? [{ label: "2025", value: "2025" }]
+            {kind === "pit" ? (
+              // PIT files a plain calendar tax year ("2025") — the
+              // PeriodPicker year mode is the FY#### statement grammar,
+              // which rejects it (Codex review on PR #209), so PIT gets
+              // a year Select of ended years instead.
+              <Select
+                label="Period"
+                options={[
+                  { value: "2025", label: "2025" },
+                  { value: "2024", label: "2024" },
+                ]}
+                value={period}
+                onValueChange={setPeriod}
+              />
+            ) : (
+              <PeriodPicker
+                mode={kind === "vat" ? "month" : "year"}
+                label="Period"
+                value={period}
+                onValueChange={setPeriod}
+                presets={
+                  kind === "vat"
+                    ? [
+                        { label: "June 2026", value: "2026-06" },
+                        { label: "May 2026", value: "2026-05" },
+                      ]
                     : [{ label: "FY2025", value: "FY2025" }]
-              }
-            />
+                }
+              />
+            )}
             <Button
               loading={busy}
               disabled={!period}

--- a/web/src/app/dashboard/taxes/file/FilingWizardView.tsx
+++ b/web/src/app/dashboard/taxes/file/FilingWizardView.tsx
@@ -353,9 +353,8 @@ export const FilingWizardView: React.FC = () => {
                 }
               >
                 Complete your tax profile —{" "}
-                {filing.kind === "cit" ? "TIN and RC number are" : "TIN is"}{" "}
-                required before documents can be generated
-                (tax_identity_incomplete).
+                {formatMissingIdentifiers(missingIdentifiers)} required before
+                documents can be generated (tax_identity_incomplete).
               </Banner>
             ) : null}
             <p className="text-[13px] text-text-2">

--- a/web/src/app/dashboard/transactions/TransactionsView.tsx
+++ b/web/src/app/dashboard/transactions/TransactionsView.tsx
@@ -286,8 +286,17 @@ export const TransactionsView: React.FC = () => {
     setToast(`Exported ${rows.length} transactions`);
   };
 
+  // A stale pick (e.g. chosen, then cancelled, then the selection changed
+  // to mixed) must never apply — Codex review on PR #209: the hidden
+  // picker left Apply armed with the previous category.
+  const bulkCategoryApplies =
+    !!bulkCategory &&
+    selectedDirection !== "mixed" &&
+    selectedDirection !== null &&
+    categoryTypeById.get(bulkCategory) === selectedDirection;
+
   const bulkRecategorize = async () => {
-    if (!bulkCategory) return;
+    if (!bulkCategoryApplies || !bulkCategory) return;
     const ids = [...selected];
     await Promise.all(
       ids.map((id) => txns.update(id, { category_id: bulkCategory })),
@@ -709,7 +718,10 @@ export const TransactionsView: React.FC = () => {
           <BulkActionBar
             className="pointer-events-auto"
             selectedCount={selected.size}
-            onRecategorize={() => setBulkOpen(true)}
+            onRecategorize={() => {
+              if (!bulkCategoryApplies) setBulkCategory(null);
+              setBulkOpen(true);
+            }}
             onExport={exportSelection}
             onClear={() => setSelected(new Set())}
           />
@@ -728,7 +740,7 @@ export const TransactionsView: React.FC = () => {
               Cancel
             </Button>
             <Button
-              disabled={!bulkCategory}
+              disabled={!bulkCategoryApplies}
               onClick={() => void bulkRecategorize()}
             >
               Apply

--- a/web/src/app/dashboard/transactions/TransactionsView.tsx
+++ b/web/src/app/dashboard/transactions/TransactionsView.tsx
@@ -151,10 +151,53 @@ export const TransactionsView: React.FC = () => {
     () => new Map(categoryOptions.map((cat) => [cat.id, cat])),
     [categoryOptions],
   );
+  const categoryTypeById = useMemo(
+    () => new Map(categories.map((cat) => [cat.id, cat.type])),
+    [categories],
+  );
   const categorySelectOptions = useMemo(
     () => categories.map((cat) => ({ value: cat.id, label: cat.name })),
     [categories],
   );
+  // Categories are typed income/expense (B8 registry) — recategorize can
+  // only land on a same-direction category (system QA 2026-07-19: an
+  // expense row could be filed under an income category, poisoning the
+  // donut and VAT treatment).
+  const categoryOptionsByDirection = useMemo(
+    () => ({
+      expense: categoryOptions.filter(
+        (option) => categoryTypeById.get(option.id) === "expense",
+      ),
+      income: categoryOptions.filter(
+        (option) => categoryTypeById.get(option.id) === "income",
+      ),
+    }),
+    [categoryOptions, categoryTypeById],
+  );
+  const categorySelectOptionsByDirection = useMemo(
+    () => ({
+      expense: categories
+        .filter((cat) => cat.type === "expense")
+        .map((cat) => ({ value: cat.id, label: cat.name })),
+      income: categories
+        .filter((cat) => cat.type === "income")
+        .map((cat) => ({ value: cat.id, label: cat.name })),
+    }),
+    [categories],
+  );
+  // Bulk re-categorize applies one category — the selection must share a
+  // direction for a typed category to fit every row.
+  const selectedDirection = useMemo<
+    "income" | "expense" | "mixed" | null
+  >(() => {
+    const directions = new Set(
+      txns.items
+        .filter((txn) => selected.has(txn.id))
+        .map((txn) => txn.direction),
+    );
+    if (directions.size === 0) return null;
+    return directions.size === 1 ? [...directions][0] : "mixed";
+  }, [txns.items, selected]);
 
   const openInspector = useCallback(
     (next: InspectorState) => {
@@ -610,7 +653,7 @@ export const TransactionsView: React.FC = () => {
                       color: FALLBACK_CATEGORY_COLOR,
                     }
                   }
-                  categoryOptions={categoryOptions}
+                  categoryOptions={categoryOptionsByDirection[txn.direction]}
                   selected={selected.has(txn.id)}
                   onSelectedChange={(isSelected) =>
                     setSelected((prev) => {
@@ -656,12 +699,22 @@ export const TransactionsView: React.FC = () => {
         </section>
       )}
 
-      <BulkActionBar
-        selectedCount={selected.size}
-        onRecategorize={() => setBulkOpen(true)}
-        onExport={exportSelection}
-        onClear={() => setSelected(new Set())}
-      />
+      {/* Floats over the ledger at the viewport bottom — selecting rows
+          anywhere in a long table keeps the bar visible (system QA
+          2026-07-19: in normal flow it rendered below the fold and a
+          selection showed no affordance at all). z-sticky per the §2
+          layer registry; the component's own slide-in animates entry. */}
+      {selected.size > 0 ? (
+        <div className="pointer-events-none fixed inset-x-0 bottom-6 z-sticky flex justify-center">
+          <BulkActionBar
+            className="pointer-events-auto"
+            selectedCount={selected.size}
+            onRecategorize={() => setBulkOpen(true)}
+            onExport={exportSelection}
+            onClear={() => setSelected(new Set())}
+          />
+        </div>
+      ) : null}
 
       {/* Bulk re-categorize (MI-4 at scale) */}
       <Modal
@@ -683,13 +736,24 @@ export const TransactionsView: React.FC = () => {
           </div>
         }
       >
-        <Select
-          label="Category"
-          options={categorySelectOptions}
-          value={bulkCategory}
-          onValueChange={setBulkCategory}
-          placeholder="Pick a category"
-        />
+        {selectedDirection === "mixed" ? (
+          <Banner kind="warn">
+            The selection mixes income and expense rows — categories are typed,
+            so pick rows of one direction to re-categorize together.
+          </Banner>
+        ) : (
+          <Select
+            label="Category"
+            options={
+              selectedDirection
+                ? categorySelectOptionsByDirection[selectedDirection]
+                : categorySelectOptions
+            }
+            value={bulkCategory}
+            onValueChange={setBulkCategory}
+            placeholder="Pick a category"
+          />
+        )}
       </Modal>
 
       {/* Save current filters as a view */}
@@ -812,6 +876,13 @@ export const TransactionsView: React.FC = () => {
                     setDraft((prev) => ({
                       ...prev,
                       direction: value as "income" | "expense",
+                      // Direction switch drops a now-mismatched category
+                      // (typed registry — same-direction only).
+                      category_id:
+                        prev.category_id &&
+                        categoryTypeById.get(prev.category_id) === value
+                          ? prev.category_id
+                          : null,
                     }))
                   }
                 />
@@ -821,7 +892,7 @@ export const TransactionsView: React.FC = () => {
           <FormRow label="Category" required>
             {() => (
               <Select
-                options={categorySelectOptions}
+                options={categorySelectOptionsByDirection[draft.direction]}
                 value={draft.category_id}
                 onValueChange={(value) =>
                   setDraft((prev) => ({ ...prev, category_id: value }))

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -1535,11 +1535,11 @@ export const ComponentGallery: React.FC = () => {
             <div className="w-full space-y-3">
               <MarketingNav
                 variant="on-dark"
-                links={[{ label: "Docs", href: "#" }]}
-                solutions={[
-                  { label: "Freelancers", href: "#" },
-                  { label: "SMEs", href: "#" },
-                  { label: "Companies", href: "#" },
+                links={[
+                  { label: "Features", href: "#" },
+                  { label: "Pricing", href: "#" },
+                  { label: "Docs", href: "#" },
+                  { label: "GitHub", href: "#" },
                 ]}
               />
               <MarketingNav

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -14,6 +14,18 @@
     text-align: inherit;
   }
 
+  /* Cursor affordance canon [Directive 2026-07-19]: enabled interactive
+     controls show the pointer — explicit so Tailwind v3/v4 repos behave
+     identically (v4 preflight dropped the button pointer). Links use the
+     native pointer; disabled controls keep the default cursor. */
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]),
+  select:not(:disabled),
+  summary,
+  label[for] {
+    cursor: pointer;
+  }
+
   /* Anchor scrolling is smooth unless the user opts out (design.md §5). */
   html {
     scroll-behavior: smooth;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Inter, JetBrains_Mono } from "next/font/google";
+import { ThemeProvider, themeInitScript } from "@/design/ThemeProvider";
 import "./globals.css";
 
 // Design-system type (design.md §2): Inter for UI/display (Inter Display
@@ -25,9 +26,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" data-scroll-behavior="smooth">
+    <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
+      <head>
+        {/* Pre-paint theme bootstrap: applies the persisted data-theme
+            override before first paint (ThemeProvider contract — a fully
+            static string, no runtime code construction). */}
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body className={`${inter.variable} ${jetbrainsMono.variable}`}>
-        {children}
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -1,42 +1,43 @@
 import React from "react";
 import Link from "next/link";
 
-// Legacy-styled 404 (redesign lands with its own tranche). Live QA
-// 2026-07-19: single h1 + a main landmark (it rendered two h1s and no
-// landmarks), and the dead HOME/Contact Us buttons are real links now.
-const NotFound = () => {
-  return (
-    <div className="bg-gradient-to-r from-purple-300 to-blue-200">
-      <main className="w-9/12 m-auto py-16 min-h-screen flex items-center justify-center">
-        <div className="bg-white shadow overflow-hidden sm:rounded-lg pb-8">
-          <div className="border-t border-gray-200 text-center pt-8">
-            <p aria-hidden className="text-9xl font-bold text-purple-400">
-              404
-            </p>
-            <h1 className="text-6xl font-medium py-8">oops! Page not found</h1>
-            <p className="text-2xl pb-8 px-12 font-medium">
-              Oops! The page you are looking for does not exist. It might have
-              been moved or deleted.
-            </p>
-            <Link
-              href="/"
-              className="bg-gradient-to-r from-purple-400 to-blue-500 hover:from-pink-500 hover:to-orange-500 text-white font-semibold px-6 py-3 rounded-md mr-6 inline-block"
-            >
-              HOME
-            </Link>
-            <a
-              href="https://github.com/cuesoftinc/expendit/issues"
-              target="_blank"
-              rel="noreferrer"
-              className="bg-gradient-to-r from-red-400 to-red-500 hover:from-red-500 hover:to-red-500 text-white font-semibold px-6 py-3 rounded-md inline-block"
-            >
-              Contact Us
-            </a>
-          </div>
-        </div>
-      </main>
-    </div>
-  );
-};
+/**
+ * 404 — token-true, both themes (system QA 2026-07-19: the legacy
+ * purple-gradient page was the last off-brand surface). Editorial-dark
+ * like the marketing hero (bg-editorial is #0C0C0E in both modes); the
+ * only accent is the brand orange, per the design.md §2 tokens.
+ */
+const NotFound = () => (
+  <div data-theme="dark" className="bg-bg-editorial">
+    <main className="mx-auto flex min-h-screen w-full max-w-[1200px] flex-col items-center justify-center px-6 py-16 text-center">
+      <p className="font-mono text-[13px] tabular-nums tracking-wide text-text-2">
+        404 — page not found
+      </p>
+      <h1 className="mt-4 max-w-2xl font-display text-4xl font-bold leading-tight tracking-tight text-text md:text-5xl">
+        This page doesn’t add up.
+      </h1>
+      <p className="mt-4 max-w-md text-sm leading-relaxed text-text-2">
+        The page you’re looking for was moved, deleted, or never posted to the
+        ledger.
+      </p>
+      <div className="mt-8 flex items-center gap-3">
+        <Link
+          href="/"
+          className="rounded bg-accent px-4 py-2 text-sm font-medium text-on-accent transition-colors duration-fast ease-standard hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+        >
+          Back to home
+        </Link>
+        <a
+          href="https://github.com/cuesoftinc/expendit/issues"
+          target="_blank"
+          rel="noreferrer"
+          className="rounded px-4 py-2 text-sm font-medium text-text-2 transition-colors duration-fast ease-standard hover:bg-bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Report an issue
+        </a>
+      </div>
+    </main>
+  </div>
+);
 
 export default NotFound;

--- a/web/src/components/home/HeroSection.tsx
+++ b/web/src/components/home/HeroSection.tsx
@@ -36,6 +36,20 @@ const HERO_CHIPS = [
   { id: "transport", name: "Transport", color: "#B26A00", ai: true },
 ];
 
+/**
+ * Hero-visual composition geometry (design space, px): the 1037-wide
+ * device frame (the Figma hero-visual scale 1037/1440 ≈ 0.72) plus a
+ * 16px chip overhang above its top edge.
+ */
+const HERO_VISUAL_WIDTH = 1037;
+const CHIP_OVERHANG = 16;
+const HERO_VISUAL_HEIGHT =
+  Math.round(
+    DASHBOARD_EMBED_HEIGHT * (HERO_VISUAL_WIDTH / DASHBOARD_EMBED_WIDTH),
+  ) +
+  2 + // frame border (1px top + bottom)
+  CHIP_OVERHANG;
+
 export const HeroSection: React.FC<HeroSectionProps> = ({
   onTryCloud,
   onSelfHost,
@@ -64,38 +78,59 @@ export const HeroSection: React.FC<HeroSectionProps> = ({
         Open source · MIT licensed · Self-host with one command
       </p>
 
-      {/* Hero visual — the B1 overview in a device frame. */}
-      <div className="relative mx-auto mt-14 max-w-[1037px]">
-        {/* Categorization chips animate in once (MI-4 moment). */}
-        <div
-          aria-hidden
-          data-testid="hero-chips"
-          className="pointer-events-none absolute -top-4 right-6 flex gap-2"
+      {/* Hero visual — the B1 overview in a device frame, with the
+          categorization chips floating over its top edge. Chips + frame
+          form ONE scaled composition (design width 1037): the chips ride
+          the same transform as the dashboard, so they keep the Figma
+          proportion at every viewport — and they render AFTER the frame
+          in the DOM so they paint above the embed's own stacking context
+          (system QA 2026-07-19: as positioned siblings BEFORE the
+          transformed subtree they painted underneath it, clipped at the
+          frame's top edge). */}
+      <div className="mx-auto mt-14 max-w-[1037px]">
+        <ScaledEmbed
+          designWidth={HERO_VISUAL_WIDTH}
+          designHeight={HERO_VISUAL_HEIGHT}
         >
-          {HERO_CHIPS.map((chip, index) => (
-            <span
-              key={chip.id}
-              className="animate-rise-in motion-reduce:animate-none"
-              style={{ animationDelay: `${200 + index * 150}ms` }}
+          {/* pt matches CHIP_OVERHANG so the floating chips stay inside
+              the scaled box (no clipping). */}
+          <div className="relative h-full w-full pt-4">
+            <div
+              data-theme="light"
+              // Decorative composition: inert removes it from tab order and
+              // the accessibility tree (the CTAs above are the real actions).
+              inert
+              className="overflow-hidden rounded-lg border border-border bg-bg text-left"
             >
-              <CategoryChip category={chip} aiSuggested={chip.ai} disabled />
-            </span>
-          ))}
-        </div>
-        <div
-          data-theme="light"
-          // Decorative composition: inert removes it from tab order and
-          // the accessibility tree (the CTAs above are the real actions).
-          inert
-          className="overflow-hidden rounded-lg border border-border bg-bg text-left"
-        >
-          <ScaledEmbed
-            designWidth={DASHBOARD_EMBED_WIDTH}
-            designHeight={DASHBOARD_EMBED_HEIGHT}
-          >
-            <DashboardEmbed />
-          </ScaledEmbed>
-        </div>
+              <ScaledEmbed
+                designWidth={DASHBOARD_EMBED_WIDTH}
+                designHeight={DASHBOARD_EMBED_HEIGHT}
+              >
+                <DashboardEmbed />
+              </ScaledEmbed>
+            </div>
+            {/* Categorization chips animate in once (MI-4 moment). */}
+            <div
+              aria-hidden
+              data-testid="hero-chips"
+              className="pointer-events-none absolute right-6 top-0 flex gap-2"
+            >
+              {HERO_CHIPS.map((chip, index) => (
+                <span
+                  key={chip.id}
+                  className="animate-rise-in motion-reduce:animate-none"
+                  style={{ animationDelay: `${200 + index * 150}ms` }}
+                >
+                  <CategoryChip
+                    category={chip}
+                    aiSuggested={chip.ai}
+                    disabled
+                  />
+                </span>
+              ))}
+            </div>
+          </div>
+        </ScaledEmbed>
       </div>
     </SectionInner>
   </EditorialDark>

--- a/web/src/components/home/HomeView.test.tsx
+++ b/web/src/components/home/HomeView.test.tsx
@@ -1,7 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@/design/ThemeProvider";
 import HomeView from "./HomeView";
+
+// The nav theme toggle reads the design-layer ThemeProvider (parity
+// canon, 2026-07-19) — render under it.
+const renderHome = () =>
+  render(
+    <ThemeProvider>
+      <HomeView />
+    </ThemeProvider>,
+  );
 
 const push = vi.fn();
 vi.mock("next/navigation", () => ({
@@ -15,7 +25,7 @@ describe("public home `/` (pages.md Part A, A1–A11)", () => {
   });
 
   it("renders every Part A section", () => {
-    render(<HomeView />);
+    renderHome();
     // A2 hero
     expect(
       screen.getByRole("heading", {
@@ -54,18 +64,19 @@ describe("public home `/` (pages.md Part A, A1–A11)", () => {
   });
 
   it("emits page_view on mount", () => {
-    render(<HomeView />);
+    renderHome();
     expect(
       window.__expenditEvents?.some((record) => record.event === "page_view"),
     ).toBe(true);
   });
 
   it("hero Try Cloud emits try_cloud_click and routes to /signin", async () => {
-    render(<HomeView />);
-    // Order on the page: A1 nav CTA, then the A2 hero CTA.
+    renderHome();
+    // The nav Try Cloud retired with the parity canon (Sign in is the nav
+    // CTA) — the first Try Cloud button is now the A2 hero CTA.
     const heroTryCloud = screen.getAllByRole("button", {
       name: "Try Cloud",
-    })[1];
+    })[0];
     await userEvent.click(heroTryCloud);
     expect(push).toHaveBeenCalledWith("/signin");
     expect(window.__expenditEvents?.at(-1)).toMatchObject({
@@ -75,7 +86,7 @@ describe("public home `/` (pages.md Part A, A1–A11)", () => {
   });
 
   it("Self Host CTA emits self_host_click (scrolls to A8a)", async () => {
-    render(<HomeView />);
+    renderHome();
     const [heroSelfHost] = screen.getAllByRole("button", {
       name: "Self Host",
     });
@@ -89,7 +100,7 @@ describe("public home `/` (pages.md Part A, A1–A11)", () => {
   });
 
   it("A10b final CTA re-emits the A2 events (pages.md A10b)", async () => {
-    render(<HomeView />);
+    renderHome();
     const tryClouds = screen.getAllByRole("button", { name: "Try Cloud" });
     await userEvent.click(tryClouds[tryClouds.length - 1]);
     expect(window.__expenditEvents?.at(-1)).toMatchObject({
@@ -100,7 +111,7 @@ describe("public home `/` (pages.md Part A, A1–A11)", () => {
   });
 
   it("marketing accuracy: pricing is only the GA/self-host line", () => {
-    render(<HomeView />);
+    renderHome();
     expect(screen.getByText("Announced at GA")).toBeInTheDocument();
     expect(screen.getByText("Free forever")).toBeInTheDocument();
     // Star badge is neutral until a runtime count arrives (TEST_MODE: never).

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -16,6 +16,7 @@ import {
   useAnalyticsController,
   usePageView,
 } from "@/controllers/use-analytics";
+import { useGithubStarsController } from "@/controllers/use-github-stars";
 import HeroSection from "./HeroSection";
 import { LogoStrip, PillarsSection } from "./PillarsSection";
 import DeepDivesSection from "./DeepDivesSection";
@@ -51,7 +52,9 @@ const NAV_LINKS = [
   { label: "Features", href: `#${ANCHORS.product}` },
   { label: "Pricing", href: `#${ANCHORS.compare}` },
   { label: "Docs", href: DOCS_URL },
-  { label: "GitHub", href: GITHUB_URL },
+  // Star badge — live count via the stars controller (canon revision:
+  // never hardcoded; neutral "Star" in TEST_MODE / on fetch failure).
+  { label: "GitHub", href: GITHUB_URL, star: true },
 ];
 
 // A11 footer — brand block + 4 columns + legal bar (parity canon).
@@ -123,12 +126,16 @@ export const HomeView: React.FC = () => {
     scrollToAnchor(ANCHORS.selfHost);
   };
 
+  const { stars } = useGithubStarsController();
+
   const navProps = {
     links: NAV_LINKS,
     trailing: <ThemeToggle />,
+    starCount: stars,
     onLinkClick: (label: string) => {
       if (label === "GitHub") track("github_click", { source: "nav" });
     },
+    onTryCloud: () => track("try_cloud_click", { source: "nav" }),
   };
 
   return (
@@ -187,7 +194,16 @@ export const HomeView: React.FC = () => {
             >
               Cuesoft Inc.
             </a>{" "}
-            2026. Expendit. CueLABS™ Division.{" "}
+            2026. Expendit.{" "}
+            <a
+              href={CUELABS_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded transition-colors duration-fast ease-standard hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              CueLABS™ Division
+            </a>
+            .{" "}
             <a
               href={LICENSE_URL}
               target="_blank"

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -83,7 +83,7 @@ const FOOTER_COLUMNS = [
       { label: "GitHub", href: GITHUB_URL },
       { label: "Discord", href: DISCORD_URL },
       { label: "Roadmap", href: ROADMAP_URL },
-      { label: "CueLABS", href: CUELABS_URL },
+      { label: "CueLABS™", href: CUELABS_URL },
     ],
   },
   {

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -25,29 +25,36 @@ import { AiSection, SecuritySection } from "./TrustSections";
 import ContributeSection from "./ContributeSection";
 import { CommunitySection, SelfHostSection } from "./SelfHostCommunity";
 import { CompareSection, FaqSection, FinalCtaSection } from "./CompareFaqCta";
+import ThemeToggle from "@/components/ui/ThemeToggle";
 import {
   ANCHORS,
   scrollToAnchor,
+  API_REFERENCE_URL,
+  CUELABS_URL,
+  CUESOFT_URL,
   DISCORD_URL,
   DOCS_URL,
   GITHUB_URL,
+  LICENSE_URL,
   PRIVACY_HUB_URL,
+  QUICKSTART_URL,
   ROADMAP_URL,
   SECURITY_POLICY_URL,
+  SELF_HOST_DOCS_URL,
+  STATUS_URL,
+  TERMS_URL,
 } from "./links";
 
+// A1 nav — the canonical 4 text links (nav/footer parity canon,
+// org SKILL.md 2026-07-19).
 const NAV_LINKS = [
-  { label: "Product", href: `#${ANCHORS.product}` },
+  { label: "Features", href: `#${ANCHORS.product}` },
+  { label: "Pricing", href: `#${ANCHORS.compare}` },
   { label: "Docs", href: DOCS_URL },
-  { label: "Community", href: `#${ANCHORS.community}` },
+  { label: "GitHub", href: GITHUB_URL },
 ];
 
-const SOLUTIONS = [
-  { label: "Individuals", href: `#${ANCHORS.demo}` },
-  { label: "SMEs", href: `#${ANCHORS.demo}` },
-  { label: "Companies", href: `#${ANCHORS.demo}` },
-];
-
+// A11 footer — brand block + 4 columns + legal bar (parity canon).
 const FOOTER_COLUMNS = [
   {
     heading: "Product",
@@ -59,20 +66,29 @@ const FOOTER_COLUMNS = [
     ],
   },
   {
-    heading: "Resources",
+    heading: "Docs",
     links: [
       { label: "Docs", href: DOCS_URL },
+      { label: "Quickstart", href: QUICKSTART_URL },
+      { label: "API reference", href: API_REFERENCE_URL },
+      { label: "Self-host guide", href: SELF_HOST_DOCS_URL },
+    ],
+  },
+  {
+    heading: "Community",
+    links: [
       { label: "GitHub", href: GITHUB_URL },
       { label: "Discord", href: DISCORD_URL },
       { label: "Roadmap", href: ROADMAP_URL },
+      { label: "CueLABS", href: CUELABS_URL },
     ],
   },
   {
     heading: "Legal",
     links: [
       { label: "Privacy", href: PRIVACY_HUB_URL },
-      { label: "Terms", href: PRIVACY_HUB_URL },
-      { label: "Data rights", href: PRIVACY_HUB_URL },
+      { label: "Terms", href: TERMS_URL },
+      { label: "Status", href: STATUS_URL },
     ],
   },
 ];
@@ -109,11 +125,10 @@ export const HomeView: React.FC = () => {
 
   const navProps = {
     links: NAV_LINKS,
-    solutions: SOLUTIONS,
-    githubHref: GITHUB_URL,
-    onGithubClick: () => track("github_click", { source: "nav" }),
-    onSignIn: () => router.push("/signin"),
-    onTryCloud: () => tryCloud("nav"),
+    trailing: <ThemeToggle />,
+    onLinkClick: (label: string) => {
+      if (label === "GitHub") track("github_click", { source: "nav" });
+    },
   };
 
   return (
@@ -159,7 +174,31 @@ export const HomeView: React.FC = () => {
       <MarketingFooter
         columns={FOOTER_COLUMNS}
         securityPolicyHref={SECURITY_POLICY_URL}
-        note="© 2026 Cuesoft Inc."
+        // Legal bar verbatim per the parity canon — Cuesoft Inc. and MIT
+        // License carry their canonical links.
+        note={
+          <>
+            ©{" "}
+            <a
+              href={CUESOFT_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded transition-colors duration-fast ease-standard hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Cuesoft Inc.
+            </a>{" "}
+            2026. Expendit. CueLABS™ Division.{" "}
+            <a
+              href={LICENSE_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded transition-colors duration-fast ease-standard hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              MIT License
+            </a>
+            .
+          </>
+        }
         brand={
           <div>
             <div className="text-lg font-semibold tracking-tight text-text">
@@ -170,7 +209,19 @@ export const HomeView: React.FC = () => {
             </p>
           </div>
         }
-        meta={<span className="text-[13px] text-text-2">English</span>}
+        meta={
+          // The language selector is a real control (single locale in v1).
+          <label className="flex items-center gap-2 text-[13px] text-text-2">
+            <span className="sr-only">Language</span>
+            <select
+              aria-label="Language"
+              defaultValue="en"
+              className="rounded border border-border bg-bg px-2 py-1 text-[13px] text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              <option value="en">English</option>
+            </select>
+          </label>
+        }
       />
     </div>
   );

--- a/web/src/components/home/embeds.tsx
+++ b/web/src/components/home/embeds.tsx
@@ -110,28 +110,41 @@ const NAV = (
   </AppNav>
 );
 
-/** Latest-transactions rows in the hero embed (seed July narrative). */
+/**
+ * Latest-transactions rows in the hero embed — the seed.ts Cuesoft Ltd
+ * ledger's five most recent July rows, verbatim (system QA 2026-07-19:
+ * two invented rows diverged from the product the CTA leads to).
+ */
 const HERO_TXNS: DemoTxn[] = [
   {
     id: "hero-1",
-    date: "2026-07-16",
-    description: "MTN Business — data bundles",
-    amount: 120_000,
+    date: "2026-07-18",
+    description: "Payroll — July",
+    amount: 1_850_000,
     direction: "expense",
-    categoryId: "utilities",
+    categoryId: "payroll",
     source: "bank",
   },
   {
     id: "hero-2",
-    date: "2026-07-15",
-    description: "Paystack payout — web sales",
-    amount: 1_845_000,
+    date: "2026-07-18",
+    description: "Workshop facilitation — DataCamp Lagos",
+    amount: 800_000,
     direction: "income",
-    categoryId: "product",
-    source: "bank",
+    categoryId: "workshops",
+    source: "manual",
   },
   {
     id: "hero-3",
+    date: "2026-07-16",
+    description: "Team lunch — sprint close",
+    amount: 85_000,
+    direction: "expense",
+    categoryId: "meals",
+    source: "manual",
+  },
+  {
+    id: "hero-4",
     date: "2026-07-15",
     description: "Consulting — BlueRidge Capital",
     amount: 1_585_200,
@@ -140,32 +153,28 @@ const HERO_TXNS: DemoTxn[] = [
     source: "bank",
   },
   {
-    id: "hero-4",
-    date: "2026-07-06",
-    description: "AWS hosting",
-    amount: 438_700,
-    direction: "expense",
-    categoryId: "cloud",
-    source: "bank",
-    ai: true,
-  },
-  {
     id: "hero-5",
-    date: "2026-07-01",
-    description: "Office rent — July",
-    amount: 650_000,
+    date: "2026-07-14",
+    description: "Equipment repair — office AC",
+    amount: 95_300,
     direction: "expense",
-    categoryId: "rent",
-    source: "bank",
+    categoryId: "ops",
+    source: "receipt",
+    ai: true,
   },
 ];
 
+/** Seed registry categories (colors are data — the B8 registry). */
 const HERO_CATEGORIES = {
-  utilities: { id: "utilities", name: "Utilities", color: "#B26A00" },
-  product: { id: "product", name: "Sales", color: "#1B7F4B" },
-  consulting: { id: "consulting", name: "Consulting", color: "#1B7F4B" },
-  cloud: { id: "cloud", name: "Cloud & software", color: "#6E6E76" },
-  rent: { id: "rent", name: "Rent", color: "#2456D6" },
+  payroll: { id: "payroll", name: "Payroll", color: "#C6373C" },
+  workshops: {
+    id: "workshops",
+    name: "Workshops & training",
+    color: "#7DA2FF",
+  },
+  meals: { id: "meals", name: "Meals & team", color: "#F59E0B" },
+  consulting: { id: "consulting", name: "Consulting income", color: "#1B7F4B" },
+  ops: { id: "ops", name: "Ops & logistics", color: "#0EA5E9" },
 } as const;
 
 /*
@@ -211,27 +220,29 @@ export const DashboardEmbed: React.FC = () => {
           VAT return due tomorrow — 21 Jul 2026
         </Banner>
         <div className="grid grid-cols-4 gap-3">
+          {/* Deltas are the seed-computed July-vs-June values, matching
+              the TEST_MODE overview at boot (June net is negative, so the
+              net card carries no delta chip — the app's prev>0 rule). */}
           <StatCard
             label="Net cash flow"
             value={company.stats.net.value}
             format={(value) => formatMoney(value)}
-            delta={company.stats.net.delta}
-            deltaCaption="vs Jun"
             sparkline={company.stats.net.sparkline}
           />
           <StatCard
             label="Income"
             value={company.stats.income.value}
             format={(value) => formatMoney(value)}
-            delta={company.stats.income.delta}
+            delta={-0.075}
             deltaCaption="vs Jun"
             sparkline={company.stats.income.sparkline}
           />
           <StatCard
             label="Expenses"
+            deltaDirection="down-good"
             value={company.stats.expenses.value}
             format={(value) => formatMoney(value)}
-            delta={company.stats.expenses.delta}
+            delta={-0.686}
             deltaCaption="vs Jun"
             sparkline={company.stats.expenses.sparkline}
           />
@@ -286,18 +297,19 @@ export const DashboardEmbed: React.FC = () => {
               </div>
               <div className="space-y-2">
                 <AnomalyBadge
+                  type="abnormal_category"
+                  severity="info"
+                  variant="feed"
+                  description="₦95,300 is 3.4× the trailing mean for Ops & logistics (₦28,000)."
+                  timestamp="14 Jul"
+                />
+                <AnomalyBadge
                   type="large_transaction"
                   severity="warn"
                   variant="feed"
-                  description="₦480,000.00 is 3.4× your median for Equipment"
-                  timestamp="6d"
-                />
-                <AnomalyBadge
-                  type="duplicate_charge"
-                  severity="info"
-                  variant="feed"
-                  description="Same amount & merchant as txn 2 minutes earlier"
-                  timestamp="12d"
+                  // "#2041" is an invoice number (seed data), not a hex color.
+                  description="Invoice #2041 — Nairaflow — ₦2,850,000.00"
+                  timestamp="8 Jul"
                 />
               </div>
               <div className="mt-2 text-[11px] font-medium text-accent">
@@ -398,12 +410,6 @@ const FIRS = {
   payment_channels: ["TaxPro-Max", "Remita"],
 };
 
-const LIRS = {
-  code: "LIRS",
-  name: "Lagos State Internal Revenue Service",
-  payment_channels: ["eTax portal"],
-};
-
 /** B7 tax-center mini (A5a step-3 thumb) — seed tax narrative. */
 export const TaxCenterEmbed: React.FC = () => (
   <div
@@ -432,7 +438,7 @@ export const TaxCenterEmbed: React.FC = () => (
         <RemitToCard
           kind="cit"
           authority={FIRS}
-          amountDue={6_214_900}
+          amountDue={5_474_000}
           dueDate="2027-06-30"
         />
       </div>
@@ -461,12 +467,12 @@ export const TaxCenterEmbed: React.FC = () => (
           />
           <TaxCalendarRow
             entry={{
-              kind: "pit",
+              kind: "cit",
               period: "FY2026",
-              due_date: "2027-03-31",
-              authority: LIRS,
+              due_date: "2027-06-30",
+              authority: FIRS,
             }}
-            daysToDue={254}
+            daysToDue={345}
           />
         </ul>
       </div>
@@ -482,29 +488,29 @@ export const TaxCenterEmbed: React.FC = () => (
               kind: "vat",
               period: "2026-05",
               status: "accepted",
-              amount_due: 421_300,
+              amount_due: 512_300,
               due_date: "2026-06-21",
               computed_fields: [],
               authority: FIRS,
               artifact_key: "receipts/tf-vat-2026-05.pdf",
-              filed_at: "2026-06-18T10:00:00.000Z",
+              filed_at: "2026-06-19T10:00:00.000Z",
               created_at: "2026-06-15T10:00:00.000Z",
             }}
           />
           <FilingHistoryRow
             filing={{
-              id: "tf-vat-2026-04",
+              id: "tf-cit-fy2025",
               org_id: "org-cuesoft",
-              kind: "vat",
-              period: "2026-04",
+              kind: "cit",
+              period: "FY2025",
               status: "accepted",
-              amount_due: 386_750,
-              due_date: "2026-05-21",
+              amount_due: 5_474_000,
+              due_date: "2026-06-30",
               computed_fields: [],
               authority: FIRS,
-              artifact_key: "receipts/tf-vat-2026-04.pdf",
-              filed_at: "2026-05-19T10:00:00.000Z",
-              created_at: "2026-05-15T10:00:00.000Z",
+              artifact_key: "receipts/tf-cit-fy2025.pdf",
+              filed_at: "2026-06-12T10:00:00.000Z",
+              created_at: "2026-06-10T10:00:00.000Z",
             }}
           />
         </ul>

--- a/web/src/components/home/links.ts
+++ b/web/src/components/home/links.ts
@@ -7,15 +7,24 @@
 
 import { prefersReducedMotion } from "@/lib/use-reduced-motion";
 
+// Canonical inventory per the marketing nav/footer & theme parity canon
+// (org SKILL.md, 2026-07-19) — all URLs verified 200.
 export const GITHUB_URL = "https://github.com/cuesoftinc/expendit";
 export const GITHUB_ISSUES_URL = `${GITHUB_URL}/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`;
 export const CONTRIBUTING_URL = `${GITHUB_URL}/blob/main/CONTRIBUTING.md`;
 export const SECURITY_POLICY_URL = `${GITHUB_URL}/blob/main/SECURITY.md`;
-export const ROADMAP_URL = `${GITHUB_URL}/blob/main/docs/roadmap.md`;
-export const SELF_HOST_DOCS_URL = `${GITHUB_URL}/blob/main/docs/setup.md`;
+export const LICENSE_URL = `${GITHUB_URL}/blob/main/LICENSE`;
 export const DOCS_URL = "https://cuesoft.gitbook.io/expendit";
-export const DISCORD_URL = "https://discord.gg/cuesoft";
+export const QUICKSTART_URL = `${DOCS_URL}/setup`;
+export const API_REFERENCE_URL = `${DOCS_URL}/system/api-surface`;
+export const SELF_HOST_DOCS_URL = `${DOCS_URL}/system/deployment`;
+export const ROADMAP_URL = `${DOCS_URL}/product/roadmap`;
+export const DISCORD_URL = "https://discord.gg/CDfZxxrxbb";
+export const CUELABS_URL = "https://cuelabs.cuesoft.io";
+export const CUESOFT_URL = "https://cuesoft.io";
 export const PRIVACY_HUB_URL = "https://privacy.cuesoft.io";
+export const TERMS_URL = "https://terms.cuesoft.io";
+export const STATUS_URL = "https://status.cuesoft.io";
 
 /** Smooth-scrolls to a section anchor (no-op where unimplemented). */
 export const scrollToAnchor = (id: string): void => {

--- a/web/src/components/home/links.ts
+++ b/web/src/components/home/links.ts
@@ -1,7 +1,7 @@
 /**
  * Home-page link register — every external destination the Part A
  * sections reference, in one place (no fabricated URLs: GitHub/docs come
- * from the repo + overview.md; Discord is the CueLABS ecosystem invite;
+ * from the repo + overview.md; Discord is the CueLABS™ ecosystem invite;
  * the privacy hub is the D3 ecosystem surface, architecture.md §2).
  */
 

--- a/web/src/components/ui/CategoryChip.test.tsx
+++ b/web/src/components/ui/CategoryChip.test.tsx
@@ -65,4 +65,19 @@ describe("CategoryChip (design.md §8.2, MI-4)", () => {
     render(<CategoryChip category={groceries} />);
     expect(screen.getByRole("button")).toBeDisabled();
   });
+
+  it("disabled keeps the combobox closed — no live child actions (composite-control canon)", async () => {
+    render(
+      <CategoryChip
+        category={{ id: "c1", name: "Ops", color: "#0EA5E9" }}
+        options={[{ id: "c2", name: "Meals", color: "#F59E0B" }]}
+        onSelect={() => {}}
+        disabled
+      />,
+    );
+    const chip = screen.getByRole("button");
+    expect(chip).toBeDisabled();
+    await userEvent.click(chip);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/components/ui/ComparisonTable.test.tsx
+++ b/web/src/components/ui/ComparisonTable.test.tsx
@@ -59,4 +59,22 @@ describe("ComparisonTable (design.md §8.2b)", () => {
       screen.getByRole("button", { name: "Read the docs" }),
     ).toBeInTheDocument();
   });
+
+  it("text cells never wrap — the mobile price row keeps one line (system QA regression)", () => {
+    render(
+      <ComparisonTable
+        rows={[
+          {
+            feature: "Price",
+            cloud: { kind: "text", text: "Announced at GA" },
+            selfHost: { kind: "text", text: "Free forever" },
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Announced at GA")).toHaveClass(
+      "whitespace-nowrap",
+    );
+    expect(screen.getByText("Free forever")).toHaveClass("whitespace-nowrap");
+  });
 });

--- a/web/src/components/ui/ComparisonTable.tsx
+++ b/web/src/components/ui/ComparisonTable.tsx
@@ -38,7 +38,11 @@ const Cell: React.FC<{ cell: ComparisonCell }> = ({ cell }) => {
       <X aria-label="Not included" className="mx-auto h-4 w-4 text-text-2" />
     );
   }
-  return <span className="text-[13px] text-text">{cell.text}</span>;
+  // Single line always: on the 390 comparison the price row wrapped and
+  // mis-baselined against its neighbor (system QA 2026-07-19).
+  return (
+    <span className="whitespace-nowrap text-[13px] text-text">{cell.text}</span>
+  );
 };
 
 export const ComparisonTable: React.FC<ComparisonTableProps> = ({
@@ -83,10 +87,10 @@ export const ComparisonTable: React.FC<ComparisonTableProps> = ({
           >
             {row.feature}
           </th>
-          <td className="py-2.5 text-center">
+          <td className="py-2.5 text-center align-middle">
             <Cell cell={row.cloud} />
           </td>
-          <td className="py-2.5 text-center">
+          <td className="py-2.5 text-center align-middle">
             <Cell cell={row.selfHost} />
           </td>
         </tr>
@@ -96,8 +100,8 @@ export const ComparisonTable: React.FC<ComparisonTableProps> = ({
       <tfoot>
         <tr>
           <td className="py-3" />
-          <td className="py-3 text-center">{cloudCta}</td>
-          <td className="py-3 text-center">{selfHostCta}</td>
+          <td className="py-3 text-center align-middle">{cloudCta}</td>
+          <td className="py-3 text-center align-middle">{selfHostCta}</td>
         </tr>
       </tfoot>
     ) : null}

--- a/web/src/components/ui/ImportJobRow.test.tsx
+++ b/web/src/components/ui/ImportJobRow.test.tsx
@@ -40,7 +40,7 @@ describe("ImportJobRow (design.md §8.2b)", () => {
   it("completed shows the Figma caption + status tag", () => {
     render(<ImportJobRow job={job()} />);
     expect(
-      screen.getByText("209 transactions · 5 duplicates · 1 anomalies found"),
+      screen.getByText("209 transactions · 5 duplicates · 1 anomaly found"),
     ).toBeInTheDocument();
     expect(screen.getByText("Completed")).toBeInTheDocument();
   });

--- a/web/src/components/ui/ImportJobRow.tsx
+++ b/web/src/components/ui/ImportJobRow.tsx
@@ -19,14 +19,25 @@ import { cn } from "@/lib/cn";
 import Tag from "./Tag";
 
 export type ImportJobRowStatus =
-  "processing" | "completed" | "completed-empty" | "completed-bank" | "failed";
+  | "processing"
+  | "completed"
+  | "completed-empty"
+  | "completed-bank"
+  | "failed"
+  | "needs-review";
 
 /** Folded row status (design.md §8.2b as-built note). */
 export const rowStatus = (job: ImportJob): ImportJobRowStatus => {
   if (job.status === "processing") return "processing";
   if (job.status === "failed") return "failed";
-  if (job.source === "bank_sync") return "completed-bank";
-  return job.total_parsed === 0 ? "completed-empty" : "completed";
+  if (job.total_parsed === 0 && job.source !== "bank_sync")
+    return "completed-empty";
+  // Parked in staged review (parse done, nothing committed): the green
+  // "Completed · 0 transactions" read as an empty import (system QA
+  // 2026-07-19) — surface the review call-to-action instead. Applies to
+  // bank syncs too — they ride the same staged pipeline (pages.md B4).
+  if (!job.confirmed && job.total_parsed > 0) return "needs-review";
+  return job.source === "bank_sync" ? "completed-bank" : "completed";
 };
 
 const FILE_ICON = {
@@ -44,14 +55,32 @@ const caption = (job: ImportJob, status: ImportJobRowStatus): string => {
       return job.error_code ?? "failed";
     case "completed-empty":
       return "0 transactions found — check file contents";
+    case "needs-review": {
+      const staged = `${job.total_parsed} staged for review`;
+      return job.duplicates_found > 0
+        ? `${staged} · ${job.duplicates_found} ${
+            job.duplicates_found === 1 ? "duplicate" : "duplicates"
+          } flagged`
+        : staged;
+    }
     case "completed-bank":
       return `${job.imported} transactions${job.confirmed ? " · auto-confirmed" : ""}`;
     case "completed": {
-      const parts = [`${job.imported} transactions`];
+      const parts = [
+        `${job.imported} ${job.imported === 1 ? "transaction" : "transactions"}`,
+      ];
       if (job.duplicates_found > 0)
-        parts.push(`${job.duplicates_found} duplicates`);
+        parts.push(
+          `${job.duplicates_found} ${
+            job.duplicates_found === 1 ? "duplicate" : "duplicates"
+          }`,
+        );
       if (job.anomalies.length > 0)
-        parts.push(`${job.anomalies.length} anomalies found`);
+        parts.push(
+          `${job.anomalies.length} ${
+            job.anomalies.length === 1 ? "anomaly" : "anomalies"
+          } found`,
+        );
       return parts.join(" · ");
     }
   }
@@ -59,10 +88,11 @@ const caption = (job: ImportJob, status: ImportJobRowStatus): string => {
 
 const STATUS_TAG: Record<
   ImportJobRowStatus,
-  { label: string; tint: "info" | "success" | "neutral" | "error" }
+  { label: string; tint: "info" | "success" | "neutral" | "error" | "warn" }
 > = {
   processing: { label: "Processing", tint: "info" },
   completed: { label: "Completed", tint: "success" },
+  "needs-review": { label: "Needs review", tint: "warn" },
   "completed-bank": { label: "Completed", tint: "success" },
   "completed-empty": { label: "Empty", tint: "neutral" },
   failed: { label: "Failed", tint: "error" },
@@ -81,7 +111,7 @@ export const ImportJobRow: React.FC<ImportJobRowProps> = ({
 }) => {
   const status = rowStatus(job);
   const Icon =
-    status === "completed-bank" ? Landmark : FILE_ICON[job.file_type ?? "csv"];
+    job.source === "bank_sync" ? Landmark : FILE_ICON[job.file_type ?? "csv"];
   const tag = STATUS_TAG[status];
   const when = dayjs(job.created_at).isValid()
     ? dayjs(job.created_at).format("D MMM")

--- a/web/src/components/ui/ManualStatementRow.test.tsx
+++ b/web/src/components/ui/ManualStatementRow.test.tsx
@@ -68,4 +68,21 @@ describe("ManualStatementRow (design.md §8.2)", () => {
     await userEvent.click(screen.getByRole("button", { name: "Remove row" }));
     expect(onRemove).toHaveBeenCalled();
   });
+
+  it("disabled reaches EVERY child action — including the Remove button (composite-control canon)", () => {
+    render(
+      <ul>
+        <ManualStatementRow
+          keyOptions={["cash_and_equivalents", "payables"]}
+          canonicalKey={null}
+          amount=""
+          onRemove={() => {}}
+          disabled
+        />
+      </ul>,
+    );
+    expect(screen.getByRole("button", { name: "Remove row" })).toBeDisabled();
+    expect(screen.getByLabelText("Amount")).toBeDisabled();
+    expect(screen.getByRole("combobox")).toBeDisabled();
+  });
 });

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -16,7 +16,8 @@ export interface FooterColumn {
 export interface MarketingFooterProps {
   columns: FooterColumn[];
   securityPolicyHref?: string;
-  note?: string;
+  /** Legal bar content (parity canon: verbatim string with inline links). */
+  note?: React.ReactNode;
   /** Brand block (logo + tagline) — leads the link columns (Figma A11). */
   brand?: React.ReactNode;
   /** Bottom-right slot beside the security CTA (e.g. language control). */
@@ -54,6 +55,9 @@ export const MarketingFooter: React.FC<MarketingFooterProps> = ({
                 <li key={link.label}>
                   <a
                     href={link.href}
+                    {...(/^https?:\/\//.test(link.href)
+                      ? { target: "_blank", rel: "noreferrer" }
+                      : {})}
                     className="rounded text-[13px] text-text transition-colors duration-fast ease-standard hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                   >
                     {link.label}
@@ -70,6 +74,9 @@ export const MarketingFooter: React.FC<MarketingFooterProps> = ({
       <div className="flex items-center gap-4">
         <a
           href={securityPolicyHref}
+          {...(/^https?:\/\//.test(securityPolicyHref)
+            ? { target: "_blank", rel: "noreferrer" }
+            : {})}
           className={cn(
             "inline-flex items-center gap-1.5 rounded border border-border px-3 py-1.5 text-[13px] font-medium text-text",
             "transition-colors duration-fast ease-standard hover:bg-bg-elev",

--- a/web/src/components/ui/MarketingNav.test.tsx
+++ b/web/src/components/ui/MarketingNav.test.tsx
@@ -73,4 +73,35 @@ describe("MarketingNav (design.md §8.2b + parity canon)", () => {
     );
     expect(screen.getByTestId("slot")).toBeInTheDocument();
   });
+
+  it("mobile: hamburger disclosure carries the 4 links + trailing + Sign in (parity canon)", async () => {
+    render(
+      <MarketingNav {...props} trailing={<span data-testid="slot">t</span>} />,
+    );
+    const menu = screen.getByRole("button", { name: "Menu" });
+    expect(menu).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(menu);
+    expect(menu).toHaveAttribute("aria-expanded", "true");
+    const panel = document.getElementById(
+      menu.getAttribute("aria-controls") ?? "",
+    );
+    expect(panel).toBeTruthy();
+    // Same 4 canonical links (desktop set + panel set both render).
+    for (const [label, href] of [
+      ["Features", "#product"],
+      ["Pricing", "#compare"],
+      ["Docs", "https://cuesoft.gitbook.io/expendit"],
+      ["GitHub", "https://github.com/cuesoftinc/expendit"],
+    ] as const) {
+      const links = screen.getAllByRole("link", { name: label });
+      expect(links.length).toBeGreaterThanOrEqual(2);
+      for (const link of links) expect(link).toHaveAttribute("href", href);
+    }
+    expect(screen.getAllByRole("link", { name: "Sign in" }).length).toBe(2);
+    expect(screen.getAllByTestId("slot").length).toBe(2);
+
+    await userEvent.click(menu);
+    expect(menu).toHaveAttribute("aria-expanded", "false");
+  });
 });

--- a/web/src/components/ui/MarketingNav.test.tsx
+++ b/web/src/components/ui/MarketingNav.test.tsx
@@ -10,9 +10,15 @@ const props = {
     { label: "Features", href: "#product" },
     { label: "Pricing", href: "#compare" },
     { label: "Docs", href: "https://cuesoft.gitbook.io/expendit" },
-    { label: "GitHub", href: "https://github.com/cuesoftinc/expendit" },
+    {
+      label: "GitHub",
+      href: "https://github.com/cuesoftinc/expendit",
+      star: true,
+    },
   ],
 };
+
+const STAR_NAME = "Star cuesoftinc/expendit on GitHub";
 
 describe("MarketingNav (design.md §8.2b + parity canon)", () => {
   it("on-dark variant scopes dark token mode over the hero", () => {
@@ -30,7 +36,7 @@ describe("MarketingNav (design.md §8.2b + parity canon)", () => {
     expect(nav).toHaveClass("sticky");
   });
 
-  it("renders the canonical links — external ones open in a new tab", () => {
+  it("renders the canonical links — GitHub as the star badge, externals in a new tab", () => {
     render(<MarketingNav {...props} />);
     expect(screen.getByRole("link", { name: "Features" })).toHaveAttribute(
       "href",
@@ -43,25 +49,40 @@ describe("MarketingNav (design.md §8.2b + parity canon)", () => {
     const docs = screen.getByRole("link", { name: "Docs" });
     expect(docs).toHaveAttribute("href", "https://cuesoft.gitbook.io/expendit");
     expect(docs).toHaveAttribute("target", "_blank");
-    const github = screen.getByRole("link", { name: "GitHub" });
+    const github = screen.getByRole("link", { name: STAR_NAME });
     expect(github).toHaveAttribute(
       "href",
       "https://github.com/cuesoftinc/expendit",
     );
     expect(github).toHaveAttribute("target", "_blank");
+    // Neutral badge — no count is ever hardcoded.
+    expect(github.textContent).toBe("Star");
   });
 
-  it("Sign in is the CTA and links to /signin", () => {
-    render(<MarketingNav {...props} />);
+  it("star badge renders the live count when provided", () => {
+    render(<MarketingNav {...props} starCount={1280} />);
+    const github = screen.getByRole("link", { name: STAR_NAME });
+    expect(github.textContent).toBe("Star1,280");
+  });
+
+  it("Sign in is a text link and Try Cloud the primary CTA — both to /signin", async () => {
+    const onTryCloud = vi.fn();
+    render(<MarketingNav {...props} onTryCloud={onTryCloud} />);
     const signIn = screen.getByRole("link", { name: "Sign in" });
     expect(signIn).toHaveAttribute("href", "/signin");
-    expect(signIn).toHaveClass("bg-accent");
+    expect(signIn).not.toHaveClass("bg-accent");
+    const tryCloud = screen.getByRole("link", { name: "Try Cloud" });
+    expect(tryCloud).toHaveAttribute("href", "/signin");
+    expect(tryCloud).toHaveClass("bg-accent");
+    tryCloud.addEventListener("click", (event) => event.preventDefault());
+    await userEvent.click(tryCloud);
+    expect(onTryCloud).toHaveBeenCalled();
   });
 
   it("link clicks report their label (github_click analytics hook)", async () => {
     const onLinkClick = vi.fn();
     render(<MarketingNav {...props} onLinkClick={onLinkClick} />);
-    const github = screen.getByRole("link", { name: "GitHub" });
+    const github = screen.getByRole("link", { name: STAR_NAME });
     github.addEventListener("click", (event) => event.preventDefault());
     await userEvent.click(github);
     expect(onLinkClick).toHaveBeenCalledWith("GitHub");
@@ -74,7 +95,7 @@ describe("MarketingNav (design.md §8.2b + parity canon)", () => {
     expect(screen.getByTestId("slot")).toBeInTheDocument();
   });
 
-  it("mobile: hamburger disclosure carries the 4 links + trailing + Sign in (parity canon)", async () => {
+  it("mobile: hamburger disclosure carries the 4 links + trailing + Sign in + Try Cloud (parity canon)", async () => {
     render(
       <MarketingNav {...props} trailing={<span data-testid="slot">t</span>} />,
     );
@@ -92,13 +113,14 @@ describe("MarketingNav (design.md §8.2b + parity canon)", () => {
       ["Features", "#product"],
       ["Pricing", "#compare"],
       ["Docs", "https://cuesoft.gitbook.io/expendit"],
-      ["GitHub", "https://github.com/cuesoftinc/expendit"],
+      [STAR_NAME, "https://github.com/cuesoftinc/expendit"],
     ] as const) {
       const links = screen.getAllByRole("link", { name: label });
       expect(links.length).toBeGreaterThanOrEqual(2);
       for (const link of links) expect(link).toHaveAttribute("href", href);
     }
     expect(screen.getAllByRole("link", { name: "Sign in" }).length).toBe(2);
+    expect(screen.getAllByRole("link", { name: "Try Cloud" }).length).toBe(2);
     expect(screen.getAllByTestId("slot").length).toBe(2);
 
     await userEvent.click(menu);

--- a/web/src/components/ui/MarketingNav.test.tsx
+++ b/web/src/components/ui/MarketingNav.test.tsx
@@ -3,15 +3,18 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MarketingNav from "./MarketingNav";
 
+// Canonical inventory (nav/footer parity canon, 2026-07-19): 4 text links
+// + trailing slot (theme toggle) + the Sign in CTA.
 const props = {
-  links: [{ label: "Docs", href: "/docs" }],
-  solutions: [
-    { label: "Freelancers", href: "/solutions/freelancers" },
-    { label: "SMEs", href: "/solutions/smes" },
+  links: [
+    { label: "Features", href: "#product" },
+    { label: "Pricing", href: "#compare" },
+    { label: "Docs", href: "https://cuesoft.gitbook.io/expendit" },
+    { label: "GitHub", href: "https://github.com/cuesoftinc/expendit" },
   ],
 };
 
-describe("MarketingNav (design.md §8.2b)", () => {
+describe("MarketingNav (design.md §8.2b + parity canon)", () => {
   it("on-dark variant scopes dark token mode over the hero", () => {
     render(<MarketingNav variant="on-dark" {...props} />);
     const nav = screen.getByRole("navigation", { name: "Marketing" });
@@ -27,43 +30,47 @@ describe("MarketingNav (design.md §8.2b)", () => {
     expect(nav).toHaveClass("sticky");
   });
 
-  it("Solutions dropdown opens with menu items", async () => {
+  it("renders the canonical links — external ones open in a new tab", () => {
     render(<MarketingNav {...props} />);
-    await userEvent.click(screen.getByRole("button", { name: /Solutions/ }));
-    expect(screen.getByRole("menu")).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: "Freelancers" }),
-    ).toBeInTheDocument();
-  });
-
-  it("GitHub badge is the neutral Star (no count)", () => {
-    render(<MarketingNav {...props} />);
-    const badge = screen.getByRole("link", { name: /Star/ });
-    expect(badge).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Features" })).toHaveAttribute(
+      "href",
+      "#product",
+    );
+    expect(screen.getByRole("link", { name: "Pricing" })).toHaveAttribute(
+      "href",
+      "#compare",
+    );
+    const docs = screen.getByRole("link", { name: "Docs" });
+    expect(docs).toHaveAttribute("href", "https://cuesoft.gitbook.io/expendit");
+    expect(docs).toHaveAttribute("target", "_blank");
+    const github = screen.getByRole("link", { name: "GitHub" });
+    expect(github).toHaveAttribute(
       "href",
       "https://github.com/cuesoftinc/expendit",
     );
-    expect(badge.textContent).toBe("Star");
+    expect(github).toHaveAttribute("target", "_blank");
   });
 
-  it("GitHub badge click reports for analytics (github_click)", async () => {
-    const onGithubClick = vi.fn();
-    render(<MarketingNav {...props} onGithubClick={onGithubClick} />);
-    const badge = screen.getByRole("link", { name: /Star/ });
-    badge.addEventListener("click", (event) => event.preventDefault());
-    await userEvent.click(badge);
-    expect(onGithubClick).toHaveBeenCalled();
+  it("Sign in is the CTA and links to /signin", () => {
+    render(<MarketingNav {...props} />);
+    const signIn = screen.getByRole("link", { name: "Sign in" });
+    expect(signIn).toHaveAttribute("href", "/signin");
+    expect(signIn).toHaveClass("bg-accent");
   });
 
-  it("Sign in + Try Cloud CTAs fire", async () => {
-    const onSignIn = vi.fn();
-    const onTryCloud = vi.fn();
+  it("link clicks report their label (github_click analytics hook)", async () => {
+    const onLinkClick = vi.fn();
+    render(<MarketingNav {...props} onLinkClick={onLinkClick} />);
+    const github = screen.getByRole("link", { name: "GitHub" });
+    github.addEventListener("click", (event) => event.preventDefault());
+    await userEvent.click(github);
+    expect(onLinkClick).toHaveBeenCalledWith("GitHub");
+  });
+
+  it("renders the trailing slot (theme toggle position)", () => {
     render(
-      <MarketingNav {...props} onSignIn={onSignIn} onTryCloud={onTryCloud} />,
+      <MarketingNav {...props} trailing={<span data-testid="slot">t</span>} />,
     );
-    await userEvent.click(screen.getByRole("button", { name: "Sign in" }));
-    await userEvent.click(screen.getByRole("button", { name: "Try Cloud" }));
-    expect(onSignIn).toHaveBeenCalled();
-    expect(onTryCloud).toHaveBeenCalled();
+    expect(screen.getByTestId("slot")).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -13,8 +13,9 @@
  * so every color here stays a token binding.
  */
 
-import React from "react";
+import React, { useEffect, useId, useState } from "react";
 import Link from "next/link";
+import { Menu, X } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 export interface MarketingNavLink {
@@ -46,11 +47,52 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
   className,
 }) => {
   const onDark = variant === "on-dark";
+  // Mobile canon (org SKILL.md, 2026-07-19): below md the text links
+  // collapse into a hamburger disclosure — never display:none with no
+  // fallback. The panel carries the same 4 links + theme toggle + Sign in.
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuId = useId();
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setMenuOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [menuOpen]);
 
   const itemClass = cn(
     "rounded px-2.5 py-1.5 text-[13px] font-medium transition-colors duration-fast ease-standard",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
     "text-text-2 hover:bg-bg-elev hover:text-text",
+  );
+
+  const signInClass = cn(
+    "rounded bg-accent px-3 py-1.5 text-[13px] font-medium text-on-accent",
+    "transition-colors duration-fast ease-standard hover:opacity-90",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
+  );
+
+  const renderLink = (
+    link: MarketingNavLink,
+    extraClass: string,
+    onNavigate?: () => void,
+  ) => (
+    <a
+      key={link.label}
+      href={link.href}
+      {...(isExternal(link.href)
+        ? { target: "_blank", rel: "noreferrer" }
+        : {})}
+      onClick={() => {
+        onLinkClick?.(link.label);
+        onNavigate?.();
+      }}
+      className={cn(itemClass, extraClass)}
+    >
+      {link.label}
+    </a>
   );
 
   return (
@@ -60,7 +102,7 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
       // on-dark: dark token mode scoped to the nav subtree (both themes).
       data-theme={onDark ? "dark" : undefined}
       className={cn(
-        "w-full px-6 py-3",
+        "relative w-full px-6 py-3",
         onDark
           ? "bg-bg-editorial"
           : "sticky top-0 z-sticky border-b border-border bg-bg",
@@ -77,35 +119,61 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
           expendit
         </Link>
 
-        {links.map((link) => (
-          <a
-            key={link.label}
-            href={link.href}
-            {...(isExternal(link.href)
-              ? { target: "_blank", rel: "noreferrer" }
-              : {})}
-            onClick={onLinkClick ? () => onLinkClick(link.label) : undefined}
-            // Text items collapse below md (375w floor keeps logo + CTAs).
-            className={cn(itemClass, "hidden md:inline-block")}
-          >
-            {link.label}
-          </a>
-        ))}
+        {links.map((link) => renderLink(link, "hidden md:inline-block"))}
 
-        <div className="ml-auto flex items-center gap-2">
+        <div className="ml-auto hidden items-center gap-2 md:flex">
           {trailing}
-          <Link
-            href={signInHref}
-            className={cn(
-              "rounded bg-accent px-3 py-1.5 text-[13px] font-medium text-on-accent",
-              "transition-colors duration-fast ease-standard hover:opacity-90",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
-            )}
-          >
+          <Link href={signInHref} className={signInClass}>
             Sign in
           </Link>
         </div>
+
+        {/* Mobile disclosure trigger. */}
+        <button
+          type="button"
+          aria-label="Menu"
+          aria-expanded={menuOpen}
+          aria-controls={menuId}
+          onClick={() => setMenuOpen((open) => !open)}
+          className={cn(
+            "ml-auto rounded p-1.5 text-text-2 md:hidden",
+            "transition-colors duration-fast ease-standard hover:bg-bg-elev hover:text-text",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+          )}
+        >
+          {menuOpen ? (
+            <X aria-hidden className="h-5 w-5" />
+          ) : (
+            <Menu aria-hidden className="h-5 w-5" />
+          )}
+        </button>
       </div>
+
+      {menuOpen ? (
+        <div
+          id={menuId}
+          className={cn(
+            "absolute inset-x-0 top-full z-dropdown border-b border-border bg-bg px-6 py-3 md:hidden",
+            onDark && "border-t border-t-border",
+          )}
+        >
+          <div className="flex flex-col gap-1">
+            {links.map((link) =>
+              renderLink(link, "block", () => setMenuOpen(false)),
+            )}
+            <div className="mt-2 flex items-center justify-between gap-2 border-t border-border pt-3">
+              {trailing}
+              <Link
+                href={signInHref}
+                className={signInClass}
+                onClick={() => setMenuOpen(false)}
+              >
+                Sign in
+              </Link>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </nav>
   );
 };

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -2,11 +2,12 @@
 
 /**
  * MarketingNav — design.md §8.2b variants: on-dark (over hero) /
- * dark-on-light (post-hero scroll, sticky). Link inventory per the
- * marketing nav/footer & theme parity canon (org SKILL.md, 2026-07-19):
- * 4 text links (Features · Pricing · Docs · GitHub) + theme toggle slot +
- * the "Sign in" CTA (/signin). The Solutions dropdown, Star badge, and
- * nav Try Cloud retired with the canon convergence.
+ * dark-on-light (post-hero scroll, sticky). Composition per the revised
+ * parity canon (2026-07-19): 4 text links where the GitHub item renders
+ * as a compact star badge (live count, neutral "Star" in TEST_MODE or on
+ * fetch failure — never hardcoded) + theme toggle + "Sign in" text link +
+ * the "Try Cloud" primary CTA (→ /signin). Below md everything collapses
+ * into the hamburger disclosure panel.
  *
  * Tokens only: the on-dark variant scopes `data-theme="dark"` on its own
  * subtree (editorial sections are #0C0C0E in both themes, design.md §2),
@@ -21,29 +22,51 @@ import { cn } from "@/lib/cn";
 export interface MarketingNavLink {
   label: string;
   href: string;
+  /** Render as the compact GitHub star badge (star glyph + count). */
+  star?: boolean;
 }
 
 export interface MarketingNavProps {
   /** on-dark: over the hero; dark-on-light: post-hero sticky scroll. */
   variant?: "on-dark" | "dark-on-light";
-  /** The 4 canonical text links (Features · Pricing · Docs · GitHub). */
+  /** The 4 canonical links (GitHub carries `star: true`). */
   links?: MarketingNavLink[];
-  /** Trailing slot before the Sign in CTA (the theme toggle). */
+  /** Trailing slot before the CTAs (the theme toggle). */
   trailing?: React.ReactNode;
+  /** Live stargazer count — null/undefined renders the neutral "Star". */
+  starCount?: number | null;
   signInHref?: string;
+  tryCloudHref?: string;
   /** Analytics hook for external links (pages.md `github_click`). */
   onLinkClick?: (label: string) => void;
+  /** Analytics hook for the Try Cloud CTA (`try_cloud_click`). */
+  onTryCloud?: () => void;
   className?: string;
 }
 
 const isExternal = (href: string): boolean => /^https?:\/\//.test(href);
 
+const GitHubMark: React.FC<{ className?: string }> = ({ className }) => (
+  // Brand glyph (icon/brand-github) — not Lucide; inherits currentColor.
+  <svg
+    viewBox="0 0 16 16"
+    aria-hidden
+    className={className}
+    fill="currentColor"
+  >
+    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.42 7.42 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+  </svg>
+);
+
 export const MarketingNav: React.FC<MarketingNavProps> = ({
   variant = "on-dark",
   links = [],
   trailing,
+  starCount = null,
   signInHref = "/signin",
+  tryCloudHref = "/signin",
   onLinkClick,
+  onTryCloud,
   className,
 }) => {
   const onDark = variant === "on-dark";
@@ -68,7 +91,7 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
     "text-text-2 hover:bg-bg-elev hover:text-text",
   );
 
-  const signInClass = cn(
+  const ctaClass = cn(
     "rounded bg-accent px-3 py-1.5 text-[13px] font-medium text-on-accent",
     "transition-colors duration-fast ease-standard hover:opacity-90",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
@@ -78,22 +101,51 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
     link: MarketingNavLink,
     extraClass: string,
     onNavigate?: () => void,
-  ) => (
-    <a
-      key={link.label}
-      href={link.href}
-      {...(isExternal(link.href)
-        ? { target: "_blank", rel: "noreferrer" }
-        : {})}
-      onClick={() => {
-        onLinkClick?.(link.label);
-        onNavigate?.();
-      }}
-      className={cn(itemClass, extraClass)}
-    >
-      {link.label}
-    </a>
-  );
+  ) =>
+    link.star ? (
+      // Compact star badge — live count, neutral "Star" when unknown
+      // (TEST_MODE / fetch failure); the count is never hardcoded.
+      <a
+        key={link.label}
+        href={link.href}
+        target="_blank"
+        rel="noreferrer"
+        aria-label="Star cuesoftinc/expendit on GitHub"
+        onClick={() => {
+          onLinkClick?.(link.label);
+          onNavigate?.();
+        }}
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded border border-border px-2.5 py-1 text-[13px] font-medium text-text",
+          "transition-colors duration-fast ease-standard hover:bg-bg-elev",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+          extraClass,
+        )}
+      >
+        <GitHubMark className="h-3.5 w-3.5" />
+        Star
+        {typeof starCount === "number" ? (
+          <span className="tabular-nums text-text-2">
+            {starCount.toLocaleString("en-NG")}
+          </span>
+        ) : null}
+      </a>
+    ) : (
+      <a
+        key={link.label}
+        href={link.href}
+        {...(isExternal(link.href)
+          ? { target: "_blank", rel: "noreferrer" }
+          : {})}
+        onClick={() => {
+          onLinkClick?.(link.label);
+          onNavigate?.();
+        }}
+        className={cn(itemClass, extraClass)}
+      >
+        {link.label}
+      </a>
+    );
 
   return (
     <nav
@@ -119,12 +171,22 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
           expendit
         </Link>
 
-        {links.map((link) => renderLink(link, "hidden md:inline-block"))}
+        {links.map((link) =>
+          renderLink(
+            link,
+            // The star badge is a flex row — md:inline-block would stack
+            // the glyph over the label.
+            link.star ? "hidden md:inline-flex" : "hidden md:inline-block",
+          ),
+        )}
 
         <div className="ml-auto hidden items-center gap-2 md:flex">
           {trailing}
-          <Link href={signInHref} className={signInClass}>
+          <Link href={signInHref} className={itemClass}>
             Sign in
+          </Link>
+          <Link href={tryCloudHref} className={ctaClass} onClick={onTryCloud}>
+            Try Cloud
           </Link>
         </div>
 
@@ -159,17 +221,31 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
         >
           <div className="flex flex-col gap-1">
             {links.map((link) =>
-              renderLink(link, "block", () => setMenuOpen(false)),
+              renderLink(link, link.star ? "self-start" : "block", () =>
+                setMenuOpen(false),
+              ),
             )}
             <div className="mt-2 flex items-center justify-between gap-2 border-t border-border pt-3">
               {trailing}
-              <Link
-                href={signInHref}
-                className={signInClass}
-                onClick={() => setMenuOpen(false)}
-              >
-                Sign in
-              </Link>
+              <span className="flex items-center gap-2">
+                <Link
+                  href={signInHref}
+                  className={itemClass}
+                  onClick={() => setMenuOpen(false)}
+                >
+                  Sign in
+                </Link>
+                <Link
+                  href={tryCloudHref}
+                  className={ctaClass}
+                  onClick={() => {
+                    onTryCloud?.();
+                    setMenuOpen(false);
+                  }}
+                >
+                  Try Cloud
+                </Link>
+              </span>
             </div>
           </div>
         </div>

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -1,20 +1,20 @@
 "use client";
 
 /**
- * MarketingNav — design.md §8.2b: on-dark (over hero) / dark-on-light
- * (post-hero scroll, sticky) · item + Solutions dropdown · GitHub badge
- * (neutral "Star", no count — as built 2026-07-18) · Sign in + Try Cloud
- * CTAs. The GitHub mark is an approved brand glyph (icon/brand-github,
- * design.md §8.1 — Lucide's `github` is deprecated), inline SVG.
+ * MarketingNav — design.md §8.2b variants: on-dark (over hero) /
+ * dark-on-light (post-hero scroll, sticky). Link inventory per the
+ * marketing nav/footer & theme parity canon (org SKILL.md, 2026-07-19):
+ * 4 text links (Features · Pricing · Docs · GitHub) + theme toggle slot +
+ * the "Sign in" CTA (/signin). The Solutions dropdown, Star badge, and
+ * nav Try Cloud retired with the canon convergence.
  *
  * Tokens only: the on-dark variant scopes `data-theme="dark"` on its own
  * subtree (editorial sections are #0C0C0E in both themes, design.md §2),
  * so every color here stays a token binding.
  */
 
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import Link from "next/link";
-import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 export interface MarketingNavLink {
@@ -25,59 +25,27 @@ export interface MarketingNavLink {
 export interface MarketingNavProps {
   /** on-dark: over the hero; dark-on-light: post-hero sticky scroll. */
   variant?: "on-dark" | "dark-on-light";
+  /** The 4 canonical text links (Features · Pricing · Docs · GitHub). */
   links?: MarketingNavLink[];
-  solutions?: MarketingNavLink[];
-  githubHref?: string;
-  /** Analytics hook for the GitHub badge (pages.md `github_click`). */
-  onGithubClick?: () => void;
-  onSignIn?: () => void;
-  onTryCloud?: () => void;
+  /** Trailing slot before the Sign in CTA (the theme toggle). */
+  trailing?: React.ReactNode;
+  signInHref?: string;
+  /** Analytics hook for external links (pages.md `github_click`). */
+  onLinkClick?: (label: string) => void;
   className?: string;
 }
 
-const GitHubMark: React.FC<{ className?: string }> = ({ className }) => (
-  // Brand glyph (icon/brand-github) — not Lucide; inherits currentColor.
-  <svg
-    viewBox="0 0 16 16"
-    aria-hidden
-    className={className}
-    fill="currentColor"
-  >
-    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.42 7.42 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
-  </svg>
-);
+const isExternal = (href: string): boolean => /^https?:\/\//.test(href);
 
 export const MarketingNav: React.FC<MarketingNavProps> = ({
   variant = "on-dark",
   links = [],
-  solutions = [],
-  githubHref = "https://github.com/cuesoftinc/expendit",
-  onGithubClick,
-  onSignIn,
-  onTryCloud,
+  trailing,
+  signInHref = "/signin",
+  onLinkClick,
   className,
 }) => {
-  const [solutionsOpen, setSolutionsOpen] = useState(false);
-  const solutionsRef = useRef<HTMLDivElement>(null);
   const onDark = variant === "on-dark";
-
-  useEffect(() => {
-    if (!solutionsOpen) return;
-    const onPointerDown = (event: PointerEvent) => {
-      if (!solutionsRef.current?.contains(event.target as Node)) {
-        setSolutionsOpen(false);
-      }
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setSolutionsOpen(false);
-    };
-    document.addEventListener("pointerdown", onPointerDown);
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown);
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [solutionsOpen]);
 
   const itemClass = cn(
     "rounded px-2.5 py-1.5 text-[13px] font-medium transition-colors duration-fast ease-standard",
@@ -109,49 +77,15 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
           expendit
         </Link>
 
-        {solutions.length > 0 ? (
-          // Text items collapse below md (375w floor keeps logo + CTAs).
-          <div ref={solutionsRef} className="relative hidden md:block">
-            <button
-              type="button"
-              aria-expanded={solutionsOpen}
-              aria-haspopup="menu"
-              onClick={() => setSolutionsOpen((state) => !state)}
-              className={cn(itemClass, "inline-flex items-center gap-1")}
-            >
-              Solutions
-              <ChevronDown
-                aria-hidden
-                className={cn(
-                  "h-3.5 w-3.5 transition-transform duration-fast ease-standard",
-                  solutionsOpen && "rotate-180",
-                )}
-              />
-            </button>
-            {solutionsOpen ? (
-              <div
-                role="menu"
-                className="absolute left-0 top-full z-dropdown mt-1 w-56 rounded border border-border bg-bg py-1 shadow-lg"
-              >
-                {solutions.map((item) => (
-                  <a
-                    key={item.label}
-                    role="menuitem"
-                    href={item.href}
-                    className="block px-3 py-1.5 text-[13px] text-text transition-colors duration-fast ease-standard hover:bg-bg-elev"
-                  >
-                    {item.label}
-                  </a>
-                ))}
-              </div>
-            ) : null}
-          </div>
-        ) : null}
-
         {links.map((link) => (
           <a
             key={link.label}
             href={link.href}
+            {...(isExternal(link.href)
+              ? { target: "_blank", rel: "noreferrer" }
+              : {})}
+            onClick={onLinkClick ? () => onLinkClick(link.label) : undefined}
+            // Text items collapse below md (375w floor keeps logo + CTAs).
             className={cn(itemClass, "hidden md:inline-block")}
           >
             {link.label}
@@ -159,35 +93,17 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
         ))}
 
         <div className="ml-auto flex items-center gap-2">
-          {/* GitHub badge — neutral "Star", no count (as built). */}
-          <a
-            href={githubHref}
-            target="_blank"
-            rel="noreferrer"
-            onClick={onGithubClick}
-            className={cn(
-              "inline-flex items-center gap-1.5 rounded border border-border px-2.5 py-1 text-[13px] font-medium text-text",
-              "transition-colors duration-fast ease-standard hover:bg-bg-elev",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
-            )}
-          >
-            <GitHubMark className="h-3.5 w-3.5" />
-            Star
-          </a>
-          <button type="button" onClick={onSignIn} className={itemClass}>
-            Sign in
-          </button>
-          <button
-            type="button"
-            onClick={onTryCloud}
+          {trailing}
+          <Link
+            href={signInHref}
             className={cn(
               "rounded bg-accent px-3 py-1.5 text-[13px] font-medium text-on-accent",
               "transition-colors duration-fast ease-standard hover:opacity-90",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
             )}
           >
-            Try Cloud
-          </button>
+            Sign in
+          </Link>
         </div>
       </div>
     </nav>

--- a/web/src/components/ui/PeriodPicker.tsx
+++ b/web/src/components/ui/PeriodPicker.tsx
@@ -149,10 +149,15 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
           "disabled:cursor-not-allowed disabled:opacity-40",
         )}
       >
-        <span className="flex items-center gap-2">
-          <Calendar aria-hidden className="h-4 w-4 text-text-2" />
+        <span className="flex min-w-0 items-center gap-2">
+          <Calendar aria-hidden className="h-4 w-4 shrink-0 text-text-2" />
+          {/* Single line always — the range placeholder wrapped to two
+              lines inside narrow filter pills (system QA 2026-07-19). */}
           <span
-            className={cn("tabular-nums", value ? "text-text" : "text-text-2")}
+            className={cn(
+              "truncate whitespace-nowrap tabular-nums",
+              value ? "text-text" : "text-text-2",
+            )}
           >
             {value ? formatPeriod(mode, value) : MODE_PLACEHOLDER[mode]}
           </span>

--- a/web/src/components/ui/StagedReviewHeader.tsx
+++ b/web/src/components/ui/StagedReviewHeader.tsx
@@ -38,14 +38,14 @@ export const StagedReviewHeader: React.FC<StagedReviewHeaderProps> = ({
     <div className="flex items-center gap-3">
       <p className="flex-1 text-sm text-text">
         <span className="font-semibold tabular-nums">{importCount}</span>{" "}
-        transactions staged
+        {importCount === 1 ? "transaction" : "transactions"} staged
         {duplicateCount > 0 ? (
           <span className="text-text-2">
             {" "}
             · <span className="tabular-nums text-warn">
               {duplicateCount}
             </span>{" "}
-            duplicates flagged
+            {duplicateCount === 1 ? "duplicate" : "duplicates"} flagged
           </span>
         ) : null}
       </p>
@@ -57,12 +57,16 @@ export const StagedReviewHeader: React.FC<StagedReviewHeaderProps> = ({
         size="sm"
         loading={state === "committing"}
         onClick={onCommit}
-        aria-label={`Import ${importCount}, discard ${duplicateCount} duplicates`}
+        aria-label={`Import ${importCount}, discard ${duplicateCount} ${
+          duplicateCount === 1 ? "duplicate" : "duplicates"
+        }`}
       >
         {state === "committing"
           ? "Committing…"
           : duplicateCount > 0
-            ? `Import ${importCount} / discard ${duplicateCount} duplicates`
+            ? `Import ${importCount} / discard ${duplicateCount} ${
+                duplicateCount === 1 ? "duplicate" : "duplicates"
+              }`
             : `Import ${importCount}`}
       </Button>
     </div>

--- a/web/src/components/ui/StatCard.test.tsx
+++ b/web/src/components/ui/StatCard.test.tsx
@@ -59,4 +59,33 @@ describe("StatCard (design.md §8.2, MI-7)", () => {
     );
     expect(screen.getByText("₦1,500")).toBeInTheDocument();
   });
+
+  it("down-good metrics tint a falling delta as improvement (system QA regression)", () => {
+    render(
+      <StatCard
+        label="Expenses"
+        value={100}
+        delta={-0.686}
+        deltaDirection="down-good"
+      />,
+    );
+    const chip = screen.getByTestId("stat-delta");
+    expect(chip.className).toContain("text-income");
+    // Sign still encodes the raw direction (design.md §5).
+    expect(chip.textContent).toContain("−68.6%");
+  });
+
+  it("down-good metrics tint a rising delta as regression", () => {
+    render(
+      <StatCard
+        label="Expenses"
+        value={100}
+        delta={0.034}
+        deltaDirection="down-good"
+      />,
+    );
+    expect(screen.getByTestId("stat-delta").className).toContain(
+      "text-expense",
+    );
+  });
 });

--- a/web/src/components/ui/StatCard.tsx
+++ b/web/src/components/ui/StatCard.tsx
@@ -23,6 +23,13 @@ export interface StatCardProps {
   delta?: number;
   /** Comparison caption after the delta (Figma: "vs Jun"). */
   deltaCaption?: string;
+  /**
+   * Which way is good for this metric — expenses trending DOWN is good
+   * (income tint), up is bad (system QA 2026-07-19: a −68.6% expense
+   * delta rendered red). Icon + sign always encode the actual direction
+   * (design.md §5 — never color alone).
+   */
+  deltaDirection?: "up-good" | "down-good";
   /** Sparkline series (bespoke SVG; omit to hide). */
   sparkline?: number[];
   loading?: boolean;
@@ -101,6 +108,7 @@ export const StatCard: React.FC<StatCardProps> = ({
   format = (val) => Math.round(val).toLocaleString("en-NG"),
   delta,
   deltaCaption,
+  deltaDirection = "up-good",
   sparkline,
   loading = false,
   className,
@@ -121,6 +129,8 @@ export const StatCard: React.FC<StatCardProps> = ({
   }
 
   const positive = (delta ?? 0) >= 0;
+  // Goodness drives color; the icon + sign keep the raw direction.
+  const improving = deltaDirection === "down-good" ? !positive : positive;
   return (
     <div className={cn(card, className)}>
       <div className="text-[13px] leading-4 text-text-2">{label}</div>
@@ -137,7 +147,7 @@ export const StatCard: React.FC<StatCardProps> = ({
                 // Figma delta pill: 12% tint, no border, Table/13 Medium.
                 "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5",
                 "text-[13px] font-medium leading-4 tabular-nums",
-                positive
+                improving
                   ? "bg-income/[0.12] text-income"
                   : "bg-expense/[0.12] text-expense",
               )}
@@ -155,7 +165,7 @@ export const StatCard: React.FC<StatCardProps> = ({
             <span />
           )}
           {sparkline && sparkline.length > 1 ? (
-            <Sparkline series={sparkline} positive={positive} />
+            <Sparkline series={sparkline} positive={improving} />
           ) : null}
         </div>
       ) : null}

--- a/web/src/components/ui/ThemeToggle.test.tsx
+++ b/web/src/components/ui/ThemeToggle.test.tsx
@@ -1,0 +1,44 @@
+// ThemeToggle: flips the ThemeProvider preference light↔dark and persists
+// under `expendit.theme` (theme parity canon, 2026-07-19).
+import React from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { THEME_STORAGE_KEY, ThemeProvider } from "@/design/ThemeProvider";
+import ThemeToggle from "./ThemeToggle";
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+});
+
+const setup = () =>
+  render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>,
+  );
+
+describe("ThemeToggle", () => {
+  it("defaults to offering dark, applies + persists it", async () => {
+    setup();
+    const toggle = screen.getByRole("button", {
+      name: "Switch to dark theme",
+    });
+    await userEvent.click(toggle);
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+  });
+
+  it("flips back to light from dark", async () => {
+    setup();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Switch to dark theme" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Switch to light theme" }),
+    );
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+  });
+});

--- a/web/src/components/ui/ThemeToggle.tsx
+++ b/web/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+/**
+ * ThemeToggle — the ecosystem theme control (marketing nav + dashboard
+ * chrome; theme parity canon, org SKILL.md 2026-07-19). Mirrors the
+ * apparule contract: one icon button, Sun on dark / Moon otherwise,
+ * flips the ThemeProvider preference between light and dark.
+ */
+
+import React from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "@/design/ThemeProvider";
+import { cn } from "@/lib/cn";
+
+export interface ThemeToggleProps {
+  className?: string;
+}
+
+export const ThemeToggle: React.FC<ThemeToggleProps> = ({ className }) => {
+  const { preference, setPreference } = useTheme();
+  const nextTheme = preference === "dark" ? "light" : "dark";
+  return (
+    <button
+      type="button"
+      data-testid="theme-toggle"
+      aria-label={`Switch to ${nextTheme} theme`}
+      onClick={() => setPreference(nextTheme)}
+      className={cn(
+        "rounded p-1.5 text-text-2 transition-colors duration-fast ease-standard",
+        "hover:bg-bg-elev hover:text-text",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+        className,
+      )}
+    >
+      {preference === "dark" ? (
+        <Sun aria-hidden className="h-4 w-4" />
+      ) : (
+        <Moon aria-hidden className="h-4 w-4" />
+      )}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/web/src/components/ui/TxnTableRow.tsx
+++ b/web/src/components/ui/TxnTableRow.tsx
@@ -160,10 +160,15 @@ export const TxnTableRow: React.FC<TxnTableRowProps> = ({
       <td
         data-testid="row-actions"
         className={cn(
-          // Figma hover: bare icons over the row's hover surface.
+          // Figma hover variant: bare icons right-aligned over the row's
+          // hover surface (they cover the amount only while this row is
+          // hovered/focused). pointer-events gating keeps the hidden
+          // cluster hit-transparent — without it the invisible strip
+          // swallowed clicks on cells beneath it (system QA 2026-07-19).
           "absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1 bg-bg-elev pl-2",
-          "opacity-0 transition-opacity duration-[60ms] ease-standard",
-          "group-hover:opacity-100 group-focus-within:opacity-100",
+          "pointer-events-none opacity-0 transition-opacity duration-[60ms] ease-standard",
+          "group-hover:pointer-events-auto group-hover:opacity-100",
+          "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
         )}
       >
         <button

--- a/web/src/controllers/use-settings.ts
+++ b/web/src/controllers/use-settings.ts
@@ -99,6 +99,16 @@ export const useSettingsController = (orgId?: string) => {
     [orgId],
   );
 
+  /**
+   * Pending purge survives reloads: `null` = none on file
+   * (flows/rights.md §2 — the grace banner + cancel must persist for the
+   * whole window).
+   */
+  const purgeStatus = useCallback(
+    () => rightsRepo.purgeStatus({ orgId }),
+    [orgId],
+  );
+
   const recordConsent = useCallback(
     async (document: ConsentRecord["document"], version: string) => {
       const record = await rightsRepo.recordConsent(document, version, {
@@ -124,6 +134,7 @@ export const useSettingsController = (orgId?: string) => {
     exportStatus,
     requestPurge,
     cancelPurge,
+    purgeStatus,
     recordConsent,
   };
 };

--- a/web/src/controllers/use-theme.test.ts
+++ b/web/src/controllers/use-theme.test.ts
@@ -1,10 +1,22 @@
-import { describe, expect, it } from "vitest";
+import React from "react";
+import { describe, expect, it, beforeEach } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { ThemeProvider } from "@/design/ThemeProvider";
 import { applyTheme, useThemeController } from "./use-theme";
+
+// The controller is now an adapter over the design-layer ThemeProvider
+// (theme parity canon, 2026-07-19) — same public API, one source of truth.
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(ThemeProvider, null, children);
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+});
 
 describe("useThemeController (B9 theme control)", () => {
   it("setTheme('dark') sets data-theme and persists", async () => {
-    const { result } = renderHook(() => useThemeController());
+    const { result } = renderHook(() => useThemeController(), { wrapper });
     act(() => result.current.setTheme("dark"));
     expect(document.documentElement.dataset.theme).toBe("dark");
     expect(localStorage.getItem("expendit.theme")).toBe("dark");
@@ -12,18 +24,17 @@ describe("useThemeController (B9 theme control)", () => {
   });
 
   it("system removes the attribute (OS preference applies)", () => {
-    const { result } = renderHook(() => useThemeController());
+    const { result } = renderHook(() => useThemeController(), { wrapper });
     act(() => result.current.setTheme("dark"));
     act(() => result.current.setTheme("system"));
     expect(document.documentElement.dataset.theme).toBeUndefined();
     expect(localStorage.getItem("expendit.theme")).toBeNull();
   });
 
-  it("mount applies the stored preference", async () => {
+  it("reads a stored preference (provider store is localStorage-backed)", async () => {
     localStorage.setItem("expendit.theme", "light");
-    const { result } = renderHook(() => useThemeController());
+    const { result } = renderHook(() => useThemeController(), { wrapper });
     await waitFor(() => expect(result.current.theme).toBe("light"));
-    expect(document.documentElement.dataset.theme).toBe("light");
   });
 
   it("applyTheme is a pure DOM seam", () => {

--- a/web/src/controllers/use-theme.ts
+++ b/web/src/controllers/use-theme.ts
@@ -1,24 +1,25 @@
 "use client";
 
 /**
- * Theme controller — the B9 theme control sets `data-theme` on <html>
- * (web-implementation.md §3: light on :root, dark on [data-theme="dark"],
- * prefers-color-scheme honored with manual override — "system" removes
- * the attribute so the OS preference applies).
+ * Theme controller — the B9 theme control (and every other toggle) now
+ * delegates to the design-layer ThemeProvider, the single source of truth
+ * for the `data-theme` override (theme parity canon, 2026-07-19: one
+ * provider contract across the ecosystem — data-theme on <html>,
+ * localStorage `expendit.theme`, system default when unset). The
+ * controller API is kept so existing views stay unchanged.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import {
+  useTheme,
+  type ThemePreference,
+  THEME_STORAGE_KEY,
+} from "@/design/ThemeProvider";
 
-export type ThemeSetting = "light" | "dark" | "system";
+export type ThemeSetting = ThemePreference;
 
-const THEME_KEY = "expendit.theme";
+export { THEME_STORAGE_KEY };
 
-const readStored = (): ThemeSetting => {
-  if (typeof window === "undefined") return "system";
-  const stored = window.localStorage.getItem(THEME_KEY);
-  return stored === "light" || stored === "dark" ? stored : "system";
-};
-
+/** Pure DOM seam kept for compatibility (mirrors the provider's apply). */
 export const applyTheme = (theme: ThemeSetting): void => {
   if (typeof document === "undefined") return;
   if (theme === "system") delete document.documentElement.dataset.theme;
@@ -26,25 +27,6 @@ export const applyTheme = (theme: ThemeSetting): void => {
 };
 
 export const useThemeController = () => {
-  const [theme, setThemeState] = useState<ThemeSetting>("system");
-
-  useEffect(() => {
-    // Apply the stored preference on mount (client-only).
-    queueMicrotask(() => {
-      const stored = readStored();
-      setThemeState(stored);
-      applyTheme(stored);
-    });
-  }, []);
-
-  const setTheme = useCallback((next: ThemeSetting) => {
-    setThemeState(next);
-    applyTheme(next);
-    if (typeof window !== "undefined") {
-      if (next === "system") window.localStorage.removeItem(THEME_KEY);
-      else window.localStorage.setItem(THEME_KEY, next);
-    }
-  }, []);
-
-  return { theme, setTheme };
+  const { preference, setPreference } = useTheme();
+  return { theme: preference, setTheme: setPreference };
 };

--- a/web/src/design/ThemeProvider.test.tsx
+++ b/web/src/design/ThemeProvider.test.tsx
@@ -1,7 +1,7 @@
 // Theme provider: manual override sets data-theme + persists; "system"
 // clears the attribute (tokens.css then follows prefers-color-scheme).
 // Ported with the apparule contract (theme parity canon, 2026-07-19).
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { THEME_STORAGE_KEY, ThemeProvider, useTheme } from "./ThemeProvider";
@@ -62,5 +62,50 @@ describe("ThemeProvider", () => {
     await userEvent.click(screen.getByRole("button", { name: "system" }));
     expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+  });
+
+  it("keeps working when storage is blocked (in-memory fallback, Codex round 3)", async () => {
+    const setSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    const getSpy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    try {
+      render(
+        <ThemeProvider>
+          <Probe />
+        </ThemeProvider>,
+      );
+      await userEvent.click(screen.getByRole("button", { name: "dark" }));
+      // The attribute applied AND the store snapshot follows — the toggle
+      // can flip back even though nothing persisted.
+      expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+      expect(screen.getByTestId("pref")).toHaveTextContent("dark");
+      await userEvent.click(screen.getByRole("button", { name: "light" }));
+      expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+      expect(screen.getByTestId("pref")).toHaveTextContent("light");
+    } finally {
+      setSpy.mockRestore();
+      getSpy.mockRestore();
+      // Reset the module-level fallback for later tests.
+      window.localStorage.clear();
+    }
+  });
+
+  it("system reset clears the in-memory fallback too", async () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "dark" }));
+    await userEvent.click(screen.getByRole("button", { name: "system" }));
+    expect(screen.getByTestId("pref")).toHaveTextContent("system");
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
   });
 });

--- a/web/src/design/ThemeProvider.test.tsx
+++ b/web/src/design/ThemeProvider.test.tsx
@@ -97,6 +97,31 @@ describe("ThemeProvider", () => {
     }
   });
 
+  it("write-blocked storage (readable, setItem throws) still flips the store (Codex round 4)", async () => {
+    const setSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("quota");
+      });
+    try {
+      render(
+        <ThemeProvider>
+          <Probe />
+        </ThemeProvider>,
+      );
+      await userEvent.click(screen.getByRole("button", { name: "dark" }));
+      // getItem works and returns null — but the failed write means the
+      // in-session preference must win, or the toggle sticks.
+      expect(screen.getByTestId("pref")).toHaveTextContent("dark");
+      await userEvent.click(screen.getByRole("button", { name: "light" }));
+      expect(screen.getByTestId("pref")).toHaveTextContent("light");
+      expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    } finally {
+      setSpy.mockRestore();
+      window.localStorage.clear();
+    }
+  });
+
   it("system reset clears the in-memory fallback too", async () => {
     render(
       <ThemeProvider>

--- a/web/src/design/ThemeProvider.test.tsx
+++ b/web/src/design/ThemeProvider.test.tsx
@@ -1,0 +1,66 @@
+// Theme provider: manual override sets data-theme + persists; "system"
+// clears the attribute (tokens.css then follows prefers-color-scheme).
+// Ported with the apparule contract (theme parity canon, 2026-07-19).
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { THEME_STORAGE_KEY, ThemeProvider, useTheme } from "./ThemeProvider";
+
+function Probe() {
+  const { preference, setPreference } = useTheme();
+  return (
+    <div>
+      <span data-testid="pref">{preference}</span>
+      <button onClick={() => setPreference("dark")}>dark</button>
+      <button onClick={() => setPreference("light")}>light</button>
+      <button onClick={() => setPreference("system")}>system</button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+});
+
+describe("ThemeProvider", () => {
+  it("themeInitScript stays in sync with the storage key", async () => {
+    const { themeInitScript } = await import("./ThemeProvider");
+    expect(themeInitScript).toContain(`"${THEME_STORAGE_KEY}"`);
+    expect(THEME_STORAGE_KEY).toBe("expendit.theme");
+  });
+
+  it("defaults to system (no data-theme attribute)", () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("pref")).toHaveTextContent("system");
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+  });
+
+  it("manual dark override sets the attribute and persists", async () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "dark" }));
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+  });
+
+  it("returning to system clears override + storage", async () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "light" }));
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    await userEvent.click(screen.getByRole("button", { name: "system" }));
+    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/web/src/design/ThemeProvider.tsx
+++ b/web/src/design/ThemeProvider.tsx
@@ -43,15 +43,20 @@ function emit(): void {
 }
 
 // In-memory fallback: when storage is blocked (private mode, privacy
-// policies), the last set preference still drives the store — otherwise a
-// toggle click applied data-theme but the snapshot stayed "system" and the
-// control could never switch back (Codex round 3 on PR #209).
+// policies, full quota), the last set preference still drives the store —
+// otherwise a toggle click applied data-theme but the snapshot stayed
+// "system" and the control could never switch back (Codex rounds 3–4 on
+// PR #209). Readable+writable storage stays the source of truth; after a
+// FAILED write the stored value is stale, so the in-session preference
+// wins until a write succeeds again.
 let memoryPreference: ThemePreference = "system";
+let storageDesynced = false;
 
 function readStoredPreference(): ThemePreference {
   try {
+    if (storageDesynced) return memoryPreference;
     const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-    // Readable storage is the source of truth (null = no override).
+    // Readable, in-sync storage is the source of truth (null = none).
     return stored === "light" || stored === "dark" ? stored : "system";
   } catch {
     // Storage unavailable — the in-session preference stands.
@@ -99,8 +104,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       } else {
         window.localStorage.setItem(THEME_STORAGE_KEY, next);
       }
+      storageDesynced = false;
     } catch {
-      // non-fatal: preference just won't persist
+      // non-fatal: the in-session preference drives the store instead.
+      storageDesynced = true;
     }
     emit();
   }, []);

--- a/web/src/design/ThemeProvider.tsx
+++ b/web/src/design/ThemeProvider.tsx
@@ -42,14 +42,21 @@ function emit(): void {
   for (const listener of listeners) listener();
 }
 
+// In-memory fallback: when storage is blocked (private mode, privacy
+// policies), the last set preference still drives the store — otherwise a
+// toggle click applied data-theme but the snapshot stayed "system" and the
+// control could never switch back (Codex round 3 on PR #209).
+let memoryPreference: ThemePreference = "system";
+
 function readStoredPreference(): ThemePreference {
   try {
     const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-    if (stored === "light" || stored === "dark") return stored;
+    // Readable storage is the source of truth (null = no override).
+    return stored === "light" || stored === "dark" ? stored : "system";
   } catch {
-    // storage unavailable (private mode etc.) — fall through to system
+    // Storage unavailable — the in-session preference stands.
+    return memoryPreference;
   }
-  return "system";
 }
 
 function getServerSnapshot(): ThemePreference {
@@ -84,6 +91,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   );
 
   const setPreference = useCallback((next: ThemePreference) => {
+    memoryPreference = next;
     applyPreference(next);
     try {
       if (next === "system") {

--- a/web/src/design/ThemeProvider.tsx
+++ b/web/src/design/ThemeProvider.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+/**
+ * Theme provider — manual light/dark override with system default
+ * (web-implementation.md §3: light on :root, dark on [data-theme="dark"],
+ * prefers-color-scheme honored with manual override). Ported from the
+ * apparule contract per the marketing nav/footer & theme parity canon
+ * (org SKILL.md, 2026-07-19) — data-theme on <html>, localStorage key
+ * `expendit.theme`, "system" default when unset.
+ *
+ * The preference lives in an external module store (localStorage-backed,
+ * read via useSyncExternalStore) so no state syncs through effects; a tiny
+ * inline script in the root layout applies the persisted override before
+ * first paint to avoid a theme flash.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+
+export type ThemePreference = "light" | "dark" | "system";
+
+export const THEME_STORAGE_KEY = "expendit.theme";
+
+// -- external preference store ----------------------------------------------
+
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+function readStoredPreference(): ThemePreference {
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === "light" || stored === "dark") return stored;
+  } catch {
+    // storage unavailable (private mode etc.) — fall through to system
+  }
+  return "system";
+}
+
+function getServerSnapshot(): ThemePreference {
+  return "system";
+}
+
+function applyPreference(preference: ThemePreference): void {
+  const root = document.documentElement;
+  if (preference === "system") {
+    root.removeAttribute("data-theme");
+  } else {
+    root.setAttribute("data-theme", preference);
+  }
+}
+
+// -- context ------------------------------------------------------------------
+
+interface ThemeContextValue {
+  /** The user's stored preference (may be "system"). */
+  preference: ThemePreference;
+  /** Set + persist the preference; "system" clears the override. */
+  setPreference: (preference: ThemePreference) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const preference = useSyncExternalStore(
+    subscribe,
+    readStoredPreference,
+    getServerSnapshot,
+  );
+
+  const setPreference = useCallback((next: ThemePreference) => {
+    applyPreference(next);
+    try {
+      if (next === "system") {
+        window.localStorage.removeItem(THEME_STORAGE_KEY);
+      } else {
+        window.localStorage.setItem(THEME_STORAGE_KEY, next);
+      }
+    } catch {
+      // non-fatal: preference just won't persist
+    }
+    emit();
+  }, []);
+
+  const value = useMemo(
+    () => ({ preference, setPreference }),
+    [preference, setPreference],
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within <ThemeProvider>");
+  return ctx;
+}
+
+/**
+ * Pre-paint theme bootstrap (inlined by the root layout). A fully static
+ * string — no runtime code construction (CodeQL js/bad-code-sanitization);
+ * the literal storage key must match THEME_STORAGE_KEY (unit-tested).
+ */
+export const themeInitScript =
+  '(function(){try{var t=localStorage.getItem("expendit.theme");if(t==="light"||t==="dark"){document.documentElement.setAttribute("data-theme",t);}}catch(e){}})();';

--- a/web/src/lib/artifact-new.test.ts
+++ b/web/src/lib/artifact-new.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isArtifactNew } from "./artifact-new";
+
+const NOW = new Date("2026-07-19T12:00:00.000Z");
+
+describe("isArtifactNew (MI-14 ≤24h rule)", () => {
+  it("just-created artifacts are NEW", () => {
+    expect(isArtifactNew("2026-07-19T11:59:00.000Z", NOW)).toBe(true);
+  });
+
+  it("23h59m old is still NEW; 25h old is not", () => {
+    expect(isArtifactNew("2026-07-18T12:01:00.000Z", NOW)).toBe(true);
+    expect(isArtifactNew("2026-07-18T11:00:00.000Z", NOW)).toBe(false);
+  });
+
+  it("future-dated artifacts count as NEW (TEST_MODE mock clock is pinned ahead of real time)", () => {
+    // System QA regression: mock-stamped 2026-07-20 vs real 2026-07-19
+    // must keep the NEW tag on a freshly generated report.
+    expect(isArtifactNew("2026-07-20T11:00:00.000Z", NOW)).toBe(true);
+  });
+
+  it("invalid timestamps are never NEW", () => {
+    expect(isArtifactNew("not-a-date", NOW)).toBe(false);
+  });
+});

--- a/web/src/lib/artifact-new.ts
+++ b/web/src/lib/artifact-new.ts
@@ -1,0 +1,17 @@
+/**
+ * MI-14 NEW rule — an artifact is NEW while it is at most 24h old.
+ *
+ * Implemented as "created on or after now − 24h" (future-dated counts as
+ * new): the previous |diff| ≤ 24h comparison quietly dropped the tag for
+ * artifacts stamped by the TEST_MODE mock clock (pinned at 2026-07-20)
+ * once the real clock drifted past the absorb window — a freshly
+ * generated report rendered without its NEW tag (system QA 2026-07-19).
+ */
+export const isArtifactNew = (
+  createdAt: string,
+  now: Date = new Date(),
+): boolean => {
+  const created = new Date(createdAt).getTime();
+  if (Number.isNaN(created)) return false;
+  return created >= now.getTime() - 24 * 60 * 60 * 1000;
+};

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { formatMoney } from "./format";
+
+describe("formatMoney", () => {
+  it("formats NGN with tabular decimals", () => {
+    expect(formatMoney(1_240_300.5)).toBe("₦1,240,300.50");
+  });
+
+  it("preserves the sign on negative amounts (system QA regression: a negative net month rendered positive)", () => {
+    expect(formatMoney(-950_000)).toBe("−₦950,000.00");
+    expect(formatMoney(-950_000, "NGN", { decimals: 0 })).toBe("−₦950,000");
+  });
+
+  it("zero carries no sign", () => {
+    expect(formatMoney(0)).toBe("₦0.00");
+  });
+});

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -25,7 +25,11 @@ export const formatMoney = (
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
   });
-  return `${currencySymbol(currency)}${formatted}`;
+  // Preserve the sign — a −₦950,000 net month rendered as ₦950,000.00 on
+  // the overview StatCard (system QA 2026-07-19). Callers that render
+  // direction themselves (MoneyCell) pass unsigned magnitudes.
+  const sign = amount < 0 ? "−" : "";
+  return `${sign}${currencySymbol(currency)}${formatted}`;
 };
 
 export const formatPercent = (value: number, decimals = 1): string =>

--- a/web/src/mock/db.ts
+++ b/web/src/mock/db.ts
@@ -48,6 +48,8 @@ export interface MockDb {
   idempotency: Record<string, string>;
   /** link id → real-clock ms of the last manual sync (rate limiting). */
   lastManualSync: Record<string, number>;
+  /** bank_sync job → link id (the completer honors the link's auto_confirm). */
+  jobLinks: Record<string, string>;
   /** Real-clock ms a processing job/statement was created (lifecycle). */
   processingSince: Record<string, number>;
   seq: number;

--- a/web/src/mock/demo.ts
+++ b/web/src/mock/demo.ts
@@ -308,16 +308,25 @@ const COMPANY: DemoDataset = {
     xLabels: X_LABELS,
   },
   donut: {
+    // The seed.ts Cuesoft July breakdown (top 3 + aggregated tail) — the
+    // hero embed renders this donut as "the real B1 overview", so the
+    // slices mirror the app's (system QA 2026-07-19). Colors are the seed
+    // registry category colors (data, not styling).
     slices: [
+      { id: "payroll", label: "Payroll", value: 1_850_000, color: "#C6373C" },
       {
-        id: "inventory",
-        label: "Inventory",
-        value: 1_373_600,
+        id: "rent",
+        label: "Office rent",
+        value: 650_000,
+        color: "#B26A00",
+      },
+      {
+        id: "cloud",
+        label: "Cloud & software",
+        value: 603_000,
         color: "#F46A1F",
       },
-      { id: "rent", label: "Rent", value: 1_012_100, color: "#2456D6" },
-      { id: "utilities", label: "Utilities", value: 795_300, color: "#B26A00" },
-      { id: "other", label: "Other", value: 433_800, color: "#6E6E76" },
+      { id: "other", label: "Other", value: 511_800, color: "#6E6E76" },
     ],
     centerTotal: "₦3.61M",
   },

--- a/web/src/mock/http.ts
+++ b/web/src/mock/http.ts
@@ -50,12 +50,17 @@ export const writeBlocked = (): NextResponse | null => {
   return null;
 };
 
-/** Cursor pagination over an already-filtered array. */
+/**
+ * Cursor pagination over an already-filtered array. An unknown cursor
+ * returns null so callers can 422 — silently restarting from page one
+ * double-served rows (review canon 2026-07-19).
+ */
 export const paginate = <T extends { id: string }>(
   items: T[],
   cursor: string | null,
   limit: number,
-): { items: T[]; next_cursor: string | null } => {
+): { items: T[]; next_cursor: string | null } | null => {
+  if (cursor && !items.some((item) => item.id === cursor)) return null;
   const start = cursor ? items.findIndex((item) => item.id === cursor) + 1 : 0;
   const pageItems = items.slice(start, start + limit);
   const next =

--- a/web/src/mock/ratio-engine.test.ts
+++ b/web/src/mock/ratio-engine.test.ts
@@ -62,10 +62,21 @@ describe("ratio engine (FY2025 seed — line-items.md §5 registry)", () => {
     expect(metric("revenue_growth").na_reason).toBe("n/a — no prior period");
   });
 
-  it("persists formula + line-item inputs (the MI-8 trace)", () => {
+  it("persists formula + resolved line-item inputs (the MI-8 trace)", () => {
     const current = metric("current_ratio");
     expect(current.formula).toBe("current_assets / current_liabilities");
     expect(current.inputs.length).toBeGreaterThan(0);
+    // Resolved inputs: id (audit pointer) + key + amount, so the trace is
+    // auditable on sight (system QA 2026-07-19).
+    for (const input of current.inputs) {
+      expect(input.id).toBeTruthy();
+      expect(input.canonical_key).toBeTruthy();
+      expect(typeof input.amount).toBe("number");
+    }
+    expect(current.inputs.map((input) => input.canonical_key).sort()).toEqual([
+      "current_assets",
+      "current_liabilities",
+    ]);
   });
 
   it("returns n/a rows for an org with no statements", () => {

--- a/web/src/mock/ratio-engine.ts
+++ b/web/src/mock/ratio-engine.ts
@@ -18,6 +18,7 @@ import { getDb, nextId, type MockDb } from "./db";
 interface ValueRef {
   amount: number;
   id: string;
+  key: CanonicalKey;
 }
 
 interface PeriodValues {
@@ -47,7 +48,11 @@ const collectValues = (
         item.status === "mapped" &&
         item.canonical_key
       ) {
-        values[item.canonical_key] = { amount: item.amount, id: item.id };
+        values[item.canonical_key] = {
+          amount: item.amount,
+          id: item.id,
+          key: item.canonical_key,
+        };
       }
     }
   }
@@ -193,7 +198,12 @@ export const computeRatioReport = (
         status: def.band ? status : "healthy",
         na_reason: null,
         badge,
-        inputs: inputs.map((input) => input.id),
+        // Resolved trace inputs (id + key + amount) — auditable on sight.
+        inputs: inputs.map((input) => ({
+          id: input.id,
+          canonical_key: input.key,
+          amount: input.amount,
+        })),
         trace_notes: [
           ...notes,
           "v1 uses period-end values (period-average denominators are later)",

--- a/web/src/mock/routes-banking.test.ts
+++ b/web/src/mock/routes-banking.test.ts
@@ -241,4 +241,38 @@ describe("mock bank links (flows/bank-link.md)", () => {
     expect(polled.staged.length).toBeGreaterThan(0); // parked for review
     db.purgeRequest = null;
   });
+
+  it("unlink with purge removes parked staged syncs — confirm cannot resurrect purged rows (Codex round 4)", async () => {
+    const db = getDb();
+    // Park a clean sync in staged review on the GTBank link.
+    const started = await syncNow(
+      mockRequest("/api/mock/bank-links/link-gtb/sync", { method: "POST" }),
+      params({ id: "link-gtb" }),
+    );
+    const { job_id } = await json<{ job_id: string }>(started);
+    db.processingSince[job_id] = Date.now() - 5_000;
+    await pollJob(mockRequest(`/api/mock/import/${job_id}`), {
+      params: Promise.resolve({ jobId: job_id }),
+    });
+    expect(db.stagedTxns.some((row) => row.job_id === job_id)).toBe(true);
+
+    // Unlink with purge: the parked job + staged rows go with the link.
+    const removed = await unlink(
+      mockRequest("/api/mock/bank-links/link-gtb?purge=true", {
+        method: "DELETE",
+      }),
+      params({ id: "link-gtb" }),
+    );
+    expect(removed.status).toBe(204);
+    expect(db.importJobs.some((job) => job.id === job_id)).toBe(false);
+    expect(db.stagedTxns.some((row) => row.job_id === job_id)).toBe(false);
+    expect(db.jobLinks[job_id]).toBeUndefined();
+
+    // Confirming the vanished job 404s instead of writing purged rows.
+    const confirmed = await confirmJob(
+      mockRequest(`/api/mock/import/${job_id}/confirm`, { method: "POST" }),
+      { params: Promise.resolve({ jobId: job_id }) },
+    );
+    expect(confirmed.status).toBe(404);
+  });
 });

--- a/web/src/mock/routes-banking.test.ts
+++ b/web/src/mock/routes-banking.test.ts
@@ -150,12 +150,20 @@ describe("mock bank links (flows/bank-link.md)", () => {
 
     // Zenith (auto_confirm: true): the sync commits straight to the ledger.
     const before = getDb().transactions.length;
+    const countBefore = getDb().bankLinks.find(
+      (link) => link.id === "link-zenith",
+    )!.imported_txn_count;
     const auto = await runSync("link-zenith");
     expect(auto.job.confirmed).toBe(true);
     expect(auto.job.imported).toBeGreaterThan(0);
     expect(auto.staged.length).toBe(0);
     const committed = getDb().transactions.length - before;
     expect(committed).toBe(auto.job.imported);
+    // The LinkAccountCard total tracks the commit (Codex P2).
+    expect(
+      getDb().bankLinks.find((link) => link.id === "link-zenith")!
+        .imported_txn_count,
+    ).toBe(countBefore + auto.job.imported);
     expect(
       getDb().transactions.filter((txn) => txn.source_link_id === "link-zenith")
         .length,
@@ -169,5 +177,53 @@ describe("mock bank links (flows/bank-link.md)", () => {
     // Bank feeds are clean — no duplicate flags either way.
     expect(auto.job.duplicates_found).toBe(0);
     expect(manual.job.duplicates_found).toBe(0);
+  });
+
+  it("purge grace keeps the ledger read-only: auto-confirm falls back to staging (Codex P1 regression)", async () => {
+    const db = getDb();
+    db.purgeRequest = {
+      id: "purge-test",
+      user_id: "user-ibukun",
+      status: "pending",
+      requested_at: new Date().toISOString(),
+      effective_at: new Date(Date.now() + 7 * 86_400_000).toISOString(),
+    };
+    // The sync POST itself is write-blocked during grace.
+    const blocked = await syncNow(
+      mockRequest("/api/mock/bank-links/link-zenith/sync", { method: "POST" }),
+      params({ id: "link-zenith" }),
+    );
+    expect(blocked.status).toBe(409);
+
+    // A job already in flight when the purge lands must not commit on the
+    // async completion path either: simulate one mid-processing.
+    db.purgeRequest = null;
+    const started = await syncNow(
+      mockRequest("/api/mock/bank-links/link-zenith/sync", { method: "POST" }),
+      params({ id: "link-zenith" }),
+    );
+    const { job_id } = await json<{ job_id: string }>(started);
+    db.purgeRequest = {
+      id: "purge-test-2",
+      user_id: "user-ibukun",
+      status: "pending",
+      requested_at: new Date().toISOString(),
+      effective_at: new Date(Date.now() + 7 * 86_400_000).toISOString(),
+    };
+    const before = db.transactions.length;
+    db.processingSince[job_id] = Date.now() - 5_000;
+    const polled = await json<{
+      job: { confirmed: boolean; imported: number };
+      staged: unknown[];
+    }>(
+      await pollJob(mockRequest(`/api/mock/import/${job_id}`), {
+        params: Promise.resolve({ jobId: job_id }),
+      }),
+    );
+    expect(db.transactions.length).toBe(before); // ledger untouched
+    expect(polled.job.confirmed).toBe(false);
+    expect(polled.job.imported).toBe(0);
+    expect(polled.staged.length).toBeGreaterThan(0); // parked for review
+    db.purgeRequest = null;
   });
 });

--- a/web/src/mock/routes-banking.test.ts
+++ b/web/src/mock/routes-banking.test.ts
@@ -9,6 +9,7 @@ import {
 import { PUT as exchange } from "@/app/api/mock/bank-links/[id]/exchange/route";
 import { POST as syncNow } from "@/app/api/mock/bank-links/[id]/sync/route";
 import { GET as pollJob } from "@/app/api/mock/import/[jobId]/route";
+import { POST as confirmJob } from "@/app/api/mock/import/[jobId]/confirm/route";
 import type { BankLink } from "@/models";
 import { getDb, resetDb } from "./db";
 import { json, mockRequest, params } from "./test-helpers";
@@ -177,6 +178,20 @@ describe("mock bank links (flows/bank-link.md)", () => {
     // Bank feeds are clean — no duplicate flags either way.
     expect(auto.job.duplicates_found).toBe(0);
     expect(manual.job.duplicates_found).toBe(0);
+
+    // Manually confirming the staged sync keeps link provenance so
+    // unlink-with-purge can remove the rows (Codex round 3).
+    const confirmed = await confirmJob(
+      mockRequest(`/api/mock/import/${manual.jobId}/confirm`, {
+        method: "POST",
+      }),
+      { params: Promise.resolve({ jobId: manual.jobId }) },
+    );
+    expect(confirmed.status).toBe(200);
+    const gtbRows = getDb().transactions.filter(
+      (txn) => txn.source_link_id === "link-gtb",
+    );
+    expect(gtbRows.length).toBeGreaterThan(0);
   });
 
   it("purge grace keeps the ledger read-only: auto-confirm falls back to staging (Codex P1 regression)", async () => {

--- a/web/src/mock/routes-banking.test.ts
+++ b/web/src/mock/routes-banking.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@/app/api/mock/bank-links/[id]/route";
 import { PUT as exchange } from "@/app/api/mock/bank-links/[id]/exchange/route";
 import { POST as syncNow } from "@/app/api/mock/bank-links/[id]/sync/route";
+import { GET as pollJob } from "@/app/api/mock/import/[jobId]/route";
 import type { BankLink } from "@/models";
 import { getDb, resetDb } from "./db";
 import { json, mockRequest, params } from "./test-helpers";
@@ -118,5 +119,55 @@ describe("mock bank links (flows/bank-link.md)", () => {
       params({ id: "link-zenith" }),
     );
     expect(getDb().transactions.length).toBe(before);
+  });
+
+  it("auto_confirm observably changes the sync outcome (review canon: no dead controls)", async () => {
+    const runSync = async (linkId: string) => {
+      const db = getDb();
+      const response = await syncNow(
+        mockRequest(`/api/mock/bank-links/${linkId}/sync`, { method: "POST" }),
+        params({ id: linkId }),
+      );
+      expect(response.status).toBe(202);
+      const { job_id } = await json<{ job_id: string }>(response);
+      // Fast-forward the async lifecycle, then poll to complete.
+      db.processingSince[job_id] = Date.now() - 5_000;
+      const polled = await json<{
+        job: {
+          confirmed: boolean;
+          imported: number;
+          total_parsed: number;
+          duplicates_found: number;
+        };
+        staged: unknown[];
+      }>(
+        await pollJob(mockRequest(`/api/mock/import/${job_id}`), {
+          params: Promise.resolve({ jobId: job_id }),
+        }),
+      );
+      return { job: polled.job, staged: polled.staged, jobId: job_id };
+    };
+
+    // Zenith (auto_confirm: true): the sync commits straight to the ledger.
+    const before = getDb().transactions.length;
+    const auto = await runSync("link-zenith");
+    expect(auto.job.confirmed).toBe(true);
+    expect(auto.job.imported).toBeGreaterThan(0);
+    expect(auto.staged.length).toBe(0);
+    const committed = getDb().transactions.length - before;
+    expect(committed).toBe(auto.job.imported);
+    expect(
+      getDb().transactions.filter((txn) => txn.source_link_id === "link-zenith")
+        .length,
+    ).toBeGreaterThanOrEqual(auto.job.imported);
+
+    // GTBank (auto_confirm: false): same feed parks in staged review.
+    const manual = await runSync("link-gtb");
+    expect(manual.job.confirmed).toBe(false);
+    expect(manual.job.imported).toBe(0);
+    expect(manual.staged.length).toBe(manual.job.total_parsed);
+    // Bank feeds are clean — no duplicate flags either way.
+    expect(auto.job.duplicates_found).toBe(0);
+    expect(manual.job.duplicates_found).toBe(0);
   });
 });

--- a/web/src/mock/routes-imports.test.ts
+++ b/web/src/mock/routes-imports.test.ts
@@ -166,4 +166,39 @@ describe("mock import pipeline (flows/import.md)", () => {
       getDb().stagedTxns.filter((row) => row.job_id === STAGED_JOB_ID),
     ).toHaveLength(0);
   });
+
+  it("consent gate: image uploads 403 consent_required without ai_processing consent (review canon: the consent control gates results)", async () => {
+    const db = getDb();
+    const image = () =>
+      upload(
+        mockRequest("/api/mock/import/upload", {
+          method: "POST",
+          form: {
+            file: new File(["fake"], "receipt.jpg", { type: "image/jpeg" }),
+          },
+        }),
+      );
+
+    // Seeded consent present → images accepted.
+    const withConsent = await image();
+    expect(withConsent.status).toBe(202);
+
+    // Withdraw the consent record → images refused with the taxonomy code
+    // (flows/import.md §3); CSVs never need AI and still pass.
+    db.consents = db.consents.filter(
+      (record) => record.document !== "ai_processing",
+    );
+    const refused = await image();
+    expect(refused.status).toBe(403);
+    const body = await json<{ error: { code: string } }>(refused);
+    expect(body.error.code).toBe("consent_required");
+
+    const csv = await upload(
+      mockRequest("/api/mock/import/upload", {
+        method: "POST",
+        form: { file: new File(["a,b"], "ledger.csv", { type: "text/csv" }) },
+      }),
+    );
+    expect(csv.status).toBe(202);
+  });
 });

--- a/web/src/mock/routes-reports-members-rights.test.ts
+++ b/web/src/mock/routes-reports-members-rights.test.ts
@@ -16,6 +16,7 @@ import {
 } from "@/app/api/mock/orgs/[id]/members/[userId]/route";
 import {
   DELETE as cancelPurge,
+  GET as purgeStatus,
   POST as requestPurge,
 } from "@/app/api/mock/account/purge/route";
 import { POST as requestExport } from "@/app/api/mock/account/export/route";
@@ -167,6 +168,16 @@ describe("mock data rights (flows/rights.md)", () => {
     const duplicate = await requestPurge();
     expect(duplicate.status).toBe(409);
 
+    // The open window is readable, so the grace banner + cancel survive a
+    // reload (system QA regression — flows/rights.md §2).
+    const readBack = await purgeStatus();
+    expect(readBack.status).toBe(200);
+    const pending = await json<{ status: string; effective_at: string }>(
+      readBack,
+    );
+    expect(pending.status).toBe("pending");
+    expect(pending.effective_at).toBeTruthy();
+
     const cancelled = await cancelPurge();
     expect(cancelled.status).toBe(204);
     const writeAfter = await createTxn(
@@ -182,6 +193,11 @@ describe("mock data rights (flows/rights.md)", () => {
       }),
     );
     expect(writeAfter.status).toBe(201);
+
+    // Cancelled window reads as gone (200 null — probe endpoint).
+    const afterCancel = await purgeStatus();
+    expect(afterCancel.status).toBe(200);
+    expect(await json(afterCancel)).toBeNull();
   });
 
   it("export-all: 202 job → completed with a 7-day signed URL", async () => {

--- a/web/src/mock/routes-statements.test.ts
+++ b/web/src/mock/routes-statements.test.ts
@@ -18,6 +18,16 @@ const manualBalanceSheet = (
   line_items: rows,
 });
 
+const manualIncomeStatement = (
+  period: string,
+  rows: Array<{ canonical_key: string; amount: number }>,
+) => ({
+  kind: "income_statement",
+  period,
+  currency: "NGN",
+  line_items: rows,
+});
+
 describe("mock statements (flows/statement-mapping.md, line-items.md §4)", () => {
   beforeEach(() => {
     resetDb();
@@ -260,5 +270,76 @@ describe("mock statements (flows/statement-mapping.md, line-items.md §4)", () =
     expect(response.status).toBe(422);
     const body = await json<{ error: { code: string } }>(response);
     expect(body.error.code).toBe("unmapped_threshold_exceeded");
+  });
+
+  it("quarterly bucket: annualized metrics ×4, pure margins raw, receivables days use the quarter's 90 days (derived-metric semantics)", async () => {
+    // Class-(c) regression (review canon 2026-07-19): derived metrics must
+    // compute what their names claim when the period bucket changes —
+    // quarterly flows annualize ×4 for flow/stock ratios, flow/flow
+    // margins stay raw, and receivables days use the actual day count.
+    const post = async (body: object) =>
+      json<{ statement_id: string }>(
+        await createStatement(
+          mockRequest("/api/mock/statements", { method: "POST", body }),
+        ),
+      );
+    const confirm = async (id: string) =>
+      confirmStatement(
+        mockRequest(`/api/mock/statements/${id}/confirm`, { method: "POST" }),
+        params({ id }),
+      );
+
+    const bs = await post(
+      manualBalanceSheet("2026-Q1", [
+        { canonical_key: "cash_and_equivalents", amount: 10_000_000 },
+        { canonical_key: "receivables", amount: 9_000_000 },
+        { canonical_key: "payables", amount: 4_000_000 },
+        { canonical_key: "retained_earnings", amount: 15_000_000 },
+      ]),
+    );
+    expect((await confirm(bs.statement_id)).status).toBe(200);
+
+    const is = await post(
+      manualIncomeStatement("2026-Q1", [
+        { canonical_key: "revenue", amount: 9_000_000 },
+        { canonical_key: "cogs", amount: 3_000_000 },
+        { canonical_key: "opex", amount: 3_000_000 },
+        { canonical_key: "interest_expense", amount: 500_000 },
+        { canonical_key: "tax_expense", amount: 500_000 },
+      ]),
+    );
+    expect((await confirm(is.statement_id)).status).toBe(200);
+
+    const { computeRatioReport } = await import("./ratio-engine");
+    const report = computeRatioReport("org-cuesoft", "2026-Q1");
+    const metric = (key: string) => {
+      const row = report.ratios.find((item) => item.key === key);
+      if (!row) throw new Error(`missing metric ${key}`);
+      return row;
+    };
+
+    // Flow/flow — raw quarter figures, no annualization:
+    // gross margin = (9m − 3m) / 9m.
+    expect(metric("gross_margin").value).toBeCloseTo(6 / 9, 10);
+    // net income = 3m op − 0.5m interest − 0.5m tax = 2m → 2/9.
+    expect(metric("net_margin").value).toBeCloseTo(2 / 9, 10);
+    // interest coverage = 3m / 0.5m — flow/flow, unannualized.
+    expect(metric("interest_coverage").value).toBeCloseTo(6, 10);
+
+    // Flow/stock — quarterly flows annualize ×4:
+    // total_assets = 19m; asset turnover = (9m × 4) / 19m.
+    expect(metric("asset_turnover").value).toBeCloseTo(36 / 19, 10);
+    expect(metric("asset_turnover").trace_notes.join(" ")).toContain(
+      "annualized ×4",
+    );
+    // ROA = (2m × 4) / 19m.
+    expect(metric("roa").value).toBeCloseTo(8 / 19, 10);
+
+    // Receivables days uses Q1 2026's actual 90 days (not 365):
+    // 9m / 9m × 90.
+    expect(metric("receivables_days").value).toBeCloseTo(90, 10);
+    expect(metric("receivables_days").trace_notes.join(" ")).toContain(
+      "90 days",
+    );
   });
 });

--- a/web/src/mock/routes-statements.test.ts
+++ b/web/src/mock/routes-statements.test.ts
@@ -128,6 +128,29 @@ describe("mock statements (flows/statement-mapping.md, line-items.md §4)", () =
     expect(body.error.code).toBe("mapping_identity_violation");
   });
 
+  it("confirm: missing ASSET side counts as 0 too — liabilities+equity alone cannot confirm (Codex review regression)", async () => {
+    const created = await json<{ statement_id: string }>(
+      await createStatement(
+        mockRequest("/api/mock/statements", {
+          method: "POST",
+          body: manualBalanceSheet("2026-Q1", [
+            { canonical_key: "payables", amount: 1_000_000 },
+            { canonical_key: "share_capital", amount: 1_000_000 },
+          ]),
+        }),
+      ),
+    );
+    const response = await confirmStatement(
+      mockRequest(`/api/mock/statements/${created.statement_id}/confirm`, {
+        method: "POST",
+      }),
+      params({ id: created.statement_id }),
+    );
+    expect(response.status).toBe(422);
+    const body = await json<{ error: { code: string } }>(response);
+    expect(body.error.code).toBe("mapping_identity_violation");
+  });
+
   it("confirm: missing equity side counts as 0 — unbalanced sheet cannot confirm (system QA regression)", async () => {
     // Assets mapped, liabilities mapped, NO equity rows at all: the
     // identity must be treated as violated, not skipped (line-items.md §4).

--- a/web/src/mock/routes-statements.test.ts
+++ b/web/src/mock/routes-statements.test.ts
@@ -118,6 +118,34 @@ describe("mock statements (flows/statement-mapping.md, line-items.md §4)", () =
     expect(body.error.code).toBe("mapping_identity_violation");
   });
 
+  it("confirm: missing equity side counts as 0 — unbalanced sheet cannot confirm (system QA regression)", async () => {
+    // Assets mapped, liabilities mapped, NO equity rows at all: the
+    // identity must be treated as violated, not skipped (line-items.md §4).
+    const created = await json<{ statement_id: string }>(
+      await createStatement(
+        mockRequest("/api/mock/statements", {
+          method: "POST",
+          body: manualBalanceSheet("2026-Q1", [
+            { canonical_key: "cash_and_equivalents", amount: 10_000_000 },
+            { canonical_key: "payables", amount: 1_000_000 },
+          ]),
+        }),
+      ),
+    );
+    const response = await confirmStatement(
+      mockRequest(`/api/mock/statements/${created.statement_id}/confirm`, {
+        method: "POST",
+      }),
+      params({ id: created.statement_id }),
+    );
+    expect(response.status).toBe(422);
+    const body = await json<{
+      error: { code: string; details: { equity: number } };
+    }>(response);
+    expect(body.error.code).toBe("mapping_identity_violation");
+    expect(body.error.details.equity).toBe(0);
+  });
+
   it("confirm: identity-consistent statement derives rows and computes ratios", async () => {
     const created = await json<{ statement_id: string }>(
       await createStatement(

--- a/web/src/mock/routes-transactions.test.ts
+++ b/web/src/mock/routes-transactions.test.ts
@@ -123,4 +123,41 @@ describe("mock /transactions (docs-coherent ledger)", () => {
     const body = await json<{ error: { code: string } }>(response);
     expect(body.error.code).toBe("not_found");
   });
+
+  it("query grammar is a boundary: malformed params 422 instead of silently filtering (review canon)", async () => {
+    const cases: Array<[string, string]> = [
+      ["amount_min", "abc"], // NaN-compared every row away before the fix
+      ["amount_max", "1,000"],
+      ["date_from", "yesterday"],
+      ["date_to", "2026-7-1"],
+      ["direction", "sideways"],
+      ["source", "carrier-pigeon"],
+      ["limit", "abc"],
+      ["limit", "0"],
+    ];
+    for (const [param, value] of cases) {
+      const response = await listTxns(
+        mockRequest(`/api/mock/transactions?${param}=${value}`),
+      );
+      expect(response.status, `${param}=${value}`).toBe(422);
+      const body = await json<{ error: { code: string; details: unknown } }>(
+        response,
+      );
+      expect(body.error.code).toBe("validation_failed");
+    }
+    // Well-formed values still work.
+    const good = await listTxns(
+      mockRequest(
+        "/api/mock/transactions?amount_min=100&date_from=2026-07-01&direction=expense&source=bank&limit=5",
+      ),
+    );
+    expect(good.status).toBe(200);
+  });
+
+  it("unknown cursors 422 instead of silently restarting from page one", async () => {
+    const response = await listTxns(
+      mockRequest("/api/mock/transactions?cursor=txn-nope"),
+    );
+    expect(response.status).toBe(422);
+  });
 });

--- a/web/src/mock/routes-transactions.test.ts
+++ b/web/src/mock/routes-transactions.test.ts
@@ -129,7 +129,9 @@ describe("mock /transactions (docs-coherent ledger)", () => {
       ["amount_min", "abc"], // NaN-compared every row away before the fix
       ["amount_max", "1,000"],
       ["date_from", "yesterday"],
+      ["date_from", "2026-02-30"], // shape-valid, calendar-impossible
       ["date_to", "2026-7-1"],
+      ["date_to", "2026-13-01"],
       ["direction", "sideways"],
       ["source", "carrier-pigeon"],
       ["limit", "abc"],

--- a/web/src/mock/routes-transactions.test.ts
+++ b/web/src/mock/routes-transactions.test.ts
@@ -127,6 +127,7 @@ describe("mock /transactions (docs-coherent ledger)", () => {
   it("query grammar is a boundary: malformed params 422 instead of silently filtering (review canon)", async () => {
     const cases: Array<[string, string]> = [
       ["amount_min", "abc"], // NaN-compared every row away before the fix
+      ["amount_min", "9".repeat(400)], // digit-only overflow → Infinity
       ["amount_max", "1,000"],
       ["date_from", "yesterday"],
       ["date_from", "2026-02-30"], // shape-valid, calendar-impossible

--- a/web/src/mock/seed.ts
+++ b/web/src/mock/seed.ts
@@ -1262,6 +1262,7 @@ export const buildSeed = (): MockDb => ({
   purgeRequest: null,
   idempotency: {},
   lastManualSync: {},
+  jobLinks: {},
   processingSince: {},
   seq: 1000,
 });

--- a/web/src/mock/statement-engine.ts
+++ b/web/src/mock/statement-engine.ts
@@ -105,14 +105,18 @@ export const validateConfirm = (statement: FinStatement): ConfirmCheck => {
     const liabilities = value("total_liabilities");
     const equity = value("equity");
     // A missing side counts as 0 — a sheet with assets but no mapped
-    // liability/equity rows VIOLATES the identity rather than skipping it
-    // (system QA 2026-07-19: the absent-equity case confirmed silently,
-    // letting an unbalanced sheet through; line-items.md §4 requires the
-    // identity to hold before `confirmed`).
-    if (assets !== null) {
-      const basis = Math.max(Math.abs(assets), 1);
+    // liability/equity rows (or vice versa: liabilities/equity but no
+    // asset side, Codex review on PR #209) VIOLATES the identity rather
+    // than skipping it; line-items.md §4 requires the identity to hold
+    // before `confirmed`.
+    if (assets !== null || liabilities !== null || equity !== null) {
+      const basis = Math.max(
+        Math.abs(assets ?? 0),
+        Math.abs((liabilities ?? 0) + (equity ?? 0)),
+        1,
+      );
       if (
-        Math.abs(assets - ((liabilities ?? 0) + (equity ?? 0))) / basis >
+        Math.abs((assets ?? 0) - ((liabilities ?? 0) + (equity ?? 0))) / basis >
         IDENTITY_TOLERANCE
       ) {
         return {
@@ -121,7 +125,7 @@ export const validateConfirm = (statement: FinStatement): ConfirmCheck => {
           message:
             "total_assets must equal total_liabilities + equity within ±1%",
           details: {
-            total_assets: assets,
+            total_assets: assets ?? 0,
             total_liabilities: liabilities ?? 0,
             equity: equity ?? 0,
           },

--- a/web/src/mock/statement-engine.ts
+++ b/web/src/mock/statement-engine.ts
@@ -104,10 +104,15 @@ export const validateConfirm = (statement: FinStatement): ConfirmCheck => {
     const assets = value("total_assets");
     const liabilities = value("total_liabilities");
     const equity = value("equity");
-    if (assets !== null && liabilities !== null && equity !== null) {
+    // A missing side counts as 0 — a sheet with assets but no mapped
+    // liability/equity rows VIOLATES the identity rather than skipping it
+    // (system QA 2026-07-19: the absent-equity case confirmed silently,
+    // letting an unbalanced sheet through; line-items.md §4 requires the
+    // identity to hold before `confirmed`).
+    if (assets !== null) {
       const basis = Math.max(Math.abs(assets), 1);
       if (
-        Math.abs(assets - (liabilities + equity)) / basis >
+        Math.abs(assets - ((liabilities ?? 0) + (equity ?? 0))) / basis >
         IDENTITY_TOLERANCE
       ) {
         return {
@@ -117,8 +122,8 @@ export const validateConfirm = (statement: FinStatement): ConfirmCheck => {
             "total_assets must equal total_liabilities + equity within ±1%",
           details: {
             total_assets: assets,
-            total_liabilities: liabilities,
-            equity,
+            total_liabilities: liabilities ?? 0,
+            equity: equity ?? 0,
           },
         };
       }

--- a/web/src/mock/tax-engine.test.ts
+++ b/web/src/mock/tax-engine.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { missingTaxIdentifiers } from "@/models/tax";
 import { beforeEach, describe, expect, it } from "vitest";
 import { getDb, resetDb } from "./db";
 import {
@@ -85,5 +86,49 @@ describe("tax engine (tax-engine.md)", () => {
     expect(identityIncomplete(personal!)).toEqual(["tin"]);
     const company = db.taxProfiles.find((p) => p.org_id === ORG_CUESOFT);
     expect(identityIncomplete(company!)).toEqual([]);
+  });
+
+  it("missingTaxIdentifiers: one predicate for both taxpayer kinds (wizard gate == generate endpoint)", () => {
+    // Company: TIN present but RC + registered address missing → both named.
+    expect(
+      missingTaxIdentifiers(
+        {
+          taxpayer_kind: "company",
+          tin: "TIN-1",
+          rc_number: null,
+          state_of_residence: null,
+        },
+        { registered_address: undefined },
+      ),
+    ).toEqual(["rc_number", "registered_address"]);
+    // Company complete.
+    expect(
+      missingTaxIdentifiers(
+        {
+          taxpayer_kind: "company",
+          tin: "TIN-1",
+          rc_number: "RC-1",
+          state_of_residence: null,
+        },
+        { registered_address: { line1: "1 Road" } },
+      ),
+    ).toEqual([]);
+    // Individual: no RC requirement, state of residence required.
+    expect(
+      missingTaxIdentifiers({
+        taxpayer_kind: "individual",
+        tin: null,
+        rc_number: null,
+        state_of_residence: null,
+      }),
+    ).toEqual(["tin", "state_of_residence"]);
+    expect(
+      missingTaxIdentifiers({
+        taxpayer_kind: "individual",
+        tin: "TIN-2",
+        rc_number: null,
+        state_of_residence: "NG-LA",
+      }),
+    ).toEqual([]);
   });
 });

--- a/web/src/mock/tax-engine.ts
+++ b/web/src/mock/tax-engine.ts
@@ -6,6 +6,7 @@
  * tax_identity_incomplete).
  */
 
+import { missingTaxIdentifiers } from "@/models/tax";
 import type { ComputedField, TaxEstimate, TaxKind, TaxProfile } from "@/models";
 import { resolveAuthority } from "@/models/registry/authorities";
 import { mockNow } from "./clock";
@@ -419,16 +420,10 @@ export const computeEstimates = (orgId: string): TaxEstimate[] => {
 };
 
 /** Tax-identity completeness (tax-engine.md §5). */
-export const identityIncomplete = (profile: TaxProfile): string[] => {
-  const missing: string[] = [];
-  if (!profile.tin) missing.push("tin");
-  if (profile.taxpayer_kind === "company") {
-    const db = getDb();
-    const org = db.orgs.find((item) => item.id === profile.org_id);
-    if (!profile.rc_number) missing.push("rc_number");
-    if (!org?.registered_address) missing.push("registered_address");
-  } else if (!profile.state_of_residence) {
-    missing.push("state_of_residence");
-  }
-  return missing;
-};
+export const identityIncomplete = (profile: TaxProfile): string[] =>
+  // One predicate with the wizard gate (models/tax.ts) — the org lookup
+  // supplies the registered-address requirement for companies.
+  missingTaxIdentifiers(
+    profile,
+    getDb().orgs.find((item) => item.id === profile.org_id),
+  );

--- a/web/src/models/ratio.ts
+++ b/web/src/models/ratio.ts
@@ -11,6 +11,13 @@ export type RatioStatus = "healthy" | "warning" | "critical" | "na";
 /** How the value renders (currency rows are StatCard/MoneyCell, not gauges). */
 export type RatioDisplay = "ratio" | "percent" | "currency" | "days" | "months";
 
+export interface RatioInput {
+  /** LINE_ITEM id (data-model.md §5) — the persisted audit pointer. */
+  id: string;
+  canonical_key: string;
+  amount: number;
+}
+
 export interface RatioResult {
   key: MetricKey;
   label: string;
@@ -25,8 +32,9 @@ export interface RatioResult {
   /** e.g. "negative equity" (shown as badge instead of a number). */
   badge: string | null;
   formula: string;
-  /** The exact LINE_ITEM ids used — the MI-8 trace. */
-  inputs: string[];
+  /** The exact LINE_ITEM inputs — id + resolved key/amount so the trace
+      is auditable on sight (system QA 2026-07-19; the raw ids stay). */
+  inputs: RatioInput[];
   /** Trace notes: annualization factors, burn source, EBIT basis, etc. */
   trace_notes: string[];
   benchmark_band: string | null;

--- a/web/src/models/repositories/rights.ts
+++ b/web/src/models/repositories/rights.ts
@@ -23,6 +23,14 @@ export const rightsRepo = {
   requestPurge: (options?: RequestOptions) =>
     api.post<PurgeRequest>("/account/purge", undefined, options),
 
+  /**
+   * Read the open purge request (200 `null` when none) so the grace
+   * banner and cancel affordance survive reloads (flows/rights.md §2:
+   * cancel any time in grace).
+   */
+  purgeStatus: (options?: RequestOptions) =>
+    api.get<PurgeRequest | null>("/account/purge", options),
+
   cancelPurge: (options?: RequestOptions) =>
     api.delete<void>("/account/purge", options),
 

--- a/web/src/models/tax.ts
+++ b/web/src/models/tax.ts
@@ -14,6 +14,33 @@ export interface CategoryTreatment {
   vat_basis: VatBasis;
 }
 
+/**
+ * The filing-identity completeness predicate — ONE definition shared by
+ * the mock generate endpoint and the wizard's data-review gate (Codex
+ * review on PR #209: the gate branched on filing kind and checked only
+ * TIN, so a company with TIN but no RC sailed past the review step into
+ * the 422). Requirements follow the TAXPAYER, not the filing kind
+ * (tax-engine.md §5.5): TIN always; companies add RC number + registered
+ * address; individuals add state of residence.
+ */
+export const missingTaxIdentifiers = (
+  profile: Pick<
+    TaxProfile,
+    "taxpayer_kind" | "tin" | "rc_number" | "state_of_residence"
+  >,
+  org?: { registered_address?: unknown } | null,
+): string[] => {
+  const missing: string[] = [];
+  if (!profile.tin) missing.push("tin");
+  if (profile.taxpayer_kind === "company") {
+    if (!profile.rc_number) missing.push("rc_number");
+    if (!org?.registered_address) missing.push("registered_address");
+  } else if (!profile.state_of_residence) {
+    missing.push("state_of_residence");
+  }
+  return missing;
+};
+
 export interface TaxProfile {
   id: string;
   org_id: string;


### PR DESCRIPTION
Full-system QA of the web phase — every journey walked as a skeptical accountant against the TEST_MODE prod build (1440/390, light+dark) with live spot-checks, then audit → fix → verify on this branch.

## Journeys walked (all pass after fixes)
signin → onboarding (personal + company, AI-consent) → overview · ledger (filter/sort/search/bulk/inline ✨-recategorize/split/exclude/manual create/`?record=` deep link/↑↓-enter-`e`/⌘K) · imports (upload → job → staged review → duplicate re-include → MI-3 commit; `password_protected_pdf` + 415 failure paths) · bank link MI-9 (connect → consent → syncing w/ live counter → done → staged handoff) · statements (mapping review → add parser-missed row → confirm → statement view; supersede covered at unit level) · ratios (all groups, MI-8 traces, recompute, n/a semantics) · taxes (profile gate, PIT/VAT/CIT wizard, typed confirm, stamped immutable history) · reports (generate → NEW → download) · categories CRUD + merge · settings/rights (export 202 job, MI-15 purge → grace → cancel) · legacy redirects · 404.

## Accuracy verification (the money is right)
- Recomputed **all 16 registry ratio formulas** from mock line items via API: exact matches (current/quick/cash, D/E, debt ratio, coverage, margins, ROA/ROE, turnovers, receivables days, WC).
- B1 aggregates ↔ ledger exact (Jul income 8,435,200 / expenses 3,614,800 / net 4,820,400); donut slices sum to expenses to the naira; VAT trace = 7.5/107.5 inclusive basis with named inputs (636,000 − 85,400 = 550,600 ✓); runway 7.2 (FY2025) vs 6.5 (post-Q2-confirm) is period-scoped, not drift.
- Found + fixed: **identity-check bypass** (absent equity side ⇒ unbalanced sheet confirmed silently), **unsigned negative money** (`formatMoney` abs), **cross-direction recategorize**, embed↔seed divergences (hero txns, CIT/filing amounts, donut, deltas).

## Fixes by severity
**Blocker** — identity-check bypass on statement confirm; purge grace state lost on reload (no cancel path while all writes 409).
**Major** — BulkActionBar below the fold; staged-review jobs shown as green "Completed · 0 transactions" (now warn "Needs review" + staged counts); 390 dashboard unusable (nav rail auto-collapse + 1-col stat grids); MI-14 NEW tag lost on fresh artifacts (clock-skew hack → pure ≥now−24h rule); negative net rendered positive; hero chips painting under/clipped by the embed (now inside the ScaledEmbed composition, scale with the frame); hidden row-actions swallowed clicks (pointer-events gating).
**Minor** — wizard PIT default on personal orgs + gate at data review + zero-draft note + "TIN is required" grammar; ratio-trace inputs resolved to key+amount; StatCard `deltaDirection` (expenses down = green); ComparisonTable single-line price/CTA rows (user-reported); donut legend "Other" tail; pluralization ("1 anomaly", "1 duplicate"); PeriodPicker nowrap; token-true editorial 404 (flagged off-brand).

## Directive: nav/footer link parity + theme toggle (canon 2026-07-19)
Nav = Features · Pricing · Docs · GitHub + ThemeToggle + Sign in CTA. Footer = brand + Product/Docs/Community/Legal (canonical URLs) + verbatim legal bar ("© Cuesoft Inc. 2026. Expendit. CueLABS™ Division. MIT License." with links), SECURITY.md CTA, real language control. apparule ThemeProvider ported (`expendit.theme`, pre-paint script, one store for marketing nav + dashboard chrome + B9 control). `e2e/parity.spec.ts` pins every href and theme flip/persist on home + dashboard.

## Regression tests
identity-violation (missing equity) · purge read-back · needs-review row · MI-14 rule · signed money · deltaDirection · ComparisonTable nowrap · resolved trace inputs · ThemeProvider/ThemeToggle/controller · MarketingNav canon · parity e2e.

## Gates
lint + boundaries (444 files) ✓ · typecheck ✓ · jest 1 ✓ · vitest **345** ✓ · Playwright **20** ✓ (TEST_MODE prod build).

Notes for follow-up (not fixed here): seed narrative gaps vs docs §6 (ledger lacks a `duplicate_charge` anomaly; calendar lacks T-30/T-7 rows; trends never render from seed; tax-profile completeness inverted personal↔company vs the doc), and hover actions still cover the amount cell during hover — that is the Figma hover variant; flagged as design feedback rather than deviated from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)