### PR TITLE
feat(web): demo completeness — MI-6 hover actions in the description cell + B4 trust-path copy

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -117,7 +117,7 @@ ecosystem change, PR'd to all three design.md files together.
 | MI-3 | **Staged-review commit** | confirm button shows count ("Import 209 / discard 5 duplicates"); on commit, staged rows cascade-collapse into the ledger toast (240ms stagger ≤10 rows, then batch) |
 | MI-4 | **Inline category edit** | click chip → combobox in-cell; enter commits with 80ms chip color crossfade; AI ✨ mark clears on human confirm; `e` on focused row opens it |
 | MI-5 | **Anomaly pulse** | new anomalies pulse twice on first render, then rest; count in nav badge |
-| MI-6 | **Row hover** | 60ms bg tint + action icons fade-in right-aligned; no layout shift (icons absolutely positioned) |
+| MI-6 | **Row hover** | 60ms bg tint + action icons fade-in right-aligned; no layout shift (icons absolutely positioned). Actions dock at the right edge of the DESCRIPTION cell, overlaying only truncation whitespace — the amount column stays legible during hover [Decided 2026-07-19] |
 | MI-7 | **Number tick** | stat cards animate value changes with 300ms count-up (once per data refresh, not on scroll) |
 | MI-8 | **Ratio gauge** | needle eases to value 600ms cubic; benchmark band fades in after; hover shows formula tooltip ("Current ratio = current assets ÷ current liabilities") |
 | MI-9 | **Bank link flow** | provider modal (Mono/Plaid-style) inside `WizardShell`; status stepper: connect → consent → syncing (progress with live txn counter) → done; sync dot breathes while syncing |

--- a/web/e2e/mobile-responsive.spec.ts
+++ b/web/e2e/mobile-responsive.spec.ts
@@ -135,6 +135,11 @@ const COMPANY_ROUTES = [
 for (const viewport of [
   { width: 390, height: 844 },
   { width: 768, height: 1024 },
+  // ≥md the AppNav boots EXPANDED (240px) by default — these widths
+  // sweep the narrowest expanded-nav content columns (canon 2026-07-19:
+  // the content must reflow cleanly in both nav states).
+  { width: 1024, height: 900 },
+  { width: 1280, height: 900 },
 ]) {
   test.describe(`no horizontal overflow at ${viewport.width}`, () => {
     test.use({ viewport });
@@ -233,3 +238,72 @@ for (const viewport of [
     });
   });
 }
+
+test.describe("mobile nav drawer (390)", () => {
+  // Canon (2026-07-19): below md the AppNav rides the 64px rail;
+  // EXPANSION opens an overlay drawer over a scrim — the content column
+  // never reflows; the persisted expanded state applies only ≥md.
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("expanding overlays a drawer — content width unchanged; scrim and Escape dismiss", async ({
+    page,
+  }) => {
+    await signIn(page);
+    const main = page.locator("main");
+    const widthBefore = (await main.boundingBox())!.width;
+
+    await page.getByRole("button", { name: "Expand navigation" }).click();
+    const drawer = page.getByRole("dialog", { name: "Navigation drawer" });
+    await expect(drawer).toBeVisible();
+    // Overlay, not reflow: the content column keeps its width.
+    expect((await main.boundingBox())!.width).toBe(widthBefore);
+    const drawerBox = (await drawer.boundingBox())!;
+    expect(drawerBox.x).toBe(0);
+    expect(drawerBox.width).toBeLessThan(390);
+    // The drawer carries the labeled nav groups the rail hides.
+    await expect(
+      drawer.getByRole("link", { name: /^Transactions/ }),
+    ).toBeVisible();
+
+    // Escape closes and returns focus to the trigger.
+    await page.keyboard.press("Escape");
+    await expect(drawer).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Expand navigation" }),
+    ).toBeFocused();
+
+    // Scrim tap closes too (click far right of the 240px panel).
+    await page.getByRole("button", { name: "Expand navigation" }).click();
+    await expect(drawer).toBeVisible();
+    await page
+      .getByTestId("nav-drawer-scrim")
+      .click({ position: { x: 360, y: 420 } });
+    await expect(drawer).not.toBeVisible();
+  });
+
+  test("drawer links navigate and dismiss the drawer", async ({ page }) => {
+    await signIn(page);
+    await page.getByRole("button", { name: "Expand navigation" }).click();
+    const drawer = page.getByRole("dialog", { name: "Navigation drawer" });
+    await drawer.getByRole("link", { name: "Reports" }).click();
+    await page.waitForURL("**/dashboard/reports");
+    await expect(drawer).not.toBeVisible();
+  });
+
+  test("a persisted expanded state boots collapsed at 390", async ({
+    page,
+  }) => {
+    await signIn(page);
+    // Simulate a desktop session that persisted the EXPANDED state.
+    await page.evaluate(() =>
+      window.localStorage.setItem("expendit.nav-collapsed", "0"),
+    );
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    const nav = page.getByRole("navigation", { name: "Primary" });
+    await expect(nav).toHaveAttribute("data-collapsed", "true");
+    await expect(
+      page.getByRole("dialog", { name: "Navigation drawer" }),
+    ).toHaveCount(0);
+  });
+});

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,4 +1,11 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = { output: "standalone" };
+const nextConfig = {
+  output: "standalone",
+  // The floating dev indicator (a <nextjs-portal> overlay, bottom-left)
+  // intercepts pointer events over the AppNav footer during local
+  // `next dev` Playwright runs — CI runs `next start`, so this only
+  // affects local e2e determinism.
+  devIndicators: false,
+};
 
 module.exports = nextConfig;

