### PR TITLE
chore(web): remove legacy redirect stubs — old paths 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `RequestID`/`Logger`/`Recovery`/CORS middleware, and graceful shutdown.
 - Local Docker stack: root `docker-compose.yml` (mongo, redis, api-common:8080,
   web:3000), compose-driven `Makefile`, and `.env.example`.
-- Standardized repository structure and shared CueLABS community-health files
+- Standardized repository structure and shared CueLABS™ community-health files
   (SECURITY, CODE_OF_CONDUCT, CONTRIBUTING, CODEOWNERS, PR/issue templates), a
   scoped Dependabot config, `deploy/{docker,helm,terraform}`, and
   `docs/overview.md` + `docs/setup.md`.
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   purpose-based packages and `snake_case.go` files.
 - Standardized web naming (kebab-case folders + modules, PascalCase components);
   moved `src/API/APIS` → `src/api`.
-- Aligned README + docs (overview, setup) to the shared CueLABS section
+- Aligned README + docs (overview, setup) to the shared CueLABS™ section
   structure; run commands use `make up` / `go run ./cmd/server`.
 - Rewrote README/CONTRIBUTING to match the real stack (Go + Gin + MongoDB,
   Next.js); aligned `.gitignore`, `.editorconfig`, and `.dockerignore` to the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in contributing! This guide applies across CueLABS
+Thanks for your interest in contributing! This guide applies across CueLABS™
 repositories, which share a common structure and conventions.
 
 ## Getting started
@@ -12,7 +12,7 @@ repositories, which share a common structure and conventions.
 
 ## Repository layout
 
-CueLABS repositories follow a shared standard:
+CueLABS™ repositories follow a shared standard:
 
 - `api/common` — Go backend (auth + core API)
 - `api/<service>` — additional services, named by function

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# CueLABS standard Makefile — compose-driven local development + terraform deploy.
+# CueLABS™ standard Makefile — compose-driven local development + terraform deploy.
 # Run `make help` to list targets.
 .DEFAULT_GOAL := help
 .PHONY: help up down build rebuild logs ps restart clean tf-init tf-plan tf-apply tf-destroy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,10 +90,11 @@ preview), `/signin` (Google-only, X-1), `/onboarding`, and the nested app
 surface `/dashboard/<area>` — transactions, imports, accounts, reports,
 company (+ statements/ratios), taxes (+ filing wizard), categories, and
 settings incl. the USR-001/002 rights controls
-(web-implementation.md §4 route map). Flat-path redirects (`/expense`,
+(web-implementation.md §4 route map). Legacy flat paths (`/expense`,
 `/income`, `/history`, `/import`, `/reports`, `/categories`, `/settings`,
-`/signup`, `/forgot-password[/new-password]`, `/change-password`) point at
-the canonical routes. Target adds: `/privacy` (EXP-005).
+`/signup`, `/forgot-password[/new-password]`, `/change-password`) carry no
+redirect stubs — they 404 on the branded page. Target adds: `/privacy`
+(EXP-005).
 **[Proposed placement]**
 
 ## 4. The import pipeline (core asset) **[Current]**

--- a/docs/flows/auth.md
+++ b/docs/flows/auth.md
@@ -63,5 +63,5 @@ a support-ticket tag counted operationally (registry annotation updated).
 - [ ] Legacy user links on first Google sign-in; history intact
 - [ ] Day-61: legacy endpoints 410; password columns dropped; templates gone
 - [ ] Non-Google-provider tokens rejected (crafted-token test)
-- [ ] `/signup` + `/forgot-password` routes removed; redirects to `/signin`
+- [ ] `/signup` + `/forgot-password` routes removed; 404 on the branded page (no redirect stub, web-implementation.md §4)
 - [ ] Rate-limiter middleware removed from auth routes only

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -279,12 +279,13 @@ the ⌘K palette (MI-1) is a global overlay, not a route.
 | B8 | `/dashboard/categories` | Categories (CRUD, color, merge) |
 | B9 | `/dashboard/settings` | Settings incl. members/roles, org profile, rights & data screens (export-all, purge MI-15) |
 
-Part C (mobile) has no web routes — it is a later phase (§8). Flat-path
-redirects keep old links working: `/expense` · `/income` · `/history` →
-`/dashboard/transactions`; `/import` → `/dashboard/imports`; `/reports` ·
-`/categories` · `/settings` → the matching `/dashboard/<area>`; and the
-password-era auth paths (`/signup`, `/forgot-password[/new-password]`,
-`/change-password`) → `/signin` (X-1, flows/auth.md §1).
+Part C (mobile) has no web routes — it is a later phase (§8). Legacy
+flat paths (`/expense`, `/income`, `/history`, `/import`, `/reports`,
+`/categories`, `/settings`, and the password-era auth paths `/signup`,
+`/forgot-password[/new-password]`, `/change-password`) carry no redirect
+stubs — they 404 on the branded page (route canon, above): the only
+routes are `/`, `/signin`, `/onboarding`, and `/dashboard/<area>`
+(X-1, flows/auth.md §1).
 
 ## 5. TEST_MODE contract
 
