### PR TITLE
fix(web): /docs/api header coexistence + tri-state theme (light | dark | system)

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -245,12 +245,38 @@ links with absolute home anchors, live star count, ThemeToggle,
 `docs/api/openapi.yaml` — the single spec source — served by the
 `/docs/api/openapi.yaml` route handler from a build-time string asset
 (`npm run generate:openapi`, wired as `predev`/`prebuild`/
-`pretypecheck`; output gitignored under `src/generated/`). Theme follows
-ThemeProvider (Scalar `darkMode` config; its own toggle hidden); remote
-default fonts are disabled (self-host ethos). The footer Docs column's
-"API reference" (`API_REFERENCE_URL`) links `/docs/api`;
+`pretypecheck`; output gitignored under `src/generated/`). Theme: the
+embed is forced to the RESOLVED theme via Scalar's `forceDarkModeState`
+(a creation-time override — the view mounts after hydration and remounts
+on theme change, since `updateConfiguration` never re-applies it);
+Scalar's own toggle is hidden and its remote default fonts are disabled
+(self-host ethos). Header construction: the sticky marketing nav and
+Scalar's sticky layout coexist via `--scalar-custom-header-height` on
+the embed wrapper (offsets Scalar's sticky sidebar/mobile bar below the
+nav and shrinks its viewport math — one coherent page scroll) plus
+`isolate` so no Scalar z-index paints over the nav. The footer Docs
+column's "API reference" (`API_REFERENCE_URL`) links `/docs/api`;
 `e2e/docs-api.spec.ts` pins route 200, a rendered operation from the
-spec, the served document, and the footer handoff.
+spec, the served document, the footer handoff, the header/scroll sanity
+and the embed-theme sync.
+
+**Theme contract as-built (2026-07-20, ratified — identical across
+apparule, expendit and upstat).** The preference is tri-state
+light | dark | system: `ThemeProvider` persists it at `expendit.theme`
+("light"/"dark" stored explicitly; KEY ABSENT = system — the
+cross-product storage convention), and `data-theme` on `<html>` always
+carries the RESOLVED theme — system resolves via `prefers-color-scheme`
+and tracks it live (a matchMedia listener updates `data-theme` on an OS
+flip, no reload). The pre-paint init script applies the resolved theme
+(no FOUC in any mode). `ThemeToggle` (marketing nav + dashboard chrome)
+cycles light → dark → system with distinct icons (sun / moon / monitor);
+its aria-label announces the active mode. The B9 Appearance section
+keeps the three-way Light/System/Dark segmented control over the same
+store (`useThemeController` delegates to the provider). The Scalar embed
+follows `resolvedTheme` (X-2 note above). Unit tests pin the storage
+convention, live system tracking, the cycle order and the storage-
+blocked fallbacks; e2e pins the cycle, an emulated OS flip in system
+mode and reload persistence.
 
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
@@ -267,8 +293,9 @@ their W3 screens, not `components/ui/` modules.
 
 One custom property per Figma variable in the `expendit/tokens` collection
 (design.md §7 — true Light/Dark modes); light values on `:root`, dark on
-`[data-theme="dark"]`, `prefers-color-scheme` honored with manual override
-(the B9 settings theme control sets `data-theme`).
+`[data-theme="dark"]` — `data-theme` always carries the RESOLVED theme
+(tri-state contract, §2 as-built; the tokens.css `prefers-color-scheme`
+block remains as the no-JS fallback only).
 
 | Group | Token names |
 | --- | --- |

--- a/web/e2e/docs-api.spec.ts
+++ b/web/e2e/docs-api.spec.ts
@@ -50,4 +50,75 @@ test.describe("API reference — /docs/api", () => {
       page.getByRole("heading", { name: "Expendit API" }),
     ).toBeVisible({ timeout: 20_000 });
   });