--- a/web/src/app/api/mock/bank-links/[id]/route.ts
+++ b/web/src/app/api/mock/bank-links/[id]/route.ts
@@ -50,7 +50,31 @@ export async function PATCH(request: Request, context: Context) {
     }
     link.status = body.status;
   }
-  if (body.auto_confirm !== undefined) link.auto_confirm = body.auto_confirm;
+  if (body.auto_confirm !== undefined) {
+    // Trust path (flows/import.md §5 [Decided default]): auto-confirm is
+    // opt-in only after ≥3 manually confirmed clean syncs on this link —
+    // enabling earlier bypasses review entirely (PR #217 review).
+    if (body.auto_confirm && !link.auto_confirm) {
+      const db = getDb();
+      const cleanSyncs = db.importJobs.filter(
+        (job) =>
+          db.jobLinks[job.id] === link.id &&
+          job.source === "bank_sync" &&
+          job.confirmed &&
+          job.duplicates_found === 0 &&
+          job.anomalies.length === 0,
+      ).length;
+      if (cleanSyncs < 3) {
+        return fail(
+          422,
+          "validation_failed",
+          `Auto-confirm opens after 3 manually confirmed clean syncs — this link has ${cleanSyncs}.`,
+          { clean_syncs: cleanSyncs, required: 3 },
+        );
+      }
+    }
+    link.auto_confirm = body.auto_confirm;
+  }
   return ok(link);
 }
 