@@ -395,8 +396,9 @@ in CI (`scripts/check-boundaries.mjs` + the eslint
 `no-restricted-imports` rules, both wired into `npm run lint`): **MUI
 imports are legal only under `src/legacy/`**, and live code never imports
 from it. `src/legacy/` is **currently empty** — the app runs entirely on
-the token-layer registry (§1), and retired paths stay reachable as
-redirects (§4). `@mui/material` + `@mui/x-data-grid` remain pinned in
+the token-layer registry (§1), and retired paths 404 on the branded page
+rather than carrying redirect stubs forward (§4). `@mui/material` +
+`@mui/x-data-grid` remain pinned in
 package.json; dropping them is the outstanding cleanup **[Proposed]**.
 
 The **mobile app is a later phase** (pages.md Part C): no `mobile/` tree

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -5,7 +5,8 @@ import { expect, test, type Page } from "@playwright/test";
  * web-implementation.md §7): signin → overview → transactions CRUD →
  * import journey → statements mapping → ratios → tax wizard → filing
  * history, plus the keyboard-first path (⌘K palette MI-1 + table nav
- * ↑↓/enter/`e`, design.md §5) and the legacy-route redirects (§8 step 2).
+ * ↑↓/enter/`e`, design.md §5) and the legacy flat-path 404s
+ * (web-implementation.md §4/§8: no redirect stubs, branded 404 page).
  *
  * Runs in TEST_MODE against the in-app mock server; the journey mutates
  * the shared seeded store, so the file runs serially and steps stay
