### PR TITLE
fix(web): unset theme boots the design default — system is an explicit choice

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -263,9 +263,10 @@ and the embed-theme sync.
 **Theme contract as-built (2026-07-20, ratified — identical across
 apparule, expendit and upstat).** The preference is tri-state
 light | dark | system: `ThemeProvider` persists it at `expendit.theme`
-("light"/"dark" stored explicitly; KEY ABSENT = system — the
-cross-product storage convention), and `data-theme` on `<html>` always
-carries the RESOLVED theme — system resolves via `prefers-color-scheme`
+("light"/"dark"/"system" all stored explicitly; KEY ABSENT = dark,
+expendit's design default — the cross-product storage convention;
+"system" is never modeled as key-absent), and `data-theme` on `<html>`
+always carries the RESOLVED theme — system resolves via `prefers-color-scheme`
 and tracks it live (a matchMedia listener updates `data-theme` on an OS
 flip, no reload). The pre-paint init script applies the resolved theme
 (no FOUC in any mode). `ThemeToggle` (marketing nav + dashboard chrome)

--- a/web/e2e/docs-api.spec.ts
+++ b/web/e2e/docs-api.spec.ts
@@ -90,35 +90,36 @@ test.describe("API reference — /docs/api", () => {
   test("the embed follows the tri-state theme, incl. a live OS flip in system mode", async ({
     page,
   }) => {
-    await page.emulateMedia({ colorScheme: "light" });
+    await page.emulateMedia({ colorScheme: "dark" });
     await page.goto("/docs/api");
     await expect(
       page.getByRole("heading", { name: "Expendit API" }),
     ).toBeVisible({ timeout: 20_000 });
 
-    // Scalar mirrors the resolved theme on body (light-mode/dark-mode).
+    // Scalar mirrors the resolved theme on body (light-mode/dark-mode);
+    // key absent = dark, the design default (theme contract).
     const body = page.locator("body");
-    await expect(body).toHaveClass(/light-mode/);
+    await expect(body).toHaveClass(/dark-mode/);
 
-    // system mode (default) follows an OS scheme flip live.
-    await page.emulateMedia({ colorScheme: "dark" });
-    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
-    await expect(body).toHaveClass(/dark-mode/, { timeout: 15_000 });
-
-    // Explicit choice via the nav toggle wins over the OS (the embed
-    // resyncs to light after cycling system → light).
-    await page
-      .getByRole("button", { name: "Theme: system — switch to light" })
-      .click();
+    // Explicit SYSTEM mode follows an OS scheme flip live.
+    await page.getByTestId("theme-toggle").click(); // dark(default) → system
+    await page.emulateMedia({ colorScheme: "light" });
     await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
     await expect(body).toHaveClass(/light-mode/, { timeout: 15_000 });
+
+    // Explicit choice via the nav toggle wins over the OS (the embed
+    // resyncs after cycling system → light → dark).
+    await page.getByTestId("theme-toggle").click(); // system → light
+    await page.getByTestId("theme-toggle").click(); // light → dark
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(body).toHaveClass(/dark-mode/, { timeout: 15_000 });
     await expect(
       page.getByRole("heading", { name: "Expendit API" }),
     ).toBeVisible({ timeout: 20_000 });
 
     // The choice persists across reload (stored at expendit.theme).
     await page.reload();
-    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
-    await expect(body).toHaveClass(/light-mode/, { timeout: 20_000 });
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(body).toHaveClass(/dark-mode/, { timeout: 20_000 });
   });
 });

--- a/web/e2e/parity.spec.ts
+++ b/web/e2e/parity.spec.ts
@@ -4,8 +4,9 @@ import { expect, test, type Page } from "@playwright/test";
  * Marketing nav/footer & theme parity canon (org SKILL.md, 2026-07-19):
  * canonical link inventory on the A1 nav + A11 footer, and the
  * ThemeProvider contract (2026-07-20 tri-state: data-theme on <html>
- * always carries the RESOLVED theme; localStorage `expendit.theme`,
- * key absent = system) cycling + persisting on home AND dashboard.
+ * always carries the RESOLVED theme; localStorage `expendit.theme`, key
+ * absent = dark, expendit's design default; "system" stored explicitly)
+ * cycling + persisting on home AND dashboard.
  */
 
 const GITHUB = "https://github.com/cuesoftinc/expendit";