--- a/web/src/app/dashboard/DashboardShell.tsx
+++ b/web/src/app/dashboard/DashboardShell.tsx
@@ -11,6 +11,7 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
+import * as Dialog from "@radix-ui/react-dialog";
 import {
   ArrowLeftRight,
   Building2,
@@ -108,7 +109,18 @@ const ShellChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [collapsed, setCollapsed] = useState(false);
   // Below md the nav always rides the 64px icon rail — a fixed 240px
   // column left ~150px of content at 390w (system QA 2026-07-19).
-  const [isMobile, setIsMobile] = useState(false);
+  // Expansion at <md opens an OVERLAY DRAWER instead (canon 2026-07-19):
+  // the content keeps its full width beneath a scrim; the persisted
+  // expanded state applies only ≥md, so mobile always boots collapsed.
+  // Initialized synchronously — a false initial value painted the 240px
+  // nav for the first frames at 390 (mobile-boot FOUC, e2e-caught); the
+  // shell only renders client-side post-auth, so this is hydration-safe.
+  const [isMobile, setIsMobile] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(max-width: 767px)").matches,
+  );
+  const [drawerOpen, setDrawerOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
 
   useEffect(() => {
@@ -121,6 +133,11 @@ const ShellChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   }, []);
 
   const effectiveCollapsed = collapsed || isMobile;
+
+  // Crossing up to ≥md dismisses the drawer — the in-flow nav takes over.
+  useEffect(() => {
+    if (!isMobile) setDrawerOpen(false);
+  }, [isMobile]);
 
   // First-run guard: a signed-in user with no org lands on B0.
   useEffect(() => {
@@ -204,11 +221,43 @@ const ShellChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     return [...actions, ...navigation];
   }, [router]);
 
+  // Shared by the in-flow rail and the mobile drawer (drawer clicks
+  // dismiss it before navigating).
+  const renderNavItems = (onNavigate?: () => void) =>
+    NAV_ROUTES.map((route, index) => {
+      const groupLabel =
+        route.group && route.group !== NAV_ROUTES[index - 1]?.group
+          ? route.group
+          : null;
+      return (
+        <React.Fragment key={route.href}>
+          {groupLabel ? <NavGroupLabel>{groupLabel}</NavGroupLabel> : null}
+          <NavItem
+            icon={route.icon}
+            label={route.label}
+            href={route.href}
+            active={isActive(pathname, route)}
+            badgeCount={
+              route.href === "/dashboard/transactions"
+                ? anomalyCount
+                : undefined
+            }
+            onClick={onNavigate}
+          />
+        </React.Fragment>
+      );
+    });
+
   return (
     <div className="flex h-screen overflow-hidden bg-bg text-text">
       <AppNav
         collapsed={effectiveCollapsed}
-        onCollapsedChange={isMobile ? undefined : onCollapsedChange}
+        // <md: the rail's expand affordance opens the overlay drawer —
+        // the in-flow column never widens, so content keeps its width
+        // (canon 2026-07-19); ≥md it toggles + persists as before.
+        onCollapsedChange={
+          isMobile ? () => setDrawerOpen(true) : onCollapsedChange
+        }
         orgSwitcher={
           activeOrgId ? (
             <OrgSwitcher
@@ -249,29 +298,73 @@ const ShellChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           </div>
         }
       >
-        {NAV_ROUTES.map((route, index) => {
-          const groupLabel =
-            route.group && route.group !== NAV_ROUTES[index - 1]?.group
-              ? route.group
-              : null;
-          return (
-            <React.Fragment key={route.href}>
-              {groupLabel ? <NavGroupLabel>{groupLabel}</NavGroupLabel> : null}
-              <NavItem
-                icon={route.icon}
-                label={route.label}
-                href={route.href}
-                active={isActive(pathname, route)}
-                badgeCount={
-                  route.href === "/dashboard/transactions"
-                    ? anomalyCount
-                    : undefined
-                }
-              />
-            </React.Fragment>
-          );
-        })}
+        {renderNavItems()}
       </AppNav>
+
+      {/* Mobile overlay drawer (canon 2026-07-19): expansion below md
+          paints the 240px nav OVER the content behind a scrim — the
+          content column never reflows. Radix supplies the focus trap,
+          Escape and scrim-tap dismissal; the expanded state is never
+          persisted from here, so mobile always boots on the rail. */}
+      {isMobile ? (
+        <Dialog.Root open={drawerOpen} onOpenChange={setDrawerOpen}>
+          <Dialog.Portal>
+            <Dialog.Overlay
+              data-testid="nav-drawer-scrim"
+              className="fixed inset-0 z-overlay bg-bg-editorial/40 animate-fade-in motion-reduce:animate-none"
+            />
+            <Dialog.Content
+              aria-label="Navigation drawer"
+              // The drawer opens programmatically (no Dialog.Trigger), so
+              // closing must hand focus back to the rail's expand button
+              // explicitly (a11y contract: focus returns to the opener).
+              onCloseAutoFocus={(event) => {
+                event.preventDefault();
+                document
+                  .querySelector<HTMLButtonElement>(
+                    'button[aria-label="Expand navigation"]',
+                  )
+                  ?.focus();
+              }}
+              className="fixed inset-y-0 left-0 z-modal flex w-60 flex-col border-r border-border bg-bg font-sans shadow-lg focus:outline-none"
+            >
+              {activeOrgId ? (
+                <div className="border-b border-border p-2">
+                  <OrgSwitcher
+                    orgs={orgs}
+                    currentOrgId={activeOrgId}
+                    onSelect={switchOrg}
+                    onCreate={() => {
+                      setDrawerOpen(false);
+                      router.push("/onboarding?create=1");
+                    }}
+                  />
+                </div>
+              ) : null}
+              <div className="flex-1 space-y-0.5 overflow-y-auto p-2">
+                {renderNavItems(() => setDrawerOpen(false))}
+              </div>
+              <div className="border-t border-border p-2">
+                <div className="mb-1 flex items-center gap-2 px-2.5 py-1.5">
+                  <Avatar name={user?.name ?? "…"} size="sm" />
+                  <span className="min-w-0 flex-1 truncate text-[13px] text-text-2">
+                    {user?.name}
+                  </span>
+                  <ThemeToggle className="p-1" />
+                  <button
+                    type="button"
+                    aria-label="Sign out"
+                    onClick={() => void signOut()}
+                    className="rounded p-1 text-text-2 transition-colors duration-fast ease-standard hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  >
+                    <LogOut className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
+      ) : null}
 
       <main className="flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-[1440px] px-6 py-6">

--- a/web/src/app/dashboard/DashboardShell.tsx
+++ b/web/src/app/dashboard/DashboardShell.tsx
@@ -134,10 +134,13 @@ const ShellChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
   const effectiveCollapsed = collapsed || isMobile;
 
-  // Crossing up to ≥md dismisses the drawer — the in-flow nav takes over.
-  useEffect(() => {
+  // Crossing up to ≥md dismisses the drawer — the in-flow nav takes
+  // over. Adjust-state-during-render, no effect (react-hooks rule).
+  const [prevIsMobile, setPrevIsMobile] = useState(isMobile);
+  if (prevIsMobile !== isMobile) {
+    setPrevIsMobile(isMobile);
     if (!isMobile) setDrawerOpen(false);
-  }, [isMobile]);
+  }
 
   // First-run guard: a signed-in user with no org lands on B0.
   useEffect(() => {

--- a/web/src/app/dashboard/accounts/AccountsView.tsx
+++ b/web/src/app/dashboard/accounts/AccountsView.tsx
@@ -237,6 +237,10 @@ export const AccountsView: React.FC = () => {
                     </dl>
                     <Switch
                       label="Auto-confirm clean syncs"
+                      // Trust path (flows/import.md §5): opt-in once ≥3
+                      // clean syncs were manually confirmed; anomalies or
+                      // duplicates always force review regardless.
+                      helper="Opens up after 3 manually confirmed clean syncs — anomalies and duplicates still go to review."
                       checked={link.auto_confirm}
                       onCheckedChange={(next) =>
                         void accounts.setAutoConfirm(link.id, next)

--- a/web/src/app/dashboard/accounts/AccountsView.tsx
+++ b/web/src/app/dashboard/accounts/AccountsView.tsx
@@ -239,11 +239,20 @@ export const AccountsView: React.FC = () => {
                       label="Auto-confirm clean syncs"
                       // Trust path (flows/import.md §5): opt-in once ≥3
                       // clean syncs were manually confirmed; anomalies or
-                      // duplicates always force review regardless.
+                      // duplicates always force review regardless. The
+                      // mock enforces the threshold (422) — surface it.
                       helper="Opens up after 3 manually confirmed clean syncs — anomalies and duplicates still go to review."
                       checked={link.auto_confirm}
                       onCheckedChange={(next) =>
-                        void accounts.setAutoConfirm(link.id, next)
+                        void accounts
+                          .setAutoConfirm(link.id, next)
+                          .catch((err: unknown) =>
+                            setToast(
+                              err instanceof Error
+                                ? err.message
+                                : "Could not update auto-confirm",
+                            ),
+                          )
                       }
                     />
                     <div className="flex flex-wrap gap-2">

--- a/web/src/components/ui/TxnTableRow.test.tsx
+++ b/web/src/components/ui/TxnTableRow.test.tsx
@@ -53,6 +53,11 @@ describe("TxnTableRow (design.md §8.2, MI-6)", () => {
     const actions = screen.getByTestId("row-actions");
     expect(actions).toHaveClass("absolute", "opacity-0");
     expect(actions).toHaveClass("group-hover:opacity-100");
+    // Adjudicated 2026-07-19: the cluster docks inside the DESCRIPTION
+    // cell (right edge), so it never covers the amount column.
+    const descriptionCell = screen.getByText(txn.description).closest("td");
+    expect(descriptionCell).toContainElement(actions);
+    expect(descriptionCell).toHaveClass("relative");
   });
 
   it("density switches row height 32/44", () => {

--- a/web/src/components/ui/TxnTableRow.tsx
+++ b/web/src/components/ui/TxnTableRow.tsx
@@ -3,8 +3,10 @@
 /**
  * TxnTableRow — design.md §8.2: default / hover (actions revealed) /
  * selected / editing / staged-duplicate · density ×2. MI-6: 60ms bg tint,
- * action icons fade in absolutely positioned — no layout shift. Row-level
- * keyboard: `e` opens category edit (design.md §5).
+ * action icons fade in absolutely positioned at the right edge of the
+ * DESCRIPTION cell — no layout shift, and the amount stays legible during
+ * hover (adjudicated 2026-07-19; the Figma hover variant follows).
+ * Row-level keyboard: `e` opens category edit (design.md §5).
  */
 
 import React from "react";
@@ -125,7 +127,50 @@ export const TxnTableRow: React.FC<TxnTableRowProps> = ({
           className="h-3.5 w-3.5 shrink-0 text-text-2"
         />
       </td>
-      <td className="min-w-0 flex-1 truncate">{txn.description}</td>
+      {/* Description cell hosts the MI-6 hover actions at ITS right edge
+          (adjudicated 2026-07-19): they overlay only truncation
+          whitespace, so the amount stays legible during hover — the
+          Figma TxnTableRow hover variant follows this construction. */}
+      <td className="relative min-w-0 flex-1 truncate">
+        {txn.description}
+        <span
+          data-testid="row-actions"
+          className={cn(
+            // pointer-events gating keeps the hidden cluster
+            // hit-transparent — without it the invisible strip swallowed
+            // clicks on cells beneath it (system QA 2026-07-19).
+            "absolute right-0 top-1/2 flex -translate-y-1/2 items-center gap-1 bg-bg-elev pl-2",
+            "pointer-events-none opacity-0 transition-opacity duration-[60ms] ease-standard",
+            "group-hover:pointer-events-auto group-hover:opacity-100",
+            "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+          )}
+        >
+          <button
+            type="button"
+            aria-label="Edit category"
+            onClick={onEdit}
+            className="rounded p-1 text-text-2 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            aria-label="Split"
+            onClick={onSplit}
+            className="rounded p-1 text-text-2 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <Split className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            aria-label="Exclude from reports"
+            onClick={onExclude}
+            className="rounded p-1 text-text-2 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <EyeOff className="h-3.5 w-3.5" />
+          </button>
+        </span>
+      </td>
       {stagedDuplicate ? (
         // Figma staged-duplicate: the inline Duplicate anomaly pill.
         <td className="flex shrink-0 items-center">
@@ -154,47 +199,6 @@ export const TxnTableRow: React.FC<TxnTableRowProps> = ({
           direction={txn.direction}
           withIcon={false}
         />
-      </td>
-
-      {/* MI-6: absolutely positioned actions — hover reveal, no layout shift. */}
-      <td
-        data-testid="row-actions"
-        className={cn(
-          // Figma hover variant: bare icons right-aligned over the row's
-          // hover surface (they cover the amount only while this row is
-          // hovered/focused). pointer-events gating keeps the hidden
-          // cluster hit-transparent — without it the invisible strip
-          // swallowed clicks on cells beneath it (system QA 2026-07-19).
-          "absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1 bg-bg-elev pl-2",
-          "pointer-events-none opacity-0 transition-opacity duration-[60ms] ease-standard",
-          "group-hover:pointer-events-auto group-hover:opacity-100",
-          "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
-        )}
-      >
-        <button
-          type="button"
-          aria-label="Edit category"
-          onClick={onEdit}
-          className="rounded p-1 text-text-2 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-        >
-          <Pencil className="h-3.5 w-3.5" />
-        </button>
-        <button
-          type="button"
-          aria-label="Split"
-          onClick={onSplit}
-          className="rounded p-1 text-text-2 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-        >
-          <Split className="h-3.5 w-3.5" />
-        </button>
-        <button
-          type="button"
-          aria-label="Exclude from reports"
-          onClick={onExclude}
-          className="rounded p-1 text-text-2 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-        >
-          <EyeOff className="h-3.5 w-3.5" />
-        </button>
       </td>
     </tr>
   );

--- a/web/src/components/ui/TxnTableRow.tsx
+++ b/web/src/components/ui/TxnTableRow.tsx
@@ -130,9 +130,12 @@ export const TxnTableRow: React.FC<TxnTableRowProps> = ({
       {/* Description cell hosts the MI-6 hover actions at ITS right edge
           (adjudicated 2026-07-19): they overlay only truncation
           whitespace, so the amount stays legible during hover — the
-          Figma TxnTableRow hover variant follows this construction. */}
-      <td className="relative min-w-0 flex-1 truncate">
-        {txn.description}
+          Figma TxnTableRow hover variant follows this construction.
+          Truncation lives on an inner span: `truncate` on the cell
+          itself would overflow-hide the action cluster once the cell
+          squeezes below its ~80px width (PR #217 review). */}
+      <td className="relative min-w-0 flex-1">
+        <span className="block truncate">{txn.description}</span>
         <span
           data-testid="row-actions"
           className={cn(

--- a/web/src/mock/routes-banking.test.ts
+++ b/web/src/mock/routes-banking.test.ts
@@ -90,6 +90,57 @@ describe("mock bank links (flows/bank-link.md)", () => {
     expect(invalid.status).toBe(422);
   });
 
+  it("auto-confirm trust gate: enabling needs ≥3 confirmed clean syncs (flows/import.md §5)", async () => {
+    // GTBank has ONE seeded confirmed clean sync — enabling is blocked.
+    const blocked = await patchLink(
+      mockRequest("/api/mock/bank-links/link-gtb", {
+        method: "PATCH",
+        body: { auto_confirm: true },
+      }),
+      params({ id: "link-gtb" }),
+    );
+    expect(blocked.status).toBe(422);
+    const body = await json<{
+      error: { code: string; details: { clean_syncs: number } };
+    }>(blocked);
+    expect(body.error.code).toBe("validation_failed");
+    expect(body.error.details.clean_syncs).toBe(1);
+
+    // Two more confirmed clean syncs establish trust — enabling passes.
+    const db = getDb();
+    for (const n of [1, 2]) {
+      const id = `job-test-clean-${n}`;
+      db.importJobs.push({
+        ...db.importJobs.find((job) => job.id === "job-sync-gtb-jul18")!,
+        id,
+      });
+      db.jobLinks[id] = "link-gtb";
+    }
+    const enabled = await json<BankLink>(
+      await patchLink(
+        mockRequest("/api/mock/bank-links/link-gtb", {
+          method: "PATCH",
+          body: { auto_confirm: true },
+        }),
+        params({ id: "link-gtb" }),
+      ),
+    );
+    expect(enabled.auto_confirm).toBe(true);
+
+    // Disabling is never gated (turning review back ON is always safe).
+    const disabled = await json<BankLink>(
+      await patchLink(
+        mockRequest("/api/mock/bank-links/link-zenith", {
+          method: "PATCH",
+          body: { auto_confirm: false },
+        }),
+        params({ id: "link-zenith" }),
+      ),
+    );
+    expect(disabled.auto_confirm).toBe(false);
+    resetDb();
+  });
+
   it("exchange: stale code → 422 link_expired; success activates", async () => {
     const expired = await exchange(
       mockRequest("/api/mock/bank-links/link-gtb/exchange", {

--- a/web/src/mock/seed.ts
+++ b/web/src/mock/seed.ts
@@ -2692,7 +2692,13 @@ export const buildSeed = (): MockDb => ({
   purgeRequest: null,
   idempotency: {},
   lastManualSync: {},
-  jobLinks: {},
+  // Seeded bank-sync jobs attribute to their links — the auto-confirm
+  // trust gate counts confirmed clean syncs per link through this map.
+  jobLinks: {
+    "job-sync-zenith-jul19": "link-zenith",
+    "job-sync-gtb-jul18": "link-gtb",
+    "job-sync-access-jul08": "link-access",
+  },
   processingSince: {},
   seq: 1000,
 });


### PR DESCRIPTION
## Summary

P1 PR3 (`feat/demo-completeness`): gap analysis of docs/pages.md (screens + MI catalog) and features.md against the implementation, the adjudicated hover-actions fix, and the sidebar canon fold-ins (expanded-nav reflow + mobile overlay drawer).

### Gap analysis result
The implementation is **complete** against the catalog — verified in place: MI-2 upload lifecycle (drag-over accent, progress ring → AI-sweep → ✓ + row count, error taxonomy), A5a thumbnail click-scrolls to the A5 demo, B2 bulk re-categorize/export + amount-range filters + saved views, B5 category param + financial-statement kind, B6 manual entry + statement export + vision-path accept types, B7b typed period confirmation, B9 fiscal-year-end/notifications/bank-link permissions, MI-15 typed-confirm + 5s danger-armed countdown. Nothing skipped.

### Changes
1. **MI-6 hover actions (adjudicated 2026-07-19)**: the action cluster docks at the right edge of the **description (flex-1) cell** — it overlays only truncation whitespace, zero layout shift holds, and the amount stays legible during hover (screenshot verified). `design.md §4` MI-6 records the decision; unit test asserts containment. Figma hover variant follows in parallel (code leads by design).
2. **B4 auto-confirm trust path**: switch helper copy per flows/import.md §5 (opt-in after 3 manually confirmed clean syncs; anomalies/duplicates always route to review).
3. **Sidebar canon (user directive)**:
   - *Desktop*: responsive sweep gains **1024/1280 dimensions with the nav booted EXPANDED** (the narrowest content columns) — all dashboard routes clean, screenshots in both nav states on the narrowest cases (ledger truncates by design, wizard/mapping/ratios reflow).
   - *Mobile*: expansion below md now opens an **overlay drawer** (Radix Dialog — scrim, focus trap, Escape/scrim dismissal, focus returned to the opener); the content column never reflows; drawer links dismiss before navigating; persisted expanded state applies only ≥md. The new e2e also caught and fixed a **mobile-boot FOUC** (the 240px nav painted for the first frames at 390 before an effect corrected it — `isMobile` now initializes synchronously from matchMedia).
   - e2e at 390: overlay leaves content width unchanged · scrim + Escape dismiss with focus return · links navigate-and-dismiss · a persisted-expanded state boots collapsed.
4. `devIndicators: false` — the floating dev-indicator portal intercepted clicks over the AppNav footer in local parallel Playwright runs (CI runs `next start`; local determinism fix).

### Verification
Unit 373 ✓ · Playwright **43** ✓ (was 34 — 9 new: 2 sweep dimensions + 3 drawer + extended checks) · lint/typecheck/TEST_MODE build ✓ · screenshots: hover actions at 1440, worst-offender routes at 1024 expanded/collapsed, drawer open/rail at 390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)