### PR TITLE
fix(web): viewport collision clamping for floating layers

### DIFF
--- a/web/e2e/floating-layers.spec.ts
+++ b/web/e2e/floating-layers.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+/**
+ * Floating-layer viewport collision (system QA 2026-07-19): the Overview
+ * month popover (w-36 trigger at the header's right edge, min-w-56
+ * left-anchored panel) overflowed the right viewport edge at 1440 and
+ * clipped its Apply button. Every clamped bespoke layer — PeriodPicker,
+ * OrgSwitcher, CategoryChip — must sit fully inside the viewport at
+ * desktop (1440) and mobile (390) wherever its trigger is anchored.
+ */
+
+const signIn = async (page: Page): Promise<void> => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: "Continue with Google" }).click();
+  await page.waitForURL("**/dashboard", { timeout: 15_000 });
+};
+
+const expectFullyInViewport = async (locator: Locator): Promise<void> => {
+  const box = await locator.boundingBox();
+  const viewport = locator.page().viewportSize();
+  expect(box).not.toBeNull();
+  expect(viewport).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height);
+};
+
+for (const viewport of [
+  { width: 1440, height: 900 },
+  { width: 390, height: 844 },
+]) {
+  test.describe(`floating layers at ${viewport.width}×${viewport.height}`, () => {
+    test.use({ viewport });
+
+    test("period-picker popover stays fully within the viewport", async ({
+      page,
+    }) => {
+      await signIn(page);
+      // The Overview header period picker is the page's only
+      // aria-haspopup="dialog" trigger.
+      await page.locator('button[aria-haspopup="dialog"]').first().click();
+      const popover = page.getByRole("dialog", { name: "Pick month" });
+      await expect(popover).toBeVisible();
+      await expect(
+        popover.getByRole("button", { name: "Apply" }),
+      ).toBeVisible();
+      await expectFullyInViewport(popover);
+    });
+
+    test("org switcher menu stays fully within the viewport", async ({
+      page,
+    }) => {
+      await signIn(page);
+      // Expanded rail trigger on desktop; compact icon-only (labelled
+      // "Organization: …") on the mobile rail.
+      const trigger =
+        viewport.width < 768
+          ? page.getByRole("button", { name: /^Organization:/ })
+          : page.getByRole("button", { name: /Personal|Cuesoft/ }).first();
+      await trigger.click();
+      const menu = page.getByRole("listbox", { name: "Organizations" });
+      await expect(menu).toBeVisible();
+      await expectFullyInViewport(menu);
+    });
+
+    test("category chip combobox menu stays fully within the viewport", async ({
+      page,
+    }) => {
+      await signIn(page);
+      await page.goto("/dashboard/transactions");
+      const chip = page
+        .locator('tbody button[aria-haspopup="listbox"]')
+        .first();
+      await chip.click();
+      // The menu panel wraps the listbox (the panel carries the border
+      // box that must not clip).
+      const panel = page.locator("#category-chip-listbox").locator("..");
+      await expect(panel).toBeVisible();
+      await expectFullyInViewport(panel);
+    });
+  });
+}

--- a/web/src/components/ui/CategoryChip.tsx
+++ b/web/src/components/ui/CategoryChip.tsx
@@ -10,6 +10,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Check, Sparkles } from "lucide-react";
 import { cn } from "@/lib/cn";