@@ -201,7 +202,12 @@ test("mobile (390w): the hamburger panel reaches every canonical nav destination
   await expect(panelStar).toHaveText("Star");
   await expect(panelStar.locator("svg")).toBeVisible();
 
-  // Theme toggle works from the panel (system → light → dark).
+  // Theme toggle works from the panel (fresh boot is dark, the design
+  // default; dark → system → light → dark).
+  await nav
+    .getByRole("button", { name: "Theme: dark — switch to system" })
+    .filter({ visible: true })
+    .click();
   await nav
     .getByRole("button", { name: "Theme: system — switch to light" })
     .filter({ visible: true })
@@ -236,39 +242,59 @@ const expectTheme = async (page: Page, theme: string | null) => {
 test("theme toggle cycles light → dark → system and persists on the home page", async ({
   page,
 }) => {
+  // Deterministic OS scheme for the system-resolution assertions.
+  await page.emulateMedia({ colorScheme: "dark" });
   await page.goto("/");
-  // system default — data-theme carries the RESOLVED theme (light OS here)
+  // Fresh visit = the dark design default (key absent — theme contract).
+  await expectTheme(page, "dark");
+  expect(
+    await page.evaluate(() => localStorage.getItem("expendit.theme")),
+  ).toBeNull();
+
+  // dark(default) → system. The initial attr is applied pre-hydration
+  // (init script), so retry the click until React's handler is attached —
+  // detected via storage (the attribute stays dark under the dark OS).
+  const toggle = page.getByTestId("theme-toggle");
+  await expect(async () => {
+    await toggle.click();
+    expect(
+      await page.evaluate(() => localStorage.getItem("expendit.theme")),
+    ).toBe("system");
+  }).toPass({ timeout: 15_000 });
+  await expectTheme(page, "dark"); // OS is dark
+
+  // system → light (explicit choice).
+  await toggle.click();
+  await expectTheme(page, "light");
+  expect(
+    await page.evaluate(() => localStorage.getItem("expendit.theme")),
+  ).toBe("light");
+
+  // Pre-paint persistence across a reload (no FOUC path).
+  await page.reload();
   await expectTheme(page, "light");
 
-  await page
-    .getByRole("button", { name: "Theme: system — switch to light" })
-    .click();
-  await expectTheme(page, "light");
-  await page
-    .getByRole("button", { name: "Theme: light — switch to dark" })
-    .click();
-  await expectTheme(page, "dark");
+  // light → dark (explicit choice ignores the OS).
+  await expect(async () => {
+    await toggle.click();
+    await expectTheme(page, "dark");
+  }).toPass({ timeout: 15_000 });
   expect(
     await page.evaluate(() => localStorage.getItem("expendit.theme")),
   ).toBe("dark");
 
-  // Pre-paint persistence across a reload (no FOUC path).
-  await page.reload();
-  await expectTheme(page, "dark");
-
-  // Third press returns to system: key removed, resolved from the OS,
-  // and a live OS flip tracks without a reload.
-  await page
-    .getByRole("button", { name: "Theme: dark — switch to system" })
-    .click();
-  await expectTheme(page, "light");
+  // dark → system: stored explicitly (key absent = the dark design
+  // default); resolved follows the OS and tracks a live flip without a
+  // reload.
+  await toggle.click();
   expect(
     await page.evaluate(() => localStorage.getItem("expendit.theme")),
-  ).toBeNull();
-  await page.emulateMedia({ colorScheme: "dark" });
-  await expectTheme(page, "dark");
+  ).toBe("system");
+  await expectTheme(page, "dark"); // OS is dark
   await page.emulateMedia({ colorScheme: "light" });
   await expectTheme(page, "light");
+  await page.emulateMedia({ colorScheme: "dark" });
+  await expectTheme(page, "dark");
 });
 
 test("theme toggle lives in the dashboard chrome and persists", async ({
@@ -281,22 +307,25 @@ test("theme toggle lives in the dashboard chrome and persists", async ({
     page.getByRole("heading", { name: "Overview", level: 1 }),
   ).toBeVisible();
 
+  // Fresh session = dark (the design default, key absent).
+  await expectTheme(page, "dark");
+  await page
+    .getByRole("button", { name: "Theme: dark — switch to system" })
+    .click();
   await page
     .getByRole("button", { name: "Theme: system — switch to light" })
     .click();
-  await page
-    .getByRole("button", { name: "Theme: light — switch to dark" })
-    .click();
-  await expectTheme(page, "dark");
+  await expectTheme(page, "light");
   expect(
     await page.evaluate(() => localStorage.getItem("expendit.theme")),
-  ).toBe("dark");
+  ).toBe("light");
 
   await page.reload();
-  await expectTheme(page, "dark");
+  await expectTheme(page, "light");
 
   // The B9 settings control reads the same store (one source of truth) —
-  // its three-way segmented control returns the preference to system.
+  // its three-way segmented control moves the preference to system,
+  // stored explicitly (not key-absent).
   await page.goto("/dashboard/settings");
   await expect(page.getByRole("heading", { name: "Appearance" })).toBeVisible();
   await page
@@ -306,5 +335,5 @@ test("theme toggle lives in the dashboard chrome and persists", async ({
   await expectTheme(page, "light");
   expect(
     await page.evaluate(() => localStorage.getItem("expendit.theme")),
-  ).toBeNull();
+  ).toBe("system");
 });

--- a/web/src/components/ui/ThemeToggle.test.tsx
+++ b/web/src/components/ui/ThemeToggle.test.tsx
@@ -1,6 +1,7 @@
 // ThemeToggle: cycles the ThemeProvider preference light → dark → system
 // (theme contract 2026-07-20); persists under `expendit.theme` with
-// KEY ABSENT = system; the aria-label announces the active mode.
+// KEY ABSENT = dark, expendit's design default; "system" is stored
+// explicitly. The aria-label announces the active mode.
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
@@ -21,32 +22,32 @@ const setup = () =>
   );
 
 describe("ThemeToggle", () => {
-  it("announces the active mode and cycles system → light", async () => {
+  it("announces the active mode (key absent = dark, the design default) and cycles to system", async () => {
     setup();
     const toggle = screen.getByRole("button", {
-      name: "Theme: system — switch to light",
+      name: "Theme: dark — switch to system",
     });
     await userEvent.click(toggle);
+    // "system" is stored explicitly; data-theme carries the RESOLVED theme
+    // (light — no matchMedia dark in jsdom).
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("system");
   });
 
-  it("cycles light → dark → system (key removed, resolved applied)", async () => {
+  it("cycles system → light → dark, persisting each explicit choice", async () => {
     setup();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Theme: dark — switch to system" }),
+    );
     await userEvent.click(
       screen.getByRole("button", { name: "Theme: system — switch to light" }),
     );
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
     await userEvent.click(
       screen.getByRole("button", { name: "Theme: light — switch to dark" }),
     );
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
-    await userEvent.click(
-      screen.getByRole("button", { name: "Theme: dark — switch to system" }),
-    );
-    // Key absent = system; data-theme carries the resolved OS theme
-    // (light — no matchMedia dark in jsdom).
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
-    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
   });
 });

--- a/web/src/controllers/use-theme.test.ts
+++ b/web/src/controllers/use-theme.test.ts
@@ -23,14 +23,15 @@ describe("useThemeController (B9 theme control)", () => {
     await waitFor(() => expect(result.current.theme).toBe("dark"));
   });
 
-  it("system removes the stored key; data-theme carries the resolved OS theme", () => {
+  it("system is stored explicitly; data-theme carries the resolved OS theme", () => {
     const { result } = renderHook(() => useThemeController(), { wrapper });
     act(() => result.current.setTheme("dark"));
     act(() => result.current.setTheme("system"));
     // Contract 2026-07-20: data-theme always carries the RESOLVED theme
-    // (light here — no matchMedia dark in jsdom); key absent = system.
+    // (light here — no matchMedia dark in jsdom); "system" is stored like
+    // any other preference (key absent = dark, the design default).
     expect(document.documentElement.dataset.theme).toBe("light");
-    expect(localStorage.getItem("expendit.theme")).toBeNull();
+    expect(localStorage.getItem("expendit.theme")).toBe("system");
   });
 
   it("reads a stored preference (provider store is localStorage-backed)", async () => {

--- a/web/src/controllers/use-theme.ts
+++ b/web/src/controllers/use-theme.ts
@@ -5,8 +5,9 @@
  * delegates to the design-layer ThemeProvider, the single source of truth
  * for the `data-theme` override (theme parity canon, 2026-07-19: one
  * provider contract across the ecosystem — data-theme on <html>,
- * localStorage `expendit.theme`, system default when unset). The
- * controller API is kept so existing views stay unchanged.
+ * localStorage `expendit.theme`, dark (the design default) when unset —
+ * theme contract, 2026-07-20). The controller API is kept so existing
+ * views stay unchanged.
  */
 
 import {

--- a/web/src/design/ThemeProvider.test.tsx
+++ b/web/src/design/ThemeProvider.test.tsx
@@ -1,7 +1,8 @@
 // Theme provider — tri-state contract (ratified 2026-07-20): preference
-// light | dark | system persisted at expendit.theme (key absent = system);
-// data-theme always carries the RESOLVED theme; system tracks
-// prefers-color-scheme live via a matchMedia listener.
+// light | dark | system persisted at expendit.theme (key absent = dark,
+// the design default; "system" stored explicitly); data-theme always
+// carries the RESOLVED theme; system tracks prefers-color-scheme live via
+// a matchMedia listener.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -66,7 +67,18 @@ describe("ThemeProvider", () => {
     expect(themeInitScript).toContain("setAttribute");
   });
 
-  it("defaults to system and reports the resolved OS theme", () => {
+  it("defaults to dark (the design default) when no key is stored", () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("pref")).toHaveTextContent("dark");
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
+  });
+
+  it("stored system resolves via the OS preference (both directions)", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "system");
     render(
       <ThemeProvider>
         <Probe />
@@ -74,6 +86,18 @@ describe("ThemeProvider", () => {
     );
     expect(screen.getByTestId("pref")).toHaveTextContent("system");
     expect(screen.getByTestId("resolved")).toHaveTextContent("light");
+  });
+
+  it("stored system resolves dark when the OS prefers dark", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "system");
+    systemMatches = true;
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("pref")).toHaveTextContent("system");
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
   });
 
   it("manual dark override applies the resolved attribute and persists", async () => {
@@ -88,7 +112,7 @@ describe("ThemeProvider", () => {
     expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
   });
 
-  it("returning to system removes the stored key (absent = system) and re-resolves", async () => {
+  it("choosing system stores it explicitly and re-resolves via the OS", async () => {
     render(
       <ThemeProvider>
         <Probe />
@@ -97,9 +121,9 @@ describe("ThemeProvider", () => {
     await userEvent.click(screen.getByRole("button", { name: "light" }));
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
     await userEvent.click(screen.getByRole("button", { name: "system" }));
-    // Key absent = system — the cross-product storage convention; the
-    // attribute stays populated with the RESOLVED theme.
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+    // "system" is stored like any preference (key absent = design default);
+    // the attribute stays populated with the RESOLVED theme.
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("system");
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
     expect(screen.getByTestId("pref")).toHaveTextContent("system");
   });

--- a/web/src/design/ThemeProvider.tsx
+++ b/web/src/design/ThemeProvider.tsx
@@ -6,8 +6,9 @@
  * expendit and upstat):
  *
  * - `preference` is what the user chose; persisted at `expendit.theme`
- *   ("light"/"dark" stored explicitly; KEY ABSENT = system — the
- *   cross-product storage convention).
+ *   ("light"/"dark"/"system" all stored explicitly; KEY ABSENT = dark,
+ *   expendit's design default — the cross-product storage convention;
+ *   "system" is never modeled as key-absent).
  * - `data-theme` on <html> always carries the RESOLVED theme ("light" or
  *   "dark"): explicit preferences resolve to themselves; system resolves
  *   via `prefers-color-scheme` and tracks it LIVE (matchMedia listener —
@@ -81,15 +82,19 @@ function emit(): void {
 // PR #209). Readable+writable storage stays the source of truth; after a
 // FAILED write the stored value is stale, so the in-session preference
 // wins until a write succeeds again.
-let memoryPreference: ThemePreference = "system";
+let memoryPreference: ThemePreference = "dark";
 let storageDesynced = false;
 
 function readStoredPreference(): ThemePreference {
   try {
     if (storageDesynced) return memoryPreference;
     const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-    // Readable, in-sync storage is the source of truth (null = none).
-    return stored === "light" || stored === "dark" ? stored : "system";
+    // Readable, in-sync storage is the source of truth. Absent/invalid =
+    // dark, expendit's design default; "system" is an explicit choice,
+    // stored like any other preference.
+    if (stored === "light" || stored === "dark" || stored === "system")
+      return stored;
+    return "dark";
   } catch {
     // Storage unavailable — the in-session preference stands.
     return memoryPreference;
@@ -115,11 +120,14 @@ function readResolvedTheme(): ResolvedTheme {
 }
 
 function getServerPreference(): ThemePreference {
-  return "system";
+  return "dark";
 }
 
 function getServerResolved(): ResolvedTheme {
-  return "light";
+  // dark is expendit's design default (theme contract, 2026-07-20): the
+  // SSR frame renders it attribute-less; the init script resolves before
+  // paint.
+  return "dark";
 }
 
 function applyResolved(theme: ResolvedTheme): void {
@@ -133,7 +141,7 @@ interface ThemeContextValue {
   preference: ThemePreference;
   /** The concrete theme currently applied ("system" resolved live). */
   resolvedTheme: ResolvedTheme;
-  /** Set + persist the preference; "system" removes the stored key. */
+  /** Set + persist the preference ("system" is stored explicitly). */
   setPreference: (preference: ThemePreference) => void;
 }
 
@@ -155,11 +163,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     memoryPreference = next;
     applyResolved(resolveTheme(next));
     try {
-      if (next === "system") {
-        window.localStorage.removeItem(THEME_STORAGE_KEY);
-      } else {
-        window.localStorage.setItem(THEME_STORAGE_KEY, next);
-      }
+      window.localStorage.setItem(THEME_STORAGE_KEY, next);
       storageDesynced = false;
     } catch {
       // non-fatal: the in-session preference drives the store instead.
@@ -188,8 +192,9 @@ export function useTheme(): ThemeContextValue {
  * Pre-paint theme bootstrap (inlined by the root layout). A fully static
  * string — no runtime code construction (CodeQL js/bad-code-sanitization);
  * the literal storage key must match THEME_STORAGE_KEY (unit-tested).
- * Applies the RESOLVED theme: stored light/dark verbatim, otherwise the
- * OS preference — so system mode paints correctly on first frame (no FOUC).
+ * Applies the RESOLVED theme: stored light/dark verbatim, stored "system"
+ * via the OS preference, key absent = dark (the design default) — no FOUC
+ * in any mode.
  */
 export const themeInitScript =
-  '(function(){try{var t=localStorage.getItem("expendit.theme");if(t!=="light"&&t!=="dark"){t=window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";}document.documentElement.setAttribute("data-theme",t);}catch(e){}})();';
+  '(function(){try{var t=localStorage.getItem("expendit.theme");if(t==="system"){t=window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";}else if(t!=="light"&&t!=="dark"){t="dark";}document.documentElement.setAttribute("data-theme",t);}catch(e){}})();';


### PR DESCRIPTION
## Summary
- Theme contract fix (cross-product, ratified 2026-07-20): `ThemeProvider`'s stored preference now treats **key absent = dark**, expendit's design default. `"system"` is stored explicitly at `expendit.theme` via `setItem` — it is never modeled as key-absent.
- `setPreference` always calls `localStorage.setItem` (the `removeItem` branch for `"system"` is gone); `getServerPreference`/`getServerResolved` and `themeInitScript` follow the same default; the in-memory storage-blocked fallback (`memoryPreference`, Codex rounds 3–4) now defaults to `"dark"` too.
- Updates `ThemeProvider.test.tsx`, `ThemeToggle.test.tsx`, `use-theme.ts`/`use-theme.test.ts`, and `docs/web-implementation.md` to describe the new contract (no archaeology — old "key absent = system" wording removed).
- Aligns `e2e/parity.spec.ts` and `e2e/docs-api.spec.ts`: fresh-boot assertions now check the dark design default with a null stored key; the OS-flip-in-system-mode tests select "system" explicitly first (fresh boot no longer resolves via the OS) and use a storage-based retry (`toPass`) for the one click where the resolved attribute doesn't visibly change (dark default → system, OS also dark) — same technique as upstat's fix.
- Mirrors the identical fix landing on upstat (`fix/scalar-header-theme`) and apparule (`fix/theme-default-contract`), each keeping its own design default (upstat: dark, expendit: dark, apparule: light).

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (384 passed)
- [x] `NEXT_PUBLIC_TEST_MODE=1 npm run build`
- [x] `npx playwright test` (48 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)