@@ -282,23 +283,23 @@ test("keyboard-first path — ⌘K palette and ledger table nav", async ({
   await expect(page.getByRole("dialog", { name: "Transaction" })).toBeVisible();
 });
 
-test("legacy flat routes redirect to their nested replacements", async ({
-  page,
-}) => {
+test("legacy flat routes 404 on the branded page", async ({ page }) => {
   await signIn(page);
-  const redirects: Array<[string, string]> = [
-    ["/expense", "/dashboard/transactions"],
-    ["/income", "/dashboard/transactions"],
-    ["/history", "/dashboard/transactions"],
-    ["/import", "/dashboard/imports"],
-    ["/reports", "/dashboard/reports"],
-    ["/categories", "/dashboard/categories"],
-    ["/settings", "/dashboard/settings"],
+  const legacyPaths = [
+    "/expense",
+    "/income",
+    "/history",
+    "/import",
+    "/reports",
+    "/categories",
+    "/settings",
   ];
-  for (const [from, to] of redirects) {
-    await page.goto(from);
-    await page.waitForURL(`**${to}`);
-    expect(page.url()).toContain(to);
+  for (const path of legacyPaths) {
+    const response = await page.goto(path);
+    expect(response?.status()).toBe(404);
+    await expect(
+      page.getByRole("heading", { name: "This page doesn’t add up." }),
+    ).toBeVisible();
   }
 });
 

--- a/web/e2e/signin.spec.ts
+++ b/web/e2e/signin.spec.ts
@@ -26,10 +26,12 @@ test("TEST_MODE: Continue with Google goes straight to /dashboard", async ({
   await expect(page).toHaveURL(/\/dashboard$/);
 });
 
-test("retired password routes redirect to /signin", async ({ page }) => {
+test("retired password routes 404 on the branded page", async ({ page }) => {
   for (const path of ["/signup", "/forgot-password", "/change-password"]) {
-    await page.goto(path);
-    await page.waitForURL("**/signin");
-    await expect(page).toHaveURL(/\/signin$/);
+    const response = await page.goto(path);
+    expect(response?.status()).toBe(404);
+    await expect(
+      page.getByRole("heading", { name: "This page doesn’t add up." }),
+    ).toBeVisible();
   }
 });

--- a/web/src/app/categories/page.tsx
+++ b/web/src/app/categories/page.tsx
@@ -1,9 +1,0 @@
-import { redirect } from "next/navigation";
-
-// Route canon (web-implementation.md §4/§8): the flat /categories path
-// redirects to its nested dashboard area — old links keep working.
-const LegacyRedirect = () => {
-  redirect("/dashboard/categories");
-};
-
-export default LegacyRedirect;

--- a/web/src/app/change-password/page.tsx
+++ b/web/src/app/change-password/page.tsx
@@ -1,9 +1,0 @@
-import { redirect } from "next/navigation";
-
-// X-1: Google-only auth — there are no passwords to change; the route
-// redirects to the single auth screen (flows/auth.md §1).
-const ChangePassword = () => {
-  redirect("/signin");
-};
-
-export default ChangePassword;

--- a/web/src/app/expense/page.tsx
+++ b/web/src/app/expense/page.tsx
@@ -1,9 +1,0 @@
-import { redirect } from "next/navigation";
-
-// Route canon (web-implementation.md §4/§8): the flat /expense path
-// redirects to its nested dashboard area — old links keep working.
-const LegacyRedirect = () => {
-  redirect("/dashboard/transactions");
-};
-
-export default LegacyRedirect;

--- a/web/src/app/forgot-password/new-password/page.tsx
+++ b/web/src/app/forgot-password/new-password/page.tsx
@@ -1,9 +1,0 @@
-import { redirect } from "next/navigation";
-
-// X-1: Google-only auth — password reset no longer exists; the route
-// redirects to the single auth screen (flows/auth.md §1 acceptance).
-const NewPassword = () => {
-  redirect("/signin");
-};
-
-export default NewPassword;

--- a/web/src/app/forgot-password/page.tsx
+++ b/web/src/app/forgot-password/page.tsx
@@ -1,9 +1,0 @@
-import { redirect } from "next/navigation";
-
-// X-1: Google-only auth — password reset no longer exists; the route
-// redirects to the single auth screen (flows/auth.md §1 acceptance).
-const ForgotPassword = () => {
-  redirect("/signin");
-};
-
-export default ForgotPassword;

--- a/web/src/app/history/page.tsx
+++ b/web/src/app/history/page.tsx
@@ -1,9 +1,0 @@
-import { redirect } from "next/navigation";
-
-// Route canon (web-implementation.md §4/§8): the flat /history path
-// redirects to its nested dashboard area — old links keep working.
-const LegacyRedirect = () => {
-  redirect("/dashboard/transactions");
-};
-
-export default LegacyRedirect;

--- a/web/src/app/import/page.tsx
+++ b/web/src/app/import/page.tsx
@@ -1,9 +1,0 @@
-import { redirect } from "next/navigation";
-
-// Route canon (web-implementation.md §4/§8): the flat /import path
-// redirects to its nested dashboard area — old links keep working.
-const LegacyRedirect = () => {
-  redirect("/dashboard/imports");
-};
-
-export default LegacyRedirect;

--- a/web/src/app/income/page.tsx
+++ b/web/src/app/income/page.tsx
@@ -1,9 +1,0 @@
-import { redirect } from "next/navigation";
-
-// Route canon (web-implementation.md §4/§8): the flat /income path
-// redirects to its nested dashboard area — old links keep working.
-const LegacyRedirect = () => {
-  redirect("/dashboard/transactions");
-};
-
-export default LegacyRedirect;

--- a/web/src/app/reports/page.tsx
+++ b/web/src/app/reports/page.tsx
@@ -1,9 +1,0 @@
-import { redirect } from "next/navigation";
-
-// Route canon (web-implementation.md §4/§8): the flat /reports path
-// redirects to its nested dashboard area — old links keep working.
-const LegacyRedirect = () => {
-  redirect("/dashboard/reports");
-};
-
-export default LegacyRedirect;

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -1,9 +1,0 @@
-import { redirect } from "next/navigation";
-
-// Route canon (web-implementation.md §4/§8): the flat /settings path
-// redirects to its nested dashboard area — old links keep working.
-const LegacyRedirect = () => {
-  redirect("/dashboard/settings");
-};
-
-export default LegacyRedirect;

--- a/web/src/app/signup/page.tsx
+++ b/web/src/app/signup/page.tsx
@@ -1,9 +1,0 @@
-import { redirect } from "next/navigation";
-
-// X-1: Google-only auth — /signup redirects to the single auth screen
-// (flows/auth.md §1 acceptance).
-const Signup = () => {
-  redirect("/signin");
-};
-
-export default Signup;


### PR DESCRIPTION
## Summary
- Route canon update (user directive): legacy flat paths get no redirect stubs — old routes are deleted outright and 404 on the branded page instead of redirecting.
- Deleted 11 redirect-only stub pages under `web/src/app`: `settings/`, `signup/`, `expense/`, `income/`, `history/`, `import/`, `categories/`, `reports/`, `change-password/`, `forgot-password/`, `forgot-password/new-password/` (each was a single-purpose `redirect()` component, no rendered UI — now-empty directories removed along with the files).
- Updated `docs/web-implementation.md` §4/§8 and `docs/architecture.md` §3.2 (same stale claim duplicated there) to describe the new present-tense behavior: legacy flat paths 404 on the branded page, no redirect stubs.
- Updated the e2e specs that asserted the old redirect behavior to assert the branded 404 instead: `web/e2e/signin.spec.ts` ("retired password routes 404 on the branded page") and `web/e2e/dashboard.spec.ts` ("legacy flat routes 404 on the branded page"), plus the file-level doc comment referencing the old redirect step.
- `/signin` (the canonical X-1 auth screen) and all `/dashboard/<area>` branded routes are untouched.

## Test plan
- [x] `npm ci`
- [x] `npm run lint` (prettier + eslint + boundaries)
- [x] `npm run typecheck`
- [x] `npm run test:ci` (Jest 1/1, Vitest 371/371)
- [x] `NEXT_PUBLIC_TEST_MODE=1 npm run build` — route manifest confirms all 11 legacy paths are gone, `/_not-found` present
- [x] `npm run test:e2e` — 27/27 passed, including the two updated 404 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)