+import { useViewportShiftX } from "@/lib/use-viewport-clamp";
 
 export interface CategoryOption {
   id: string;
@@ -38,6 +39,11 @@ export const CategoryChip: React.FC<CategoryChipProps> = ({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const rootRef = useRef<HTMLSpanElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  // The 180px menu is left-anchored to a chip that can sit near the
+  // right viewport edge in narrow ledgers — clamp keeps it fully in the
+  // viewport (floating-layer sweep 2026-07-19).
+  const shiftX = useViewportShiftX(open, menuRef);
   const editable = !disabled && options.length > 0 && !!onSelect;
 
   useEffect(() => {
@@ -115,7 +121,11 @@ export const CategoryChip: React.FC<CategoryChipProps> = ({
 
       {open ? (
         // Absolutely positioned: the open combobox never shifts row layout.
-        <div className="absolute left-0 top-8 z-dropdown w-[180px] rounded border border-border bg-bg py-1 shadow-[0px_4px_16px_0px_rgba(0,0,0,0.12)]">
+        <div
+          ref={menuRef}
+          style={shiftX ? { transform: `translateX(${shiftX}px)` } : undefined}
+          className="absolute left-0 top-8 z-dropdown w-[180px] rounded border border-border bg-bg py-1 shadow-[0px_4px_16px_0px_rgba(0,0,0,0.12)]"
+        >
           <ul
             id="category-chip-listbox"
             role="listbox"

--- a/web/src/components/ui/OrgSwitcher.tsx
+++ b/web/src/components/ui/OrgSwitcher.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Building2, Check, ChevronsUpDown, Plus } from "lucide-react";
 import type { Org } from "@/models";
 import { cn } from "@/lib/cn";
+import { useViewportShiftX } from "@/lib/use-viewport-clamp";
 
 export interface OrgSwitcherProps {
   orgs: Org[];
@@ -67,6 +68,10 @@ export const OrgSwitcher: React.FC<OrgSwitcherProps> = ({
 }) => {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLUListElement>(null);
+  // w-56 menu vs the narrow compact trigger — clamp keeps it fully in
+  // the viewport at any anchor position (floating-layer sweep 2026-07-19).
+  const shiftX = useViewportShiftX(open, menuRef);
   const current = orgs.find((org) => org.id === currentOrgId) ?? orgs[0];
 
   useEffect(() => {
@@ -126,8 +131,10 @@ export const OrgSwitcher: React.FC<OrgSwitcherProps> = ({
 
       {open ? (
         <ul
+          ref={menuRef}
           role="listbox"
           aria-label="Organizations"
+          style={shiftX ? { transform: `translateX(${shiftX}px)` } : undefined}
           className="absolute left-0 top-full z-dropdown mt-1 w-56 rounded border border-border bg-bg py-1 shadow-lg"
         >
           {orgs.map((org) => (

--- a/web/src/components/ui/PeriodPicker.test.tsx
+++ b/web/src/components/ui/PeriodPicker.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import PeriodPicker, { isValidPeriod } from "./PeriodPicker";
@@ -61,5 +61,45 @@ describe("PeriodPicker (design.md §8.2b)", () => {
   it("renders external error state", () => {
     render(<PeriodPicker mode="month" value="2026-06" error="Out of range" />);
     expect(screen.getByRole("alert")).toHaveTextContent("Out of range");
+  });
+
+  describe("viewport collision clamp (system QA 2026-07-19)", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    });
+
+    it("translates the popover back inside the viewport when it would overflow right", async () => {
+      // Overview header regression: w-36 trigger at the right edge of a
+      // 1440 viewport; the min-w-56 panel overflowed by 56px.
+      vi.stubGlobal("innerWidth", 1440);
+      vi.spyOn(
+        window.HTMLElement.prototype,
+        "getBoundingClientRect",
+      ).mockReturnValue({ left: 1272, right: 1496 } as DOMRect);
+
+      render(<PeriodPicker mode="month" value="2026-07" />);
+      await userEvent.click(screen.getByRole("button"));
+
+      expect(screen.getByRole("dialog")).toHaveStyle({
+        transform: "translateX(-64px)",
+      });
+    });
+
+    it("leaves an in-viewport popover unshifted", async () => {
+      vi.stubGlobal("innerWidth", 1440);
+      vi.spyOn(
+        window.HTMLElement.prototype,
+        "getBoundingClientRect",
+      ).mockReturnValue({ left: 400, right: 624 } as DOMRect);
+
+      render(<PeriodPicker mode="month" value="2026-07" />);
+      await userEvent.click(screen.getByRole("button"));
+
+      expect(screen.getByRole("dialog")).not.toHaveStyle({
+        transform: "translateX(-64px)",
+      });
+      expect(screen.getByRole("dialog").style.transform).toBe("");
+    });
   });
 });

--- a/web/src/components/ui/PeriodPicker.tsx
+++ b/web/src/components/ui/PeriodPicker.tsx
@@ -10,6 +10,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Calendar, ChevronDown } from "lucide-react";
 import dayjs from "dayjs";
 import { cn } from "@/lib/cn";
+import { useViewportShiftX } from "@/lib/use-viewport-clamp";
 
 export type PeriodMode = "day" | "range" | "month" | "quarter" | "year";
 
@@ -89,6 +90,11 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
   const [draft, setDraft] = useState(value ?? "");
   const [draftError, setDraftError] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  // The panel is min-w-56 while the trigger can be narrower (Overview
+  // header w-36) — left-anchored it overflowed the right viewport edge
+  // (system QA 2026-07-19). Clamp keeps it fully in the viewport.
+  const shiftX = useViewportShiftX(open, panelRef);
 
   // Track the controlled value — adjust-state-during-render, no effect.
   const [prevValue, setPrevValue] = useState(value);
@@ -167,8 +173,10 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
 
       {open ? (
         <div
+          ref={panelRef}
           role="dialog"
           aria-label={`Pick ${mode}`}
+          style={shiftX ? { transform: `translateX(${shiftX}px)` } : undefined}
           className="absolute left-0 top-full z-dropdown mt-1 w-full min-w-56 rounded border border-border bg-bg p-3 shadow-lg"
         >
           {presets.length > 0 ? (

--- a/web/src/lib/use-viewport-clamp.test.ts
+++ b/web/src/lib/use-viewport-clamp.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import {
+  VIEWPORT_GUTTER,
+  clampShiftX,
+  useViewportShiftX,
+} from "./use-viewport-clamp";
+
+describe("clampShiftX (floating-layer viewport clamp)", () => {
+  it("returns 0 when the panel already fits", () => {
+    expect(clampShiftX(100, 300, 1440)).toBe(0);
+  });
+
+  it("shifts left when the panel overflows the right edge", () => {
+    // The Overview regression: trigger at 1272, min-w-56 panel → right
+    // edge 1496 at a 1440 viewport. Clamp pulls it back inside.
+    expect(clampShiftX(1272, 1496, 1440)).toBe(1440 - VIEWPORT_GUTTER - 1496);
+  });
+
+  it("shifts right when the panel overflows the left edge", () => {
+    expect(clampShiftX(-20, 160, 390)).toBe(VIEWPORT_GUTTER - -20);
+  });
+
+  it("lets the left edge win when the panel is wider than the viewport", () => {
+    expect(clampShiftX(10, 500, 390)).toBe(VIEWPORT_GUTTER - 10);
+  });
+
+  it("honors a custom gutter", () => {
+    expect(clampShiftX(0, 100, 1440, 0)).toBe(0);
+  });
+});
+
+describe("useViewportShiftX", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const panelAt = (left: number, right: number) =>
+    ({
+      getBoundingClientRect: () => ({ left, right }) as DOMRect,
+    }) as HTMLElement;
+
+  it("measures the open panel and clamps it into the viewport", () => {
+    vi.stubGlobal("innerWidth", 1440);
+    const ref = { current: panelAt(1272, 1496) };
+    const { result } = renderHook(
+      ({ open }: { open: boolean }) => useViewportShiftX(open, ref),
+      { initialProps: { open: true } },
+    );
+    expect(result.current).toBe(1440 - VIEWPORT_GUTTER - 1496);
+  });
+
+  it("returns 0 while closed and resets after closing", () => {
+    vi.stubGlobal("innerWidth", 1440);
+    const ref = { current: panelAt(1272, 1496) };
+    const { result, rerender } = renderHook(
+      ({ open }: { open: boolean }) => useViewportShiftX(open, ref),
+      { initialProps: { open: false } },
+    );
+    expect(result.current).toBe(0);
+    rerender({ open: true });
+    expect(result.current).not.toBe(0);
+    rerender({ open: false });
+    expect(result.current).toBe(0);
+  });
+
+  it("re-measures on window resize using the unshifted geometry", () => {
+    vi.stubGlobal("innerWidth", 1440);
+    const ref = { current: panelAt(1272, 1496) };
+    const { result } = renderHook(() => useViewportShiftX(true, ref));
+    const first = result.current;
+    expect(first).toBeLessThan(0);
+
+    // The viewport grows: the panel fits again, so the shift is removed
+    // (the live rect includes the applied shift; the hook subtracts it).
+    vi.stubGlobal("innerWidth", 1600);
+    ref.current = panelAt(1272 + first, 1496 + first);
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(result.current).toBe(0);
+  });
+});

--- a/web/src/lib/use-viewport-clamp.ts
+++ b/web/src/lib/use-viewport-clamp.ts
@@ -1,0 +1,79 @@
+"use client";
+
+/**
+ * Horizontal viewport collision clamp for the bespoke floating layers
+ * (PeriodPicker, OrgSwitcher, CategoryChip). System QA 2026-07-19: the
+ * Overview month popover (w-36 trigger, min-w-56 panel, left-anchored)
+ * overflowed the right viewport edge and clipped its Apply button.
+ *
+ * Layers stay absolutely anchored to their trigger; after opening we
+ * measure the panel and translate it horizontally so it sits fully
+ * inside the viewport with an 8px gutter — at every anchor position.
+ * Radix-portaled layers (Tooltip, Modal) already collision-handle and
+ * do not need this.
+ */
+
+import { useLayoutEffect, useState, type RefObject } from "react";
+
+export const VIEWPORT_GUTTER = 8;
+
+/**
+ * Pure clamp: the translate-x that keeps [left, right] inside
+ * [gutter, viewportWidth - gutter]. When the panel is wider than the
+ * viewport the left edge wins (content starts readable, scroll reaches
+ * the rest).
+ */
+export const clampShiftX = (
+  left: number,
+  right: number,
+  viewportWidth: number,
+  gutter: number = VIEWPORT_GUTTER,
+): number => {
+  let shift = 0;
+  if (right > viewportWidth - gutter) shift = viewportWidth - gutter - right;
+  if (left + shift < gutter) shift = gutter - left;
+  return Math.round(shift);
+};
+
+/**
+ * Measures the open panel and returns the horizontal shift (px) to apply
+ * as `translateX` so it stays fully within the viewport. Re-measures on
+ * window resize; resets when the layer closes.
+ */
+export const useViewportShiftX = (
+  open: boolean,
+  panelRef: RefObject<HTMLElement | null>,
+): number => {
+  const [shift, setShift] = useState(0);
+
+  // Reset when the layer closes — adjust-state-during-render, no effect.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
+    if (!open) setShift(0);
+  }
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    // Mirrors the shift already painted so resize re-measures can
+    // recover the unshifted anchor geometry from the live rect.
+    let applied = 0;
+    const measure = () => {
+      const panel = panelRef.current;
+      if (!panel || typeof window === "undefined") return;
+      const rect = panel.getBoundingClientRect();
+      const next = clampShiftX(
+        rect.left - applied,
+        rect.right - applied,
+        window.innerWidth,
+      );
+      applied = next;
+      setShift(next);
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [open, panelRef]);
+
+  return shift;
+};


### PR DESCRIPTION
## Summary

Live-site bug (Overview, ~1440w): the header period picker ("Jul 2026") opened a month popover that overflowed the right viewport edge, clipping its Apply button.

**Root cause** — the bespoke floating layers anchor absolutely to their trigger (`absolute left-0 top-full`) with no viewport collision handling. The PeriodPicker panel is `min-w-56` (224px) while its Overview trigger is `w-36` (144px) at the right edge of the header, so the panel overflowed by ~64px.

**Fix** — new shared `use-viewport-clamp` hook (`clampShiftX` + `useViewportShiftX`): after a layer opens, measure its rect and translate it horizontally so it sits fully inside the viewport with an 8px gutter, at every anchor position; re-measures on resize, resets on close.

## Floating-layer sweep (1440 and 390, both anchor sides)

| Layer | Verdict |
| --- | --- |
| PeriodPicker (Overview header + statement/tax/report date pickers) | **Hit — fixed** (panel wider than trigger, left-anchored) |
| CategoryChip in-row combobox | **Hit — fixed** (180px menu, chip can sit near the right edge in narrow ledgers) |
| OrgSwitcher menu | **Hardened** (w-56 menu vs narrow compact trigger; left-rail placements were safe, now safe at any anchor) |
| Select (saved-view, export/category/format selects) | Clean — menu width equals trigger width |
| MarketingNav mobile disclosure | Clean — full-bleed `inset-x-0` panel; desktop nav has no dropdown |
| Tooltip / Modal / CommandPalette / Inspector | Clean — Radix-portaled or fixed-centered with viewport-aware sizing |
| TxnTableRow hover actions | Clean — absolutely positioned inside the row bounds |

## Tests

- Unit: clamp math + hook (measure/clamp/resize/reset) + PeriodPicker regression asserting the `-64px` translate at the exact reported geometry.
- e2e (`floating-layers.spec.ts`): period-picker popover, org-switcher menu, and category-chip combobox bounding boxes fully within the viewport at **1440×900 and 390×844** — verified red without the fix.

## Gates

lint ✓ · typecheck ✓ · jest+vitest 372 ✓ · `NEXT_PUBLIC_TEST_MODE=1` build ✓ · Playwright 27/27 ✓ (post-rebase onto #211/#212)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
