### PR TITLE
fix(web): chart data domains — ledger-onset series + discrete FY trend markers

### DIFF
--- a/docs/pages.md
+++ b/docs/pages.md
@@ -58,8 +58,10 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
 ### B1 `/dashboard` — Overview
 - StatCard row: net cash flow, income, expenses, runway (company orgs;
   formula + n/a rules in line-items.md §5) (MI-7).
-- Cash-flow chart (12mo), category donut, anomaly feed (MI-5), latest
-  transactions table (5 rows → Transactions).
+- Cash-flow chart (trailing 12mo, starting at ledger onset — months before
+  the org's first transaction are never drawn; the card title states the
+  actual span), category donut, anomaly feed (MI-5), latest transactions
+  table (5 rows → Transactions).
 - Empty state: MI-16 with demo-data toggle; empty + loading frames ship per
   the screen-state rule (design.md §8.1) **[Directive 2026-07-18]**.
 
@@ -145,7 +147,10 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
     guidance"; industry-specific benchmarks are a later data product.
 - Trend view: ratio **and key line-item** time-series (revenue,
   gross_profit, net_income + period-over-period growth, line-items.md §5)
-  across periods; export to report artifact.
+  across periods; export to report artifact. As built: the periods are
+  discrete annual observations — point markers at each confirmed FY with
+  FY ticks at the data positions, so a two-year history reads as two
+  observations, not a continuous trend (scales unchanged as FYs accrue).
 - Requires ≥1 mapped statement period; empty state explains inputs needed
   and which org kind captures statements (data-model.md §5 "Who uses which
   org kind"); empty + loading frames per the screen-state rule

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -398,7 +398,7 @@ with full CRUD; contract types shared with `src/models/`.
 | Group | Mocked endpoints (under `/api/mock/v1`) |
 | --- | --- |
 | Ledger | `/expense` · `/income` · `/category` CRUD + search (v1-consolidated: JWT-scoped, enveloped, cursor-paginated) |
-| Dashboard aggregates | monthly income-vs-expense + category totals (the api.md §1 report endpoints, v1-consolidated) — B1 charts and StatCards; the anomaly feed reads anomaly-flagged transactions (flows/import.md §7 registry), no separate endpoint |
+| Dashboard aggregates | monthly income-vs-expense + category totals (the api.md §1 report endpoints, v1-consolidated) — B1 charts and StatCards; the monthly series is the trailing-12-month window trimmed to ledger onset (months before the org's first transaction are never emitted — no fabricated zero points; zero months after onset are true zeros); the anomaly feed reads anomaly-flagged transactions (flows/import.md §7 registry), no separate endpoint |
 | Import | `POST /import/upload` (`202 {job_id}`, scripted processing → completed) · `GET /import/{job_id}` (polling) · `PUT /import/transaction/{id}/category` · `POST /import/{job_id}/confirm` · `DELETE /import/{job_id}` — every flows/import.md §3 failure-taxonomy code reproducible via designated fixture files |
 | Reports & artifacts | `POST /reports` (`201 {artifact_id, signed_url, expires_at}` — mock-served file URL) · `GET /reports` (TTL'd history) |
 | Data rights | `POST /account/export` (`202 {job_id}` → poll → signed_url) · `POST /account/purge` · `DELETE /account/purge` (grace; `409 purge_pending` on writes while open) |

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -49,8 +49,21 @@ test("core journey — overview, ledger CRUD, import, statements, ratios, tax wi
     page.getByRole("heading", { name: "Overview", level: 1 }),
   ).toBeVisible();
   await expect(page.getByText("Net cash flow").first()).toBeVisible();
+  // Personal cash-flow series: a full trailing year of real monthly
+  // points — never a fabricated flat segment over pre-ledger months.
+  await expect(page.getByText("Cash flow — 12 months")).toBeVisible();
+  const personalPoints = await page
+    .getByTestId("chart-line-net")
+    .getAttribute("points");
+  expect(personalPoints?.trim().split(/\s+/).length).toBeGreaterThanOrEqual(12);
   await switchToCompanyOrg(page);
   await expect(page.getByText("Net cash flow").first()).toBeVisible();
+  // Company ledger onset is Jan 2026 — the chart starts there and says so.
+  await expect(page.getByText("Cash flow — since Jan 2026")).toBeVisible();
+  const companyPoints = await page
+    .getByTestId("chart-line-net")
+    .getAttribute("points");
+  expect(companyPoints?.trim().split(/\s+/).length).toBe(7);
 
   // --- B2 transactions CRUD (manual path, MI-11 inspector) --------------
   await openNav(page, "Transactions").click();
@@ -188,6 +201,18 @@ test("core journey — overview, ledger CRUD, import, statements, ratios, tax wi
   await expect(trace).toBeVisible();
   await expect(trace).toContainText(/current_assets/);
   await page.keyboard.press("Escape");
+
+  // Trends: discrete FY observations — point markers at each confirmed
+  // fiscal year, FY ticks at the data positions (not a fake full-width
+  // continuous trend from two datapoints).
+  const trends = page.getByRole("region", { name: "Trends" });
+  await expect(trends.getByText("FY2024")).toBeVisible();
+  await expect(trends.getByText("FY2025")).toBeVisible();
+  for (const seriesId of ["revenue", "gross", "net"]) {
+    await expect(
+      trends.getByTestId(`chart-markers-${seriesId}`).locator("circle"),
+    ).toHaveCount(2);
+  }
 
   // --- B7 tax center → B7b filing wizard → filing history ----------------
   await openNav(page, "Tax center").click();

--- a/web/src/app/api/mock/report/monthly/route.ts
+++ b/web/src/app/api/mock/report/monthly/route.ts
@@ -2,6 +2,10 @@
  * Mock: monthly income-vs-expense report (api.md §1 `GET /report/monthly/…`,
  * v1-consolidated: JWT/org-scoped, no :userID) + the runway snapshot
  * (line-items.md §5 ledger-burn rule) — the B1 overview aggregates.
+ *
+ * Series contract: a trailing 12-calendar-month window ending at
+ * mock-today, trimmed to the org's ledger onset — months before the first
+ * transaction are never emitted (no fabricated zero points on the chart).
  */
 
 import type { MonthlyFlowPoint, RunwaySnapshot } from "@/models";
@@ -87,17 +91,28 @@ export async function GET(request: Request) {
   const byMonth = new Map<string, MonthlyFlowPoint>(
     window.map((month) => [month, { month, income: 0, expense: 0 }]),
   );
+  let onsetMonth: string | null = null;
   for (const txn of db.transactions) {
     if (txn.org_id !== orgId || txn.excluded_from_reports) continue;
-    const point = byMonth.get(txn.txn_date.slice(0, 7));
+    const month = txn.txn_date.slice(0, 7);
+    if (onsetMonth === null || month < onsetMonth) onsetMonth = month;
+    const point = byMonth.get(month);
     if (!point) continue;
     if (txn.direction === "income") point.income += txn.amount;
     else point.expense += txn.amount;
   }
 
+  // Months before the ledger's first entry carry no data — emitting them
+  // as zeros drew a fabricated flat segment on the B1 chart. The series
+  // starts at ledger onset; zero months *after* onset are true zeros
+  // (an active ledger with no movement) and stay in the window.
+  const items = window
+    .filter((month) => onsetMonth !== null && month >= onsetMonth)
+    .map((month) => byMonth.get(month)!);
+
   return ok({
     currency: org?.currency ?? "NGN",
-    items: window.map((month) => byMonth.get(month)!),
+    items,
     runway: runwaySnapshot(orgId, byMonth),
   });
 }

--- a/web/src/app/dashboard/OverviewView.tsx
+++ b/web/src/app/dashboard/OverviewView.tsx
@@ -347,7 +347,13 @@ export const OverviewView: React.FC = () => {
       {/* Figma 179:12: chart left (2/3), donut + anomalies right (1/3). */}
       <div className="mt-4 grid grid-cols-1 items-start gap-4 lg:grid-cols-[2fr,1fr]">
         <Card
-          title="Cash flow — 12 months"
+          // The monthly series starts at ledger onset (no fabricated
+          // pre-onset months) — the title states the span it actually has.
+          title={
+            points.length >= 12 || points.length === 0
+              ? "Cash flow — 12 months"
+              : `Cash flow — since ${formatIso(`${points[0].month}-01`, "MMM yyyy")}`
+          }
           action={
             // Chart data-table toggle (design.md §5 — screen assembly).
             <button
@@ -419,6 +425,9 @@ export const OverviewView: React.FC = () => {
               xLabels={points
                 .filter((_, index) => index % 2 === 0)
                 .map((p) => monthLabel(p.month))}
+              xLabelIndices={points
+                .map((_, index) => index)
+                .filter((index) => index % 2 === 0)}
             />
           )}
         </Card>

--- a/web/src/app/dashboard/company/ratios/RatiosView.tsx
+++ b/web/src/app/dashboard/company/ratios/RatiosView.tsx
@@ -301,7 +301,11 @@ export const RatiosView: React.FC = () => {
             </h2>
             {trend && trend.labels.length >= 2 ? (
               <div className="rounded border border-border bg-bg p-4">
+                {/* Annual observations, not a continuous series — point
+                    markers + FY ticks at the data positions so N=2 reads
+                    as two observations (scales to more FYs). */}
                 <ChartLine
+                  pointMarkers
                   series={[
                     {
                       id: "revenue",

--- a/web/src/components/ui/ChartLine.test.tsx
+++ b/web/src/components/ui/ChartLine.test.tsx
@@ -42,6 +42,45 @@ describe("Chart/Line (design.md §8.2b, MI-12)", () => {
     );
   });
 
+  it("pointMarkers renders one circle per datum (B6b discrete FY reading)", () => {
+    const { container } = render(
+      <ChartLine
+        pointMarkers
+        series={series}
+        xLabels={["FY2024", "FY2025", "FY2026", "FY2027"]}
+      />,
+    );
+    const income = screen.getByTestId("chart-markers-income");
+    expect(income.querySelectorAll("circle")).toHaveLength(4);
+    expect(income.querySelector("circle")).toHaveClass("fill-income");
+    expect(
+      screen.getByTestId("chart-markers-expense").querySelectorAll("circle"),
+    ).toHaveLength(4);
+    // The plot insets so edge markers are not clipped by the viewBox.
+    const first = income.querySelector("circle")!;
+    expect(Number(first.getAttribute("cx"))).toBeGreaterThan(0);
+    expect(container.querySelectorAll("polyline")).toHaveLength(2);
+  });
+
+  it("no markers by default (continuous series stay austere)", () => {
+    render(<ChartLine series={series} />);
+    expect(screen.queryByTestId("chart-markers-income")).toBeNull();
+  });
+
+  it("xLabelIndices pins thinned ticks to their data positions", () => {
+    render(
+      <ChartLine
+        series={[series[0]]}
+        xLabels={["Jan", "Mar"]}
+        xLabelIndices={[0, 2]}
+      />,
+    );
+    // 4 points across 480 wide → datum 2 sits at x = 320, not the even
+    // two-label spread (0 / 480).
+    expect(Number(screen.getByText("Mar").getAttribute("x"))).toBe(320);
+    expect(Number(screen.getByText("Jan").getAttribute("x"))).toBe(0);
+  });
+
   it("loading renders the axis-first skeleton", () => {
     render(<ChartLine state="loading" series={series} />);
     expect(screen.getByTestId("skeleton-chart")).toBeInTheDocument();

--- a/web/src/components/ui/ChartLine.tsx
+++ b/web/src/components/ui/ChartLine.tsx
@@ -5,7 +5,10 @@
  * empty. Bespoke SVG per the reuse policy (no chart libraries); series
  * colors bind to --income/--expense/--accent (web-implementation.md §3).
  * Content kinds (12mo cash-flow / ratio + line-item trend) arrive via
- * props; the data-table toggle attaches at screen assembly.
+ * props; the data-table toggle attaches at screen assembly. Discrete
+ * observation sets (the B6b per-FY trend) opt into `pointMarkers`: a
+ * circle per datum so sparse series (N=2 fiscal years) read as
+ * observations, not a continuous trend; ticks sit at data positions.
  */
 
 import React from "react";
@@ -27,6 +30,17 @@ export interface ChartLineProps {
   series?: ChartLineSeries[];
   /** X axis tick labels (e.g. months). */
   xLabels?: string[];
+  /**
+   * Data index each xLabel ticks (thinned axes, e.g. every 2nd month).
+   * Without it, labels matching the point count align to data positions;
+   * otherwise they spread evenly (legacy marketing/demo usage).
+   */
+  xLabelIndices?: number[];
+  /**
+   * Circle per datum — discrete observations (B6b FY trend) read as
+   * points, not a continuous line; the plot insets so edge markers show.
+   */
+  pointMarkers?: boolean;
   /** Empty-state surface kind (MI-16). */
   emptyKind?: EmptyStateKind;
   onEmptyAction?: () => void;
@@ -46,12 +60,21 @@ const COLOR_BG: Record<ChartSeriesColor, string> = {
   accent: "bg-accent",
 };
 
+const COLOR_FILL: Record<ChartSeriesColor, string> = {
+  income: "fill-income",
+  expense: "fill-expense",
+  accent: "fill-accent",
+};
+
 const WIDTH = 480;
+const MARKER_RADIUS = 2.5;
 
 export const ChartLine: React.FC<ChartLineProps> = ({
   state = "data",
   series = [],
   xLabels = [],
+  xLabelIndices,
+  pointMarkers = false,
   emptyKind = "transactions",
   onEmptyAction,
   height = 160,
@@ -76,19 +99,30 @@ export const ChartLine: React.FC<ChartLineProps> = ({
   const max = Math.max(...all);
   const span = max - min || 1;
   const plotHeight = height - 24;
+  const pointCount = Math.max(...series.map((entry) => entry.points.length));
 
-  const toPoints = (points: number[]): string => {
-    const step = WIDTH / Math.max(1, points.length - 1);
-    return points
+  // Inset the plot when markers draw so edge circles are not clipped.
+  const inset = pointMarkers ? MARKER_RADIUS + 1 : 0;
+  const xAt = (index: number, count: number): number =>
+    inset + (index * (WIDTH - inset * 2)) / Math.max(1, count - 1);
+  const yAt = (value: number): number =>
+    plotHeight - 4 - ((value - min) / span) * (plotHeight - 8);
+
+  const toPoints = (points: number[]): string =>
+    points
       .map(
         (value, index) =>
-          `${(index * step).toFixed(1)},${(
-            plotHeight -
-            4 -
-            ((value - min) / span) * (plotHeight - 8)
-          ).toFixed(1)}`,
+          `${xAt(index, points.length).toFixed(1)},${yAt(value).toFixed(1)}`,
       )
       .join(" ");
+
+  /** Tick x: at the labelled datum when known, else an even spread. */
+  const tickX = (index: number): number => {
+    const dataIndex =
+      xLabelIndices?.[index] ?? (xLabels.length === pointCount ? index : null);
+    return dataIndex !== null
+      ? xAt(dataIndex, pointCount)
+      : (index * WIDTH) / Math.max(1, xLabels.length - 1);
   };
 
   return (
@@ -132,10 +166,30 @@ export const ChartLine: React.FC<ChartLineProps> = ({
             )}
           />
         ))}
+        {pointMarkers
+          ? series.map((entry) => (
+              <g
+                key={`${entry.id}-markers`}
+                data-testid={`chart-markers-${entry.id}`}
+                aria-hidden
+              >
+                {entry.points.map((value, index) => (
+                  <circle
+                    // Positional key — datum order is the identity here.
+                    key={index}
+                    cx={xAt(index, entry.points.length)}
+                    cy={yAt(value)}
+                    r={MARKER_RADIUS}
+                    className={COLOR_FILL[entry.color]}
+                  />
+                ))}
+              </g>
+            ))
+          : null}
         {xLabels.map((tick, index) => (
           <text
             key={tick}
-            x={(index * WIDTH) / Math.max(1, xLabels.length - 1)}
+            x={tickX(index)}
             y={height - 6}
             textAnchor={
               index === 0

--- a/web/src/mock/routes-report.test.ts
+++ b/web/src/mock/routes-report.test.ts
@@ -18,21 +18,84 @@ describe("mock /report/monthly (B1 aggregates, api.md §1 v1-consolidated)", () 
     resetDb();
   });
 
-  it("returns 12 months oldest→newest ending at the mock-today month", async () => {
+  it("company series starts at ledger onset — no fabricated pre-onset months", async () => {
+    // The Cuesoft ledger begins Jan 2026; the trailing-12 window reaches
+    // back to Aug 2025. Pre-onset months must not be emitted as zeros —
+    // they drew a fabricated flat segment on the B1 chart.
     const report = await json<MonthlyFlowReport>(
       await monthlyReport(mockRequest("/api/mock/report/monthly")),
     );
-    expect(report.items).toHaveLength(12);
-    expect(report.items[11].month).toBe("2026-07");
-    expect(report.items[0].month).toBe("2025-08");
+    expect(report.items).toHaveLength(7);
+    expect(report.items[0].month).toBe("2026-01");
+    expect(report.items.at(-1)?.month).toBe("2026-07");
     expect(report.currency).toBe("NGN");
+  });
+
+  it("personal series covers the full trailing 12 months, every month with real data", async () => {
+    const report = await json<MonthlyFlowReport>(
+      await monthlyReport(
+        mockRequest("/api/mock/report/monthly", { orgId: ORG_PERSONAL }),
+      ),
+    );
+    expect(report.items).toHaveLength(12);
+    expect(report.items[0].month).toBe("2025-08");
+    expect(report.items.at(-1)?.month).toBe("2026-07");
+    // No zero-zero placeholder months anywhere in the series.
+    for (const point of report.items) {
+      expect(point.income + point.expense).toBeGreaterThan(0);
+    }
+  });
+
+  it("personal 2025 backfill months sum to the seed-comment totals", async () => {
+    const report = await json<MonthlyFlowReport>(
+      await monthlyReport(
+        mockRequest("/api/mock/report/monthly", { orgId: ORG_PERSONAL }),
+      ),
+    );
+    const byMonth = new Map(report.items.map((point) => [point.month, point]));
+    expect(byMonth.get("2025-08")).toMatchObject({
+      income: 420_000,
+      expense: 88_400,
+    });
+    expect(byMonth.get("2025-09")).toMatchObject({
+      income: 380_000,
+      expense: 80_300,
+    });
+    expect(byMonth.get("2025-10")).toMatchObject({
+      income: 510_000,
+      expense: 92_100,
+    });
+    expect(byMonth.get("2025-11")).toMatchObject({
+      income: 300_000,
+      expense: 83_400,
+    });
+    expect(byMonth.get("2025-12")).toMatchObject({
+      income: 650_000,
+      expense: 1_057_300,
+    });
+  });
+
+  it("personal stat-card delta stays coherent (Jul net −1,134,650 vs Jun +1,529,700 → −174.2%)", async () => {
+    const report = await json<MonthlyFlowReport>(
+      await monthlyReport(
+        mockRequest("/api/mock/report/monthly", { orgId: ORG_PERSONAL }),
+      ),
+    );
+    const jun = report.items.find((point) => point.month === "2026-06")!;
+    const jul = report.items.find((point) => point.month === "2026-07")!;
+    const junNet = jun.income - jun.expense;
+    const julNet = jul.income - jul.expense;
+    expect(junNet).toBe(1_529_700);
+    expect(julNet).toBe(-1_134_650);
+    expect(Math.round(((julNet - junNet) / junNet) * 1000) / 10).toBe(-174.2);
   });
 
   it("MTD sums match the seed narrative (income ₦8,435,200 / expenses ₦3,614,800)", async () => {
     const report = await json<MonthlyFlowReport>(
       await monthlyReport(mockRequest("/api/mock/report/monthly")),
     );
-    const current = report.items[11];
+    const current = report.items.at(-1)!;
+    expect(current.month).toBe("2026-07");
     expect(current.income).toBe(8_435_200);
     expect(current.expense).toBe(3_614_800);
   });

--- a/web/src/mock/seed.ts
+++ b/web/src/mock/seed.ts
@@ -1,7 +1,9 @@
 /**
  * Seed narrative — the docs-coherent dataset ("today" = 20 Jul 2026),
  * simulating seven months of actual usage (Jan–Jul 2026) for Cuesoft Ltd
- * (Lekki, Lagos — NG-LA) plus the owner's personal/freelancer org.
+ * (Lekki, Lagos — NG-LA) plus the owner's personal/freelancer org, whose
+ * ledger spans the full trailing 12 months (Aug 2025 – Jul 2026: imported
+ * statement history + live use — the B1 chart shows a complete year).
  *
  * The company story: a services + product studio that staffed up in April
  * ahead of its June GA launch — revenue grows every month while payroll
@@ -1370,12 +1372,225 @@ const cuesoftTxns: TxnSeed[] = [
 ];
 
 /**
- * Personal org — the freelancer dataset. 2026 YTD taxable gross is LOCKED
- * at ₦5,400,000 (PIT-2026 estimate ₦762,000: 0% to 800k · 15% to 3m ·
- * 18% band). Anomaly notes compute from these rows; all four AnomalyBadge
- * types appear here too (web-implementation.md §6).
+ * Personal org — the freelancer dataset, Aug 2025 – Jul 2026 (a full
+ * trailing-12-month B1 window). Aug–Oct 2025 rows arrived as imported
+ * statement history (source csv — the org itself was created 3 Nov 2025);
+ * Nov onward is live use. 2026 YTD taxable gross is LOCKED at ₦5,400,000
+ * (PIT-2026 estimate ₦762,000: 0% to 800k · 15% to 3m · 18% band) — the
+ * 2025 backfill never enters the 2026 PIT basis. Anomaly notes compute
+ * from these rows; all four AnomalyBadge types appear here too
+ * (web-implementation.md §6).
+ *
+ * Monthly totals (income / expenses):
+ * Aug-25 420,000 / 88,400 · Sep-25 380,000 / 80,300 ·
+ * Oct-25 510,000 / 92,100 · Nov-25 300,000 / 83,400 ·
+ * Dec-25 650,000 / 1,057,300 (H1-2026 rent prepaid 29 Dec) ·
+ * Jan 380,000 / 48,200 · Feb 1,500,000 / 71,200 · Mar 450,000 / 244,300 ·
+ * Apr 1,200,000 / 88,100 · May 170,000 / 98,900 · Jun 1,700,000 / 170,300 ·
+ * Jul MTD 0 / 1,134,650 (H2 rent lands in July — the −174.2% "vs Jun"
+ * net-cash-flow delta on B1 is real: −1,134,650 vs +1,529,700).
  */
 const personalTxns: TxnSeed[] = [
+  ...month("p", "2508", [
+    [
+      8,
+      "Brand identity — Yaba fintech studio",
+      420_000,
+      "income",
+      "cat-personal-clients",
+      "csv",
+      { ai: true },
+    ],
+    [
+      2,
+      "MTN data bundle",
+      15_000,
+      "expense",
+      "cat-personal-tools",
+      "csv",
+      { ai: true },
+    ],
+    [
+      15,
+      "POS — Shoprite Lekki",
+      51_400,
+      "expense",
+      "cat-personal-living",
+      "csv",
+      { ai: true },
+    ],
+    [
+      22,
+      "Fuel — Total Admiralty",
+      22_000,
+      "expense",
+      "cat-personal-transport",
+      "csv",
+      { ai: true },
+    ],
+  ]),
+  ...month("p", "2509", [
+    [
+      12,
+      "Webflow build — Surulere logistics co",
+      380_000,
+      "income",
+      "cat-personal-clients",
+      "csv",
+      { ai: true },
+    ],
+    [
+      16,
+      "POS — Shoprite Lekki",
+      47_800,
+      "expense",
+      "cat-personal-living",
+      "csv",
+      { ai: true },
+    ],
+    [
+      21,
+      "Medplus pharmacy",
+      14_200,
+      "expense",
+      "cat-personal-health",
+      "csv",
+      { ai: true },
+    ],
+    [
+      27,
+      "Bolt rides",
+      18_300,
+      "expense",
+      "cat-personal-transport",
+      "csv",
+      { ai: true },
+    ],
+  ]),
+  ...month("p", "2510", [
+    [
+      9,
+      "Design sprint — Ikeja healthtech",
+      510_000,
+      "income",
+      "cat-personal-clients",
+      "csv",
+      { ai: true },
+    ],
+    [
+      2,
+      "MTN data bundle",
+      15_000,
+      "expense",
+      "cat-personal-tools",
+      "csv",
+      { ai: true },
+    ],
+    [
+      17,
+      "POS — Shoprite Lekki",
+      55_600,
+      "expense",
+      "cat-personal-living",
+      "csv",
+      { ai: true },
+    ],
+    [
+      24,
+      "Fuel — Total Admiralty",
+      21_500,
+      "expense",
+      "cat-personal-transport",
+      "csv",
+      { ai: true },
+    ],
+  ]),
+  // Nov 2025 — the org's first live month (created 3 Nov 2025).
+  ...month("p", "2511", [
+    [
+      14,
+      "Logo + deck refresh — Ajah retail chain",
+      300_000,
+      "income",
+      "cat-personal-clients",
+      "manual",
+    ],
+    [
+      11,
+      "POS — Shoprite Lekki",
+      49_200,
+      "expense",
+      "cat-personal-living",
+      "csv",
+      { ai: true },
+    ],
+    [
+      19,
+      "Medplus pharmacy",
+      16_800,
+      "expense",
+      "cat-personal-health",
+      "receipt",
+      { ai: true },
+    ],
+    [
+      25,
+      "Bolt rides",
+      17_400,
+      "expense",
+      "cat-personal-transport",
+      "receipt",
+      { ai: true },
+    ],
+  ]),
+  ...month("p", "2512", [
+    [
+      18,
+      "Year-end campaign — PiggyVest referral",
+      650_000,
+      "income",
+      "cat-personal-clients",
+      "csv",
+      { ai: true },
+    ],
+    [
+      20,
+      "POS — Shoprite Lekki",
+      68_900,
+      "expense",
+      "cat-personal-living",
+      "csv",
+      { ai: true },
+    ],
+    [
+      22,
+      "Fuel — Total Admiralty",
+      26_000,
+      "expense",
+      "cat-personal-transport",
+      "receipt",
+      { ai: true },
+    ],
+    [
+      27,
+      "Medplus pharmacy",
+      12_400,
+      "expense",
+      "cat-personal-health",
+      "receipt",
+      { ai: true },
+    ],
+    // Semiannual rent cycle: H1-2026 prepaid end-December, H2 paid 5 Jul
+    // (the existing July row) — December dips negative, mirroring July.
+    [
+      29,
+      "Rent — Lekki apartment (H1)",
+      950_000,
+      "expense",
+      "cat-personal-living",
+      "manual",
+    ],
+  ]),
   ...month("p", "2601", [
     [
       20,


### PR DESCRIPTION
## Problem (user-reported, live screenshots)

1. **Overview "Cash flow — 12 months" (personal org):** the mock `/report/monthly` builder zero-filled every month of the trailing-12 window, so months before the ledger's first transaction (Aug–Dec 2025 on the personal org) rendered as a fabricated dead-flat segment before real movement began. The company org had the same class of defect (flat Aug–Dec 2025 before its Jan 2026 onset).
2. **Company Ratios "Trends":** exactly two annual datapoints (FY2024, FY2025) drew as three perfectly straight full-width lines — technically correct, reads as a fake continuous trend.

## Fix

**Chart correctness (both orgs)**
- `/api/mock/report/monthly`: the trailing-12-month window is trimmed to **ledger onset** — months before the org's first transaction are never emitted, so no fabricated points can draw. Zero months *after* onset remain true zeros (an active ledger with no movement). Runway math unchanged.
- B1 card title states the actual span: `Cash flow — 12 months` when full, `Cash flow — since Jan 2026` on the company org.
- Axis ticks now pin to their data positions (`xLabelIndices`), fixing the slight drift of the thinned every-2nd-month labels.

**Demo richness (personal org)**
- Seed backfill Aug–Dec 2025 with a coherent freelancer story: monthly client income (₦300k–650k), semiannual Lekki rent (H1-2026 prepaid 29 Dec — December dips negative, mirroring July), POS/MTN/fuel/pharmacy cadence consistent with 2026. Aug–Oct rows are `csv` (imported statement history — the org was created 3 Nov 2025); Nov onward mixes live sources. No new `bank` rows, so `imported_txn_count` stays true.
- **Locked invariants untouched and proven:** Jul MTD 8,435,200 / 3,614,800 · runway 7.2 · VAT 2026-06 net ₦550,600 · FY2025 identities · 214/209/5 · personal 2026 YTD gross ₦5,400,000 (PIT ₦762,000 — the engine filters `txn_date.startsWith("2026")`, so the 2025 backfill never enters the basis). Stat-card deltas stay coherent: **−174.2% vs Jun** is pinned by a new unit test (Jul net −1,134,650 vs Jun +1,529,700).

**Trends presentation (B6b)**
- `Chart/Line` gains `pointMarkers`: a token-bound circle per datum (plot insets so edge markers aren't clipped). The trends chart now reads as **discrete FY observations** — markers at FY2024/FY2025 with FY ticks at the data positions — and the construction scales unchanged as more fiscal years accrue. design.md §8.2b is silent on the trend construction ("content kinds via instance overrides"), so this is recorded as as-built in pages.md B6b.

## Tests & gates

- Unit 382/382 ✅ (new: onset trim, backfill month sums, delta coherence, marker/tick rendering; full invariant suite green)
- E2E 48/48 ✅ (new: personal chart ≥12 real monthly points, company chart 7 since-onset points + since-Jan title, FY markers ×3 trend series)
- lint (prettier + eslint + boundaries) ✅ · typecheck ✅ · build ✅
- Screenshots before/after at 1440, light + dark, verified.

## Docs

- `web-implementation.md` aggregates row: series contract (onset-trimmed window).
- `pages.md` B1 (chart span/title) + B6b (discrete-FY as-built note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)