+
+  test("header behaves: nav stays visible over the embed, one scroll container", async ({
+    page,
+  }) => {
+    await page.goto("/docs/api");
+    await expect(
+      page.getByRole("heading", { name: "Expendit API" }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    // One coherent scroll container: the page scrolls; no full-viewport
+    // inner scroller wraps the embed (Scalar's viewport math is offset by
+    // --scalar-custom-header-height so its sidebar fits under the nav).
+    const layout = await page.evaluate(() => ({
+      pageScrollable:
+        document.documentElement.scrollHeight > window.innerHeight,
+      fullHeightInnerScrollers: [...document.querySelectorAll("*")].filter(
+        (el) =>
+          el.scrollHeight > el.clientHeight + 10 &&
+          ["auto", "scroll"].includes(getComputedStyle(el).overflowY) &&
+          el.clientHeight >= window.innerHeight,
+      ).length,
+    }));
+    expect(layout.pageScrollable).toBe(true);
+    expect(layout.fullHeightInnerScrollers).toBe(0);
+
+    // After scrolling, the marketing nav (sticky) is still fully visible —
+    // Scalar's sticky sidebar must not paint over it (isolate + offset).
+    await page.mouse.wheel(0, 800);
+    await expect(
+      page.getByRole("link", { name: "Star cuesoftinc/expendit on GitHub" }),
+    ).toBeVisible();
+    const navTop = await page
+      .getByRole("navigation", { name: "Marketing" })
+      .evaluate((el) => el.getBoundingClientRect().top);
+    expect(navTop).toBe(0);
+  });
+
+  test("the embed follows the tri-state theme, incl. a live OS flip in system mode", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ colorScheme: "light" });
+    await page.goto("/docs/api");
+    await expect(
+      page.getByRole("heading", { name: "Expendit API" }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    // Scalar mirrors the resolved theme on body (light-mode/dark-mode).
+    const body = page.locator("body");
+    await expect(body).toHaveClass(/light-mode/);
+
+    // system mode (default) follows an OS scheme flip live.
+    await page.emulateMedia({ colorScheme: "dark" });
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(body).toHaveClass(/dark-mode/, { timeout: 15_000 });
+
+    // Explicit choice via the nav toggle wins over the OS (the embed
+    // resyncs to light after cycling system → light).
+    await page
+      .getByRole("button", { name: "Theme: system — switch to light" })
+      .click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await expect(body).toHaveClass(/light-mode/, { timeout: 15_000 });
+    await expect(
+      page.getByRole("heading", { name: "Expendit API" }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    // The choice persists across reload (stored at expendit.theme).
+    await page.reload();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await expect(body).toHaveClass(/light-mode/, { timeout: 20_000 });
+  });
 });

--- a/web/e2e/parity.spec.ts
+++ b/web/e2e/parity.spec.ts
@@ -3,8 +3,9 @@ import { expect, test, type Page } from "@playwright/test";
 /**
  * Marketing nav/footer & theme parity canon (org SKILL.md, 2026-07-19):
  * canonical link inventory on the A1 nav + A11 footer, and the
- * ThemeProvider contract (data-theme on <html>, localStorage
- * `expendit.theme`) flipping + persisting on home AND dashboard.
+ * ThemeProvider contract (2026-07-20 tri-state: data-theme on <html>
+ * always carries the RESOLVED theme; localStorage `expendit.theme`,
+ * key absent = system) cycling + persisting on home AND dashboard.
  */
 
 const GITHUB = "https://github.com/cuesoftinc/expendit";
@@ -68,7 +69,7 @@ test("nav carries the canonical 4 links + Sign in + Try Cloud CTA", async ({
   const cursorOf = (locator: ReturnType<typeof nav.getByRole>) =>
     locator.evaluate((el) => getComputedStyle(el).cursor);
   expect(
-    await cursorOf(nav.getByRole("button", { name: /Switch to .* theme/ })),
+    await cursorOf(nav.getByRole("button", { name: /^Theme: .* — switch to/ })),
   ).toBe("pointer");
   expect(await cursorOf(nav.getByRole("link", { name: "Docs" }))).toBe(
     "pointer",
@@ -200,9 +201,13 @@ test("mobile (390w): the hamburger panel reaches every canonical nav destination
   await expect(panelStar).toHaveText("Star");
   await expect(panelStar.locator("svg")).toBeVisible();
 
-  // Theme toggle works from the panel.
+  // Theme toggle works from the panel (system → light → dark).
   await nav
-    .getByRole("button", { name: "Switch to dark theme" })
+    .getByRole("button", { name: "Theme: system — switch to light" })
+    .filter({ visible: true })
+    .click();
+  await nav
+    .getByRole("button", { name: "Theme: light — switch to dark" })
     .filter({ visible: true })
     .click();
   await expect
@@ -228,24 +233,42 @@ const expectTheme = async (page: Page, theme: string | null) => {
     .toBe(theme);
 };
 
-test("theme toggle flips and persists on the home page", async ({ page }) => {
+test("theme toggle cycles light → dark → system and persists on the home page", async ({
+  page,
+}) => {
   await page.goto("/");
-  await expectTheme(page, null); // system default — no override attribute
-  await page.getByRole("button", { name: "Switch to dark theme" }).click();
+  // system default — data-theme carries the RESOLVED theme (light OS here)
+  await expectTheme(page, "light");
+
+  await page
+    .getByRole("button", { name: "Theme: system — switch to light" })
+    .click();
+  await expectTheme(page, "light");
+  await page
+    .getByRole("button", { name: "Theme: light — switch to dark" })
+    .click();
   await expectTheme(page, "dark");
   expect(
     await page.evaluate(() => localStorage.getItem("expendit.theme")),
   ).toBe("dark");
 
-  // Pre-paint persistence across a reload.
+  // Pre-paint persistence across a reload (no FOUC path).
   await page.reload();
   await expectTheme(page, "dark");
 
-  await page.getByRole("button", { name: "Switch to light theme" }).click();
+  // Third press returns to system: key removed, resolved from the OS,
+  // and a live OS flip tracks without a reload.
+  await page
+    .getByRole("button", { name: "Theme: dark — switch to system" })
+    .click();
   await expectTheme(page, "light");
   expect(
     await page.evaluate(() => localStorage.getItem("expendit.theme")),
-  ).toBe("light");
+  ).toBeNull();
+  await page.emulateMedia({ colorScheme: "dark" });
+  await expectTheme(page, "dark");
+  await page.emulateMedia({ colorScheme: "light" });
+  await expectTheme(page, "light");
 });
 
 test("theme toggle lives in the dashboard chrome and persists", async ({
@@ -258,7 +281,12 @@ test("theme toggle lives in the dashboard chrome and persists", async ({
     page.getByRole("heading", { name: "Overview", level: 1 }),
   ).toBeVisible();
 
-  await page.getByRole("button", { name: "Switch to dark theme" }).click();
+  await page
+    .getByRole("button", { name: "Theme: system — switch to light" })
+    .click();
+  await page
+    .getByRole("button", { name: "Theme: light — switch to dark" })
+    .click();
   await expectTheme(page, "dark");
   expect(
     await page.evaluate(() => localStorage.getItem("expendit.theme")),
@@ -267,9 +295,16 @@ test("theme toggle lives in the dashboard chrome and persists", async ({
   await page.reload();
   await expectTheme(page, "dark");
 
-  // The B9 settings control reads the same store (one source of truth).
+  // The B9 settings control reads the same store (one source of truth) —
+  // its three-way segmented control returns the preference to system.
   await page.goto("/dashboard/settings");
   await expect(page.getByRole("heading", { name: "Appearance" })).toBeVisible();
-  await page.getByRole("button", { name: "Switch to light theme" }).click();
+  await page
+    .getByRole("radiogroup", { name: "Theme" })
+    .getByRole("radio", { name: "System" })
+    .click();
   await expectTheme(page, "light");
+  expect(
+    await page.evaluate(() => localStorage.getItem("expendit.theme")),
+  ).toBeNull();
 });

--- a/web/src/components/docs/DocsApiView.tsx
+++ b/web/src/components/docs/DocsApiView.tsx
@@ -57,7 +57,13 @@ export const DocsApiView: React.FC = () => {
         }}
         onTryCloud={() => track("try_cloud_click", { source: "nav" })}
       />
-      <main className="flex-1">
+      {/* Header-fix construction (2026-07-20): the sticky marketing nav
+          and Scalar's own sticky layout coexist by telling Scalar about
+          the header — `--scalar-custom-header-height` offsets its sticky
+          sidebar/mobile bar below the nav and shrinks its viewport math
+          to match (one coherent scroll). `isolate` opens a stacking
+          context so no Scalar z-index can paint over the nav. */}
+      <main className="isolate flex-1 [--scalar-custom-header-height:56px]">
         <ScalarApiReference />
       </main>
       {/* Minimal footer strip — verbatim legal line only (parity canon). */}

--- a/web/src/components/docs/ScalarApiReference.tsx
+++ b/web/src/components/docs/ScalarApiReference.tsx
@@ -2,48 +2,45 @@
 
 // Scalar API reference embed (X-2) — renders the interactive reference
 // from the repo's canonical spec served at /docs/api/openapi.yaml. The
-// embed follows the product theme: dark/light comes from ThemeProvider
-// (system-resolved), Scalar's own toggle is hidden, and the remote
-// default fonts are disabled (self-host ethos: no external runtime
-// dependencies) so the reference renders in the app's font stack.
+// embed follows the product theme contract (2026-07-20): Scalar's dark
+// mode is FORCED to the resolved theme from ThemeProvider (system tracks
+// the OS live) via `forceDarkModeState` — `darkMode` alone is only an
+// initial hint and loses to Scalar's internal state. Scalar's own theme
+// toggle is hidden (ours is the master) and the remote default fonts are
+// disabled (self-host ethos: no external runtime dependencies).
 import { useSyncExternalStore } from "react";
 import { ApiReferenceReact } from "@scalar/api-reference-react";
 import "@scalar/api-reference-react/style.css";
 import { useTheme } from "@/design/ThemeProvider";
 
-const DARK_QUERY = "(prefers-color-scheme: dark)";
-
-function subscribeToSystemTheme(listener: () => void): () => void {
-  const query = window.matchMedia(DARK_QUERY);
-  query.addEventListener("change", listener);
-  return () => query.removeEventListener("change", listener);
-}
-
-function readSystemPrefersDark(): boolean {
-  return window.matchMedia(DARK_QUERY).matches;
-}
-
-// Server snapshot: light — Scalar only mounts client-side and the config
-// updates on hydration, so this is just the pre-mount default.
-function getServerSnapshot(): boolean {
-  return false;
+// Hydration probe: false for the server/hydration render, true after.
+const emptySubscribe = () => () => {};
+function useHydrated(): boolean {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
 }
 
 export function ScalarApiReference() {
-  const { preference } = useTheme();
-  const systemPrefersDark = useSyncExternalStore(
-    subscribeToSystemTheme,
-    readSystemPrefersDark,
-    getServerSnapshot,
-  );
-  const isDark =
-    preference === "system" ? systemPrefersDark : preference === "dark";
+  const { resolvedTheme } = useTheme();
+
+  // Scalar reads `forceDarkModeState` ONCE at creation (a frozen override —
+  // `updateConfiguration` never re-applies it), so: (1) skip the hydration
+  // frame, where the provider still reports the server snapshot, so the
+  // first create sees the real resolved theme; (2) remount on resolved-theme
+  // changes (`key`) so every theme flip re-creates the app with the right
+  // forced state — configuration only, no reaching into Scalar internals.
+  const hydrated = useHydrated();
+  if (!hydrated) return null;
 
   return (
     <ApiReferenceReact
+      key={resolvedTheme}
       configuration={{
         url: "/docs/api/openapi.yaml",
-        darkMode: isDark,
+        forceDarkModeState: resolvedTheme,
         hideDarkModeToggle: true,
         withDefaultFonts: false,
       }}

--- a/web/src/components/ui/ThemeToggle.test.tsx
+++ b/web/src/components/ui/ThemeToggle.test.tsx
@@ -1,5 +1,6 @@
-// ThemeToggle: flips the ThemeProvider preference light↔dark and persists
-// under `expendit.theme` (theme parity canon, 2026-07-19).
+// ThemeToggle: cycles the ThemeProvider preference light → dark → system
+// (theme contract 2026-07-20); persists under `expendit.theme` with
+// KEY ABSENT = system; the aria-label announces the active mode.
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
@@ -20,25 +21,32 @@ const setup = () =>
   );
 
 describe("ThemeToggle", () => {
-  it("defaults to offering dark, applies + persists it", async () => {
+  it("announces the active mode and cycles system → light", async () => {
     setup();
     const toggle = screen.getByRole("button", {
-      name: "Switch to dark theme",
+      name: "Theme: system — switch to light",
     });
     await userEvent.click(toggle);
-    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
-  });
-
-  it("flips back to light from dark", async () => {
-    setup();
-    await userEvent.click(
-      screen.getByRole("button", { name: "Switch to dark theme" }),
-    );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Switch to light theme" }),
-    );
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+  });
+
+  it("cycles light → dark → system (key removed, resolved applied)", async () => {
+    setup();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Theme: system — switch to light" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Theme: light — switch to dark" }),
+    );
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Theme: dark — switch to system" }),
+    );
+    // Key absent = system; data-theme carries the resolved OS theme
+    // (light — no matchMedia dark in jsdom).
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
   });
 });

--- a/web/src/components/ui/ThemeToggle.tsx
+++ b/web/src/components/ui/ThemeToggle.tsx
@@ -2,15 +2,35 @@
 
 /**
  * ThemeToggle — the ecosystem theme control (marketing nav + dashboard
- * chrome; theme parity canon, org SKILL.md 2026-07-19). Mirrors the
- * apparule contract: one icon button, Sun on dark / Moon otherwise,
- * flips the ThemeProvider preference between light and dark.
+ * chrome; theme contract ratified 2026-07-20, identical across apparule,
+ * expendit and upstat): one icon button cycling light → dark → system
+ * with a distinct icon per mode (sun / moon / monitor) and an aria-label
+ * announcing the ACTIVE mode plus the mode a press switches to.
  */
 
 import React from "react";
-import { Moon, Sun } from "lucide-react";
-import { useTheme } from "@/design/ThemeProvider";
+import { Monitor, Moon, Sun } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useTheme, type ThemePreference } from "@/design/ThemeProvider";
 import { cn } from "@/lib/cn";
+
+/** light → dark → system → light. */
+export const THEME_CYCLE: Record<ThemePreference, ThemePreference> = {
+  light: "dark",
+  dark: "system",
+  system: "light",
+};
+
+export const THEME_ICONS: Record<ThemePreference, LucideIcon> = {
+  light: Sun,
+  dark: Moon,
+  system: Monitor,
+};
+
+/** Accessible name: announces the active mode and the next one. */
+export function themeToggleLabel(preference: ThemePreference): string {
+  return `Theme: ${preference} — switch to ${THEME_CYCLE[preference]}`;
+}
 
 export interface ThemeToggleProps {
   className?: string;
@@ -18,13 +38,13 @@ export interface ThemeToggleProps {
 
 export const ThemeToggle: React.FC<ThemeToggleProps> = ({ className }) => {
   const { preference, setPreference } = useTheme();
-  const nextTheme = preference === "dark" ? "light" : "dark";
+  const Icon = THEME_ICONS[preference];
   return (
     <button
       type="button"
       data-testid="theme-toggle"
-      aria-label={`Switch to ${nextTheme} theme`}
-      onClick={() => setPreference(nextTheme)}
+      aria-label={themeToggleLabel(preference)}
+      onClick={() => setPreference(THEME_CYCLE[preference])}
       className={cn(
         "rounded p-1.5 text-text-2 transition-colors duration-fast ease-standard",
         "hover:bg-bg-elev hover:text-text",
@@ -32,11 +52,7 @@ export const ThemeToggle: React.FC<ThemeToggleProps> = ({ className }) => {
         className,
       )}
     >
-      {preference === "dark" ? (
-        <Sun aria-hidden className="h-4 w-4" />
-      ) : (
-        <Moon aria-hidden className="h-4 w-4" />
-      )}
+      <Icon aria-hidden className="h-4 w-4" />
     </button>
   );
 };

--- a/web/src/controllers/use-theme.test.ts
+++ b/web/src/controllers/use-theme.test.ts
@@ -23,11 +23,13 @@ describe("useThemeController (B9 theme control)", () => {
     await waitFor(() => expect(result.current.theme).toBe("dark"));
   });
 
-  it("system removes the attribute (OS preference applies)", () => {
+  it("system removes the stored key; data-theme carries the resolved OS theme", () => {
     const { result } = renderHook(() => useThemeController(), { wrapper });
     act(() => result.current.setTheme("dark"));
     act(() => result.current.setTheme("system"));
-    expect(document.documentElement.dataset.theme).toBeUndefined();
+    // Contract 2026-07-20: data-theme always carries the RESOLVED theme
+    // (light here — no matchMedia dark in jsdom); key absent = system.
+    expect(document.documentElement.dataset.theme).toBe("light");
     expect(localStorage.getItem("expendit.theme")).toBeNull();
   });
 
@@ -37,10 +39,10 @@ describe("useThemeController (B9 theme control)", () => {
     await waitFor(() => expect(result.current.theme).toBe("light"));
   });
 
-  it("applyTheme is a pure DOM seam", () => {
+  it("applyTheme is a pure DOM seam (applies the resolved theme)", () => {
     applyTheme("dark");
     expect(document.documentElement.dataset.theme).toBe("dark");
     applyTheme("system");
-    expect(document.documentElement.dataset.theme).toBeUndefined();
+    expect(document.documentElement.dataset.theme).toBe("light");
   });
 });

--- a/web/src/controllers/use-theme.ts
+++ b/web/src/controllers/use-theme.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+  resolveTheme,
   useTheme,
   type ThemePreference,
   THEME_STORAGE_KEY,
@@ -19,11 +20,11 @@ export type ThemeSetting = ThemePreference;
 
 export { THEME_STORAGE_KEY };
 
-/** Pure DOM seam kept for compatibility (mirrors the provider's apply). */
+/** Pure DOM seam kept for compatibility (mirrors the provider's apply):
+ * data-theme always carries the RESOLVED theme (contract 2026-07-20). */
 export const applyTheme = (theme: ThemeSetting): void => {
   if (typeof document === "undefined") return;
-  if (theme === "system") delete document.documentElement.dataset.theme;
-  else document.documentElement.dataset.theme = theme;
+  document.documentElement.dataset.theme = resolveTheme(theme);
 };
 
 export const useThemeController = () => {

--- a/web/src/design/ThemeProvider.test.tsx
+++ b/web/src/design/ThemeProvider.test.tsx
@@ -1,16 +1,18 @@
-// Theme provider: manual override sets data-theme + persists; "system"
-// clears the attribute (tokens.css then follows prefers-color-scheme).
-// Ported with the apparule contract (theme parity canon, 2026-07-19).
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+// Theme provider — tri-state contract (ratified 2026-07-20): preference
+// light | dark | system persisted at expendit.theme (key absent = system);
+// data-theme always carries the RESOLVED theme; system tracks
+// prefers-color-scheme live via a matchMedia listener.
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { THEME_STORAGE_KEY, ThemeProvider, useTheme } from "./ThemeProvider";
 
 function Probe() {
-  const { preference, setPreference } = useTheme();
+  const { preference, resolvedTheme, setPreference } = useTheme();
   return (
     <div>
       <span data-testid="pref">{preference}</span>
+      <span data-testid="resolved">{resolvedTheme}</span>
       <button onClick={() => setPreference("dark")}>dark</button>
       <button onClick={() => setPreference("light")}>light</button>
       <button onClick={() => setPreference("system")}>system</button>
@@ -18,9 +20,39 @@ function Probe() {
   );
 }
 
+// Controllable matchMedia stand-in: the provider attaches ONE module-level
+// change listener on first subscribe; `flipSystem` drives it like an OS
+// theme change. Installed before the first render in this file so the
+// provider binds to it.
+let systemMatches = false;
+const changeListeners = new Set<() => void>();
+function flipSystem(matches: boolean) {
+  systemMatches = matches;
+  act(() => {
+    for (const l of changeListeners) l();
+  });
+}
+
+beforeAll(() => {
+  window.matchMedia = ((query: string) => ({
+    get matches() {
+      return systemMatches;
+    },
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: (_: string, cb: () => void) => changeListeners.add(cb),
+    removeEventListener: (_: string, cb: () => void) =>
+      changeListeners.delete(cb),
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+});
+
 beforeEach(() => {
   window.localStorage.clear();
   document.documentElement.removeAttribute("data-theme");
+  systemMatches = false;
 });
 
 describe("ThemeProvider", () => {
@@ -28,19 +60,23 @@ describe("ThemeProvider", () => {
     const { themeInitScript } = await import("./ThemeProvider");
     expect(themeInitScript).toContain(`"${THEME_STORAGE_KEY}"`);
     expect(THEME_STORAGE_KEY).toBe("expendit.theme");
+    // System mode must resolve pre-paint (no FOUC): the script consults
+    // prefers-color-scheme and always sets the resolved data-theme.
+    expect(themeInitScript).toContain("prefers-color-scheme");
+    expect(themeInitScript).toContain("setAttribute");
   });
 
-  it("defaults to system (no data-theme attribute)", () => {
+  it("defaults to system and reports the resolved OS theme", () => {
     render(
       <ThemeProvider>
         <Probe />
       </ThemeProvider>,
     );
     expect(screen.getByTestId("pref")).toHaveTextContent("system");
-    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
   });
 
-  it("manual dark override sets the attribute and persists", async () => {
+  it("manual dark override applies the resolved attribute and persists", async () => {
     render(
       <ThemeProvider>
         <Probe />
@@ -49,9 +85,10 @@ describe("ThemeProvider", () => {
     await userEvent.click(screen.getByRole("button", { name: "dark" }));
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
   });
 
-  it("returning to system clears override + storage", async () => {
+  it("returning to system removes the stored key (absent = system) and re-resolves", async () => {
     render(
       <ThemeProvider>
         <Probe />
@@ -60,8 +97,39 @@ describe("ThemeProvider", () => {
     await userEvent.click(screen.getByRole("button", { name: "light" }));
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
     await userEvent.click(screen.getByRole("button", { name: "system" }));
-    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+    // Key absent = system — the cross-product storage convention; the
+    // attribute stays populated with the RESOLVED theme.
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(screen.getByTestId("pref")).toHaveTextContent("system");
+  });
+
+  it("system mode tracks prefers-color-scheme changes live", async () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "system" }));
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
+    flipSystem(true); // OS switches to dark
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    flipSystem(false); // and back
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("explicit preferences ignore OS theme changes", async () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "dark" }));
+    flipSystem(false);
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
   });
 
   it("keeps working when storage is blocked (in-memory fallback, Codex round 3)", async () => {
@@ -131,6 +199,7 @@ describe("ThemeProvider", () => {
     await userEvent.click(screen.getByRole("button", { name: "dark" }));
     await userEvent.click(screen.getByRole("button", { name: "system" }));
     expect(screen.getByTestId("pref")).toHaveTextContent("system");
-    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+    // data-theme stays populated with the RESOLVED theme (light OS here).
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
   });
 });

--- a/web/src/design/ThemeProvider.tsx
+++ b/web/src/design/ThemeProvider.tsx
@@ -1,17 +1,24 @@
 "use client";
 
 /**
- * Theme provider — manual light/dark override with system default
- * (web-implementation.md §3: light on :root, dark on [data-theme="dark"],
- * prefers-color-scheme honored with manual override). Ported from the
- * apparule contract per the marketing nav/footer & theme parity canon
- * (org SKILL.md, 2026-07-19) — data-theme on <html>, localStorage key
- * `expendit.theme`, "system" default when unset.
+ * Theme provider — tri-state light | dark | system (web-implementation.md
+ * §3; theme contract ratified 2026-07-20, identical across apparule,
+ * expendit and upstat):
+ *
+ * - `preference` is what the user chose; persisted at `expendit.theme`
+ *   ("light"/"dark" stored explicitly; KEY ABSENT = system — the
+ *   cross-product storage convention).
+ * - `data-theme` on <html> always carries the RESOLVED theme ("light" or
+ *   "dark"): explicit preferences resolve to themselves; system resolves
+ *   via `prefers-color-scheme` and tracks it LIVE (matchMedia listener —
+ *   an OS theme flip updates data-theme without a reload).
+ * - tokens.css keeps its media-query fallback for the pre-JS/no-JS case;
+ *   with JS the attribute is authoritative.
  *
  * The preference lives in an external module store (localStorage-backed,
  * read via useSyncExternalStore) so no state syncs through effects; a tiny
- * inline script in the root layout applies the persisted override before
- * first paint to avoid a theme flash.
+ * inline script in the root layout applies the resolved theme before first
+ * paint (no FOUC in any mode, including system).
  */
 
 import {
@@ -24,14 +31,39 @@ import {
 } from "react";
 
 export type ThemePreference = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
 
 export const THEME_STORAGE_KEY = "expendit.theme";
+const DARK_QUERY = "(prefers-color-scheme: dark)";
 
 // -- external preference store ----------------------------------------------
 
 const listeners = new Set<() => void>();
 
+// System tracking: one module-level matchMedia listener, attached lazily on
+// first subscription (client only), kept for the app lifetime.
+let systemListenerAttached = false;
+
+function onSystemChange(): void {
+  // Only the system preference re-resolves on an OS flip.
+  if (readStoredPreference() === "system") {
+    applyResolved(resolveTheme("system"));
+    emit();
+  }
+}
+
+function ensureSystemListener(): void {
+  if (systemListenerAttached || typeof window === "undefined") return;
+  try {
+    window.matchMedia(DARK_QUERY).addEventListener("change", onSystemChange);
+    systemListenerAttached = true;
+  } catch {
+    // matchMedia unavailable — system just won't track live
+  }
+}
+
 function subscribe(listener: () => void): () => void {
+  ensureSystemListener();
   listeners.add(listener);
   return () => {
     listeners.delete(listener);
@@ -64,17 +96,34 @@ function readStoredPreference(): ThemePreference {
   }
 }
 
-function getServerSnapshot(): ThemePreference {
+function systemPrefersDark(): boolean {
+  try {
+    return window.matchMedia(DARK_QUERY).matches;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve a preference to the concrete theme ("system" → the OS theme). */
+export function resolveTheme(preference: ThemePreference): ResolvedTheme {
+  if (preference === "light" || preference === "dark") return preference;
+  return systemPrefersDark() ? "dark" : "light";
+}
+
+function readResolvedTheme(): ResolvedTheme {
+  return resolveTheme(readStoredPreference());
+}
+
+function getServerPreference(): ThemePreference {
   return "system";
 }
 
-function applyPreference(preference: ThemePreference): void {
-  const root = document.documentElement;
-  if (preference === "system") {
-    root.removeAttribute("data-theme");
-  } else {
-    root.setAttribute("data-theme", preference);
-  }
+function getServerResolved(): ResolvedTheme {
+  return "light";
+}
+
+function applyResolved(theme: ResolvedTheme): void {
+  document.documentElement.setAttribute("data-theme", theme);
 }
 
 // -- context ------------------------------------------------------------------
@@ -82,7 +131,9 @@ function applyPreference(preference: ThemePreference): void {
 interface ThemeContextValue {
   /** The user's stored preference (may be "system"). */
   preference: ThemePreference;
-  /** Set + persist the preference; "system" clears the override. */
+  /** The concrete theme currently applied ("system" resolved live). */
+  resolvedTheme: ResolvedTheme;
+  /** Set + persist the preference; "system" removes the stored key. */
   setPreference: (preference: ThemePreference) => void;
 }
 
@@ -92,12 +143,17 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const preference = useSyncExternalStore(
     subscribe,
     readStoredPreference,
-    getServerSnapshot,
+    getServerPreference,
+  );
+  const resolvedTheme = useSyncExternalStore(
+    subscribe,
+    readResolvedTheme,
+    getServerResolved,
   );
 
   const setPreference = useCallback((next: ThemePreference) => {
     memoryPreference = next;
-    applyPreference(next);
+    applyResolved(resolveTheme(next));
     try {
       if (next === "system") {
         window.localStorage.removeItem(THEME_STORAGE_KEY);
@@ -113,8 +169,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const value = useMemo(
-    () => ({ preference, setPreference }),
-    [preference, setPreference],
+    () => ({ preference, resolvedTheme, setPreference }),
+    [preference, resolvedTheme, setPreference],
   );
 
   return (
@@ -132,6 +188,8 @@ export function useTheme(): ThemeContextValue {
  * Pre-paint theme bootstrap (inlined by the root layout). A fully static
  * string — no runtime code construction (CodeQL js/bad-code-sanitization);
  * the literal storage key must match THEME_STORAGE_KEY (unit-tested).
+ * Applies the RESOLVED theme: stored light/dark verbatim, otherwise the
+ * OS preference — so system mode paints correctly on first frame (no FOUC).
  */
 export const themeInitScript =
-  '(function(){try{var t=localStorage.getItem("expendit.theme");if(t==="light"||t==="dark"){document.documentElement.setAttribute("data-theme",t);}}catch(e){}})();';
+  '(function(){try{var t=localStorage.getItem("expendit.theme");if(t!=="light"&&t!=="dark"){t=window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";}document.documentElement.setAttribute("data-theme",t);}catch(e){}})();';


### PR DESCRIPTION
## Summary

User feedback on the shipped Scalar reference (X-2): the **/docs/api header was wonky** — after any scroll, Scalar's sticky sidebar pinned to `top: 0` and painted over the marketing nav (at 390 Scalar's mobile bar replaced the nav entirely) — and the embed **ignored the product theme**. Root-caused on apparule with before/after screenshots (1440 + 390, light + dark); the same construction verified here.

## Header fix

Scalar sizes its layout to `100dvh` and pins sticky elements at `top: 0` unless told about a custom header. The `DocsApiView` embed wrapper now sets:
- `--scalar-custom-header-height: 56px` (the sticky dark-on-light nav's measured height) — Scalar's sidebar/mobile bar offset below the nav and its viewport math shrinks to match: **one coherent page scroll**, no double scrollbar, the nav keeps its normal sticky marketing behavior.
- `isolate` on the wrapper — a stacking context so no Scalar z-index (it ships up to 99999) can paint over the nav.

## Tri-state theme (ratified 2026-07-20, identical contract across apparule/expendit/upstat)

- **ThemeProvider**: `preference` = `light | dark | system`, persisted at `expendit.theme` — **key absent = system** (the cross-product storage convention). `data-theme` on `<html>` always carries the **resolved** theme; system tracks `prefers-color-scheme` **live** (matchMedia listener). Pre-paint init script resolves system mode (no FOUC). The storage-blocked in-memory fallback (Codex rounds 3–4, PR #209) is preserved and re-tested.
- **ThemeToggle**: cycles light → dark → system with sun / moon / monitor (lucide); aria-label announces the active mode. The B9 Appearance **segmented control** stays three-way over the same store (`useThemeController` delegates to the provider; `applyTheme` compat seam now applies the resolved theme).
  - Note for design reconciliation: design.md's #223 row describes the nav toggle as a *three-cell segmented control* while also giving a *cycle order* — the shipped nav control is the ratified cycling icon button (uniform across the three products); the three-cell segmented presentation lives in Settings. Happy to converge whichever way is adjudicated.
- **Scalar embed sync**: forced to `resolvedTheme` via `forceDarkModeState` + `hideDarkModeToggle`. Scalar reads that override **once at creation** (`updateConfiguration` never re-applies it; plain `darkMode` is silently ignored after mount) — so the view mounts post-hydration and **remounts on resolved-theme change** (`key`), configuration-only.

## Tests

- Unit: provider tri-state contract (storage convention, live system tracking via a controllable matchMedia, explicit-preference isolation, storage-blocked fallbacks), ThemeToggle cycle + labels, `useThemeController`/`applyTheme` seam.
- e2e: /docs/api header sanity (page scrolls, **no full-height inner scroller**, nav fully visible after scroll), embed follows the resolved theme incl. an **emulated `prefers-color-scheme` flip in system mode** (asserted on Scalar's `light-mode`/`dark-mode` body class), parity theme journeys move to the tri-state cycle incl. the Settings radiogroup, persistence across reload.

## Gates (re-run after rebasing onto #223)

- `npm run lint` (prettier + eslint + check:boundaries) ✅
- `npm run typecheck` ✅
- `npm test` — 84 files, 376 passed ✅
- `NEXT_PUBLIC_TEST_MODE=1 npm run build` ✅
- `CI=1 npx playwright test` — 48 passed (full suite pre-rebase; docs-api + parity re-run post-rebase: 11 passed) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)