### PR TITLE
fix(web): Chart/Line y-axis fidelity — tick labels + gridlines per the Figma master

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -315,7 +315,15 @@ var-backed colors — v4 compiles them to `color-mix()`.
 
 Notes: Expendit has no chart series-palette tokens — donut slices take the
 registry category colors (B8, ColorSwatchPicker presets) and line charts
-draw from `--income`/`--expense`/`--accent`. The Afrocentric line motif is
+draw from `--income`/`--expense`/`--accent`. Chart/Line carries the Figma
+master's axis construction as built (2026-07-20 fidelity pass): a 44px
+y-axis column left of the plot (Table/13 Regular in `--text-2`,
+nice-scaled ticks, ₦-compact by default with a per-content-kind format
+override; negative domains tick below zero) with a 1px `--border`
+gridline per tick across the plot (the lowest gridline is the baseline —
+no separate axis hairlines), and 13px `--text-2` x labels below the plot
+at their data positions. StatCard sparklines, RatioGauge and Chart/Donut
+stay axis-free per their masters. The Afrocentric line motif is
 an asset at 4% opacity (dark editorial sections only), not a token.
 Breakpoints need no mapping — the design.md §2 scale (sm 640 … 2xl 1536) is
 Tailwind's default. Density row heights (compact 32 / comfortable 44) are

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -56,6 +56,12 @@ test("core journey — overview, ledger CRUD, import, statements, ratios, tax wi
     .getByTestId("chart-line-net")
     .getAttribute("points");
   expect(personalPoints?.trim().split(/\s+/).length).toBeGreaterThanOrEqual(12);
+  // Y-axis construction (Figma Chart/Line master): ₦-compact nice ticks
+  // left of the plot + a gridline each; the personal domain dips negative.
+  const personalYAxis = page.getByTestId("chart-y-axis");
+  await expect(personalYAxis.getByText("₦0", { exact: true })).toBeVisible();
+  await expect(personalYAxis.getByText("−₦1M", { exact: true })).toBeVisible();
+  await expect(personalYAxis.getByText("₦2M", { exact: true })).toBeVisible();
   await switchToCompanyOrg(page);
   await expect(page.getByText("Net cash flow").first()).toBeVisible();
   // Company ledger onset is Jan 2026 — the chart starts there and says so.
@@ -64,6 +70,9 @@ test("core journey — overview, ledger CRUD, import, statements, ratios, tax wi
     .getByTestId("chart-line-net")
     .getAttribute("points");
   expect(companyPoints?.trim().split(/\s+/).length).toBe(7);
+  const companyYAxis = page.getByTestId("chart-y-axis");
+  await expect(companyYAxis.getByText("−₦2.5M", { exact: true })).toBeVisible();
+  await expect(companyYAxis.getByText("₦5M", { exact: true })).toBeVisible();
 
   // --- B2 transactions CRUD (manual path, MI-11 inspector) --------------
   await openNav(page, "Transactions").click();
@@ -213,6 +222,14 @@ test("core journey — overview, ledger CRUD, import, statements, ratios, tax wi
       trends.getByTestId(`chart-markers-${seriesId}`).locator("circle"),
     ).toHaveCount(2);
   }
+  // The trend chart carries the same y-axis construction, ₦-compact:
+  // revenue tops FY2025 turnover ₦128.4M → ticks ₦0 / ₦50M / ₦100M / ₦150M.
+  await expect(
+    trends.getByTestId("chart-y-axis").getByText("₦100M", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    trends.getByTestId("chart-y-axis").getByText("₦0", { exact: true }),
+  ).toBeVisible();
 
   // --- B7 tax center → B7b filing wizard → filing history ----------------
   await openNav(page, "Tax center").click();

--- a/web/src/app/dashboard/OverviewView.tsx
+++ b/web/src/app/dashboard/OverviewView.tsx
@@ -14,7 +14,7 @@ import { useRouter } from "next/navigation";
 import { formatIso, daysUntil } from "@/lib/dates";
 import { useOrg, useOverviewController } from "@/controllers";
 import { useCategoriesController } from "@/controllers/use-categories";
-import { formatMoney } from "@/lib/format";
+import { formatMoney, formatMoneyCompact } from "@/lib/format";
 import { DEMO_DATASETS } from "@/mock/demo";
 import type { TxnEntry } from "@/models";
 import AnomalyBadge from "@/components/ui/AnomalyBadge";
@@ -170,6 +170,7 @@ export const OverviewView: React.FC = () => {
                 },
               ]}
               xLabels={demo.cashflow.xLabels}
+              yTickFormat={(value) => formatMoneyCompact(value, demo.currency)}
             />
           </Card>
           <Card title="Spending by category">
@@ -428,6 +429,7 @@ export const OverviewView: React.FC = () => {
               xLabelIndices={points
                 .map((_, index) => index)
                 .filter((index) => index % 2 === 0)}
+              yTickFormat={(value) => formatMoneyCompact(value, currency)}
             />
           )}
         </Card>

--- a/web/src/app/dashboard/company/ratios/RatiosView.tsx
+++ b/web/src/app/dashboard/company/ratios/RatiosView.tsx
@@ -23,7 +23,12 @@ import {
   type MetricGroup,
 } from "@/models/registry/ratios";
 import type { RatioResult } from "@/models";
-import { formatMoney, formatPercent, formatRatio } from "@/lib/format";
+import {
+  formatMoney,
+  formatMoneyCompact,
+  formatPercent,
+  formatRatio,
+} from "@/lib/format";
 import Banner from "@/components/ui/Banner";
 import Button from "@/components/ui/Button";
 import ChartLine from "@/components/ui/ChartLine";
@@ -306,6 +311,7 @@ export const RatiosView: React.FC = () => {
                     as two observations (scales to more FYs). */}
                 <ChartLine
                   pointMarkers
+                  yTickFormat={(value) => formatMoneyCompact(value, currency)}
                   series={[
                     {
                       id: "revenue",

--- a/web/src/components/ui/ChartLine.test.tsx
+++ b/web/src/components/ui/ChartLine.test.tsx
@@ -75,10 +75,90 @@ describe("Chart/Line (design.md §8.2b, MI-12)", () => {
         xLabelIndices={[0, 2]}
       />,
     );
-    // 4 points across 480 wide → datum 2 sits at x = 320, not the even
-    // two-label spread (0 / 480).
-    expect(Number(screen.getByText("Mar").getAttribute("x"))).toBe(320);
-    expect(Number(screen.getByText("Jan").getAttribute("x"))).toBe(0);
+    // 4 points → datum 2 sits at 2/3 of the plot width, not the even
+    // two-label spread (0% / 100%).
+    expect(parseFloat(screen.getByText("Mar").style.left)).toBeCloseTo(
+      66.667,
+      2,
+    );
+    expect(parseFloat(screen.getByText("Jan").style.left)).toBe(0);
+  });
+
+  it("y axis renders by default: nice ₦-compact ticks + a gridline each (Figma master)", () => {
+    const { container } = render(
+      <ChartLine series={series} xLabels={["Jan", "Feb", "Mar", "Apr"]} />,
+    );
+    // Domain [0, 8] → nice ticks 0 / 5 / 10.
+    const axis = screen.getByTestId("chart-y-axis");
+    expect(axis).toHaveClass("text-text-2");
+    const labels = [...axis.querySelectorAll("span")].map(
+      (node) => node.textContent,
+    );
+    expect(labels).toEqual(["₦0", "₦5", "₦10"]);
+    const gridlines = container.querySelectorAll(
+      '[data-testid="chart-gridline"]',
+    );
+    expect(gridlines).toHaveLength(3);
+    expect(gridlines[0]).toHaveClass("stroke-border");
+  });
+
+  it("yTickFormat is the content-kind instance override", () => {
+    render(<ChartLine series={series} yTickFormat={(value) => `${value}%`} />);
+    expect(screen.getByTestId("chart-y-axis")).toHaveTextContent("10%");
+  });
+
+  it("negative domains tick below zero (dipping cash flow)", () => {
+    render(
+      <ChartLine
+        series={[
+          {
+            id: "net",
+            label: "Net",
+            color: "accent" as const,
+            points: [-1_134_650, 331_800, 1_529_700],
+          },
+        ]}
+      />,
+    );
+    const labels = [
+      ...screen.getByTestId("chart-y-axis").querySelectorAll("span"),
+    ].map((node) => node.textContent);
+    expect(labels).toEqual(["−₦1M", "₦0", "₦1M", "₦2M"]);
+  });
+
+  it("mobile thinning: interior ticks hide below sm (edges + zero stay)", () => {
+    render(
+      <ChartLine
+        series={[
+          {
+            id: "net",
+            label: "Net",
+            color: "accent" as const,
+            points: [-1_134_650, 331_800, 1_529_700],
+          },
+        ]}
+        xLabels={["Aug", "Oct", "Dec"]}
+      />,
+    );
+    // Ticks −1M / 0 / 1M / 2M: only ₦1M is interior non-zero.
+    expect(screen.getByText("₦1M")).toHaveClass("max-sm:hidden");
+    expect(screen.getByText("−₦1M")).not.toHaveClass("max-sm:hidden");
+    expect(screen.getByText("₦0")).not.toHaveClass("max-sm:hidden");
+    expect(screen.getByText("₦2M")).not.toHaveClass("max-sm:hidden");
+    // X labels: interior months hide, edges stay.
+    expect(screen.getByText("Oct")).toHaveClass("max-sm:hidden");
+    expect(screen.getByText("Aug")).not.toHaveClass("max-sm:hidden");
+    expect(screen.getByText("Dec")).not.toHaveClass("max-sm:hidden");
+  });
+
+  it("yAxis={false} keeps the bare hairline variant (no labels, no gridlines)", () => {
+    const { container } = render(<ChartLine series={series} yAxis={false} />);
+    expect(screen.queryByTestId("chart-y-axis")).toBeNull();
+    expect(
+      container.querySelectorAll('[data-testid="chart-gridline"]'),
+    ).toHaveLength(0);
+    // The austere axis hairlines remain.
+    expect(container.querySelectorAll("line")).toHaveLength(2);
   });
 
   it("loading renders the axis-first skeleton", () => {

--- a/web/src/components/ui/ChartLine.tsx
+++ b/web/src/components/ui/ChartLine.tsx
@@ -5,14 +5,24 @@
  * empty. Bespoke SVG per the reuse policy (no chart libraries); series
  * colors bind to --income/--expense/--accent (web-implementation.md §3).
  * Content kinds (12mo cash-flow / ratio + line-item trend) arrive via
- * props; the data-table toggle attaches at screen assembly. Discrete
+ * props; the data-table toggle attaches at screen assembly.
+ *
+ * Axis construction (Figma Chart/Line master 125:1109): a 44px y-axis
+ * label column left of the plot (Table/13 Regular, text-2, right-aligned,
+ * nice-scaled ticks — ₦0/₦2M/₦4M/₦6M in the master) with a 1px --border
+ * gridline across the plot at each tick (the lowest gridline is the
+ * baseline — no separate axis hairlines), and 13px text-2 x labels below
+ * the plot at their data positions. Tick format is per content kind
+ * (`yTickFormat` instance override; ₦-compact by default). Discrete
  * observation sets (the B6b per-FY trend) opt into `pointMarkers`: a
  * circle per datum so sparse series (N=2 fiscal years) read as
- * observations, not a continuous trend; ticks sit at data positions.
+ * observations, not a continuous trend.
  */
 
 import React from "react";
 import { cn } from "@/lib/cn";
+import { niceScale } from "@/lib/chart-scale";
+import { formatMoneyCompact } from "@/lib/format";
 import Skeleton from "./Skeleton";
 import EmptyState, { type EmptyStateKind } from "./EmptyState";
 
@@ -41,6 +51,13 @@ export interface ChartLineProps {
    * points, not a continuous line; the plot insets so edge markers show.
    */
   pointMarkers?: boolean;
+  /**
+   * Y-axis construction (Figma master): tick labels + gridlines. On by
+   * default — every product instance in the Figma shows it.
+   */
+  yAxis?: boolean;
+  /** Tick label format — content-kind instance override (₦-compact default). */
+  yTickFormat?: (value: number) => string;
   /** Empty-state surface kind (MI-16). */
   emptyKind?: EmptyStateKind;
   onEmptyAction?: () => void;
@@ -68,6 +85,8 @@ const COLOR_FILL: Record<ChartSeriesColor, string> = {
 
 const WIDTH = 480;
 const MARKER_RADIUS = 2.5;
+// Figma master: y-axis column 44px + 8px gap to the plot.
+const Y_AXIS_OFFSET_CLASS = "pl-[52px]";
 
 export const ChartLine: React.FC<ChartLineProps> = ({
   state = "data",
@@ -75,6 +94,8 @@ export const ChartLine: React.FC<ChartLineProps> = ({
   xLabels = [],
   xLabelIndices,
   pointMarkers = false,
+  yAxis = true,
+  yTickFormat = (value) => formatMoneyCompact(value),
   emptyKind = "transactions",
   onEmptyAction,
   height = 160,
@@ -95,8 +116,9 @@ export const ChartLine: React.FC<ChartLineProps> = ({
   }
 
   const all = series.flatMap((entry) => entry.points);
-  const min = Math.min(...all, 0);
-  const max = Math.max(...all);
+  const scale = yAxis ? niceScale(Math.min(...all, 0), Math.max(...all)) : null;
+  const min = scale ? scale.domainMin : Math.min(...all, 0);
+  const max = scale ? scale.domainMax : Math.max(...all);
   const span = max - min || 1;
   const plotHeight = height - 24;
   const pointCount = Math.max(...series.map((entry) => entry.points.length));
@@ -127,83 +149,143 @@ export const ChartLine: React.FC<ChartLineProps> = ({
 
   return (
     <figure data-state="data" className={cn("w-full", className)}>
-      <svg
-        viewBox={`0 0 ${WIDTH} ${height}`}
-        role="img"
-        aria-label={`Line chart: ${series.map((entry) => entry.label).join(", ")}`}
-        className="w-full"
-      >
-        {/* Axis hairlines (austere, never decorative). */}
-        <line
-          x1="0"
-          y1={plotHeight}
-          x2={WIDTH}
-          y2={plotHeight}
-          strokeWidth="1"
-          className="stroke-border"
-        />
-        <line
-          x1="0"
-          y1="0"
-          x2="0"
-          y2={plotHeight}
-          strokeWidth="1"
-          className="stroke-border"
-        />
-        {/* Series draw in 400ms after the axis (MI-12). */}
-        {series.map((entry) => (
-          <polyline
-            key={entry.id}
-            data-testid={`chart-line-${entry.id}`}
-            points={toPoints(entry.points)}
-            fill="none"
-            strokeWidth="1.5"
-            pathLength={1}
-            strokeDasharray="1"
-            className={cn(
-              COLOR_STROKE[entry.color],
-              "animate-draw-in motion-reduce:animate-none motion-reduce:[stroke-dashoffset:0]",
-            )}
-          />
-        ))}
-        {pointMarkers
-          ? series.map((entry) => (
-              <g
-                key={`${entry.id}-markers`}
-                data-testid={`chart-markers-${entry.id}`}
-                aria-hidden
-              >
-                {entry.points.map((value, index) => (
-                  <circle
-                    // Positional key — datum order is the identity here.
-                    key={index}
-                    cx={xAt(index, entry.points.length)}
-                    cy={yAt(value)}
-                    r={MARKER_RADIUS}
-                    className={COLOR_FILL[entry.color]}
-                  />
-                ))}
-              </g>
-            ))
-          : null}
-        {xLabels.map((tick, index) => (
-          <text
-            key={tick}
-            x={tickX(index)}
-            y={height - 6}
-            textAnchor={
-              index === 0
-                ? "start"
-                : index === xLabels.length - 1
-                  ? "end"
-                  : "middle"
-            }
-            className="fill-text-2 text-[10px] tabular-nums"
+      <div className={cn("relative w-full", yAxis && Y_AXIS_OFFSET_CLASS)}>
+        {/* Y tick labels — HTML at fixed 13px (Figma Table/13 Regular),
+            absolutely spanning the plot so percentage tops track the
+            gridline fractions at any rendered width. Presentation only —
+            the data table carries the accessible values. */}
+        {scale ? (
+          <div
+            aria-hidden
+            data-testid="chart-y-axis"
+            className="absolute inset-y-0 left-0 w-11 text-[13px] leading-4 text-text-2 tabular-nums"
           >
-            {tick}
-          </text>
-        ))}
-      </svg>
+            {scale.ticks.map((tick, index) => (
+              <span
+                key={tick}
+                className={cn(
+                  "absolute right-0 -translate-y-1/2 whitespace-nowrap",
+                  // No Part C mobile frame — per the responsive canons the
+                  // axis thins below sm: domain edges + the zero baseline.
+                  index !== 0 &&
+                    index !== scale.ticks.length - 1 &&
+                    tick !== 0 &&
+                    "max-sm:hidden",
+                )}
+                style={{ top: `${(yAt(tick) / plotHeight) * 100}%` }}
+              >
+                {yTickFormat(tick)}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        <svg
+          viewBox={`0 0 ${WIDTH} ${plotHeight}`}
+          role="img"
+          aria-label={`Line chart: ${series.map((entry) => entry.label).join(", ")}`}
+          className="w-full"
+        >
+          {scale ? (
+            // Gridline per tick (--border); the lowest is the baseline.
+            scale.ticks.map((tick) => (
+              <line
+                key={tick}
+                data-testid="chart-gridline"
+                x1="0"
+                x2={WIDTH}
+                y1={yAt(tick)}
+                y2={yAt(tick)}
+                strokeWidth="1"
+                className="stroke-border"
+              />
+            ))
+          ) : (
+            // Bare variant: axis hairlines (austere, never decorative).
+            <>
+              <line
+                x1="0"
+                y1={plotHeight}
+                x2={WIDTH}
+                y2={plotHeight}
+                strokeWidth="1"
+                className="stroke-border"
+              />
+              <line
+                x1="0"
+                y1="0"
+                x2="0"
+                y2={plotHeight}
+                strokeWidth="1"
+                className="stroke-border"
+              />
+            </>
+          )}
+          {/* Series draw in 400ms after the axis (MI-12). */}
+          {series.map((entry) => (
+            <polyline
+              key={entry.id}
+              data-testid={`chart-line-${entry.id}`}
+              points={toPoints(entry.points)}
+              fill="none"
+              strokeWidth="1.5"
+              pathLength={1}
+              strokeDasharray="1"
+              className={cn(
+                COLOR_STROKE[entry.color],
+                "animate-draw-in motion-reduce:animate-none motion-reduce:[stroke-dashoffset:0]",
+              )}
+            />
+          ))}
+          {pointMarkers
+            ? series.map((entry) => (
+                <g
+                  key={`${entry.id}-markers`}
+                  data-testid={`chart-markers-${entry.id}`}
+                  aria-hidden
+                >
+                  {entry.points.map((value, index) => (
+                    <circle
+                      // Positional key — datum order is the identity here.
+                      key={index}
+                      cx={xAt(index, entry.points.length)}
+                      cy={yAt(value)}
+                      r={MARKER_RADIUS}
+                      className={COLOR_FILL[entry.color]}
+                    />
+                  ))}
+                </g>
+              ))
+            : null}
+        </svg>
+      </div>
+      {xLabels.length > 0 ? (
+        // X labels — 13px text-2 below the plot (Figma x-axis row),
+        // anchored at their data positions within the plot band.
+        <div
+          aria-hidden
+          data-testid="chart-x-axis"
+          className={cn("mt-1 w-full", yAxis && Y_AXIS_OFFSET_CLASS)}
+        >
+          <div className="relative h-4 text-[13px] leading-4 text-text-2">
+            {xLabels.map((tick, index) => (
+              <span
+                key={tick}
+                className={cn(
+                  "absolute top-0 whitespace-nowrap",
+                  index === 0
+                    ? ""
+                    : index === xLabels.length - 1
+                      ? "-translate-x-full"
+                      : "-translate-x-1/2 max-sm:hidden",
+                )}
+                style={{ left: `${(tickX(index) / WIDTH) * 100}%` }}
+              >
+                {tick}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
       <figcaption className="mt-2 flex flex-wrap items-center gap-3">
         {series.map((entry) => (
           <span

--- a/web/src/lib/chart-scale.test.ts
+++ b/web/src/lib/chart-scale.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { niceScale } from "./chart-scale";
+
+describe("niceScale (chart y-axis, design.md §8.2b construction)", () => {
+  it("reproduces the Figma master ladder (₦0 / 2M / 4M / 6M) for a 0..~5.2M domain", () => {
+    const scale = niceScale(0, 5_200_000);
+    expect(scale.ticks).toEqual([0, 2_000_000, 4_000_000, 6_000_000]);
+    expect(scale.domainMin).toBe(0);
+    expect(scale.domainMax).toBe(6_000_000);
+  });
+
+  it("handles the personal org's negative dip (−1,134,650 .. 1,529,700)", () => {
+    const scale = niceScale(-1_134_650, 1_529_700);
+    expect(scale.ticks).toEqual([-1_000_000, 0, 1_000_000, 2_000_000]);
+    // The bottom keeps the raw bound — flooring to −2M would waste
+    // most of a step below the data.
+    expect(scale.domainMin).toBe(-1_134_650);
+    expect(scale.domainMax).toBe(2_000_000);
+  });
+
+  it("handles the company org's burn months (−2.61M .. 4.82M) on a 2.5M step", () => {
+    const scale = niceScale(-2_610_000, 4_820_400);
+    expect(scale.ticks).toEqual([-2_500_000, 0, 2_500_000, 5_000_000]);
+    expect(scale.domainMin).toBe(-2_610_000);
+    expect(scale.domainMax).toBe(5_000_000);
+  });
+
+  it("a tiny negative dip never drags the axis a whole step down (trends: −130k dip on a ₦46.5M revenue axis)", () => {
+    const scale = niceScale(-130_000, 46_500_000);
+    expect(scale.ticks).toEqual([0, 20_000_000, 40_000_000]);
+    expect(scale.domainMin).toBe(-130_000);
+    expect(scale.domainMax).toBe(46_500_000);
+  });
+
+  it("zero never renders as −0", () => {
+    const scale = niceScale(-3, 3);
+    expect(scale.ticks).toContainEqual(0);
+    expect(scale.ticks.some((tick) => Object.is(tick, -0))).toBe(false);
+  });
+
+  it("degenerate domains stay renderable", () => {
+    expect(niceScale(0, 0)).toEqual({
+      ticks: [0, 1],
+      domainMin: 0,
+      domainMax: 1,
+    });
+    expect(niceScale(5, 5).ticks).toEqual([0, 2, 4, 6]);
+    expect(niceScale(Number.NaN, 3)).toEqual({
+      ticks: [0],
+      domainMin: 0,
+      domainMax: 1,
+    });
+  });
+
+  it("small unit domains (component gallery) tick cleanly", () => {
+    expect(niceScale(0, 15).ticks).toEqual([0, 5, 10, 15]);
+  });
+});

--- a/web/src/lib/chart-scale.ts
+++ b/web/src/lib/chart-scale.ts
@@ -1,0 +1,57 @@
+/**
+ * Nice-number axis scale for the bespoke charts (design.md §8.2b; the
+ * Figma Chart/Line master's ₦0 / ₦2M / ₦4M / ₦6M ladder): ticks step on
+ * a 1 / 2 / 2.5 / 5 × 10^k grid covering the data domain.
+ *
+ * Bounds snap outward to a step multiple only when the dead band that
+ * adds is small (≤ half a step) — so a ₦−130k net-income dip never pulls
+ * a ₦46M revenue axis down to −₦20M; the axis keeps the raw bound and
+ * the first/last tick sits inside the domain instead (the series may
+ * ride slightly past the outer gridline, absorbed by the plot pad).
+ */
+
+export interface ChartScale {
+  /** Ascending tick values (gridline + label positions). */
+  ticks: number[];
+  domainMin: number;
+  domainMax: number;
+}
+
+export const niceScale = (
+  min: number,
+  max: number,
+  targetCount = 4,
+): ChartScale => {
+  let lo = Math.min(min, max);
+  let hi = Math.max(min, max);
+  if (!Number.isFinite(lo) || !Number.isFinite(hi)) {
+    return { ticks: [0], domainMin: 0, domainMax: 1 };
+  }
+  if (lo === hi) {
+    // Degenerate domain — anchor at zero and give it one step of room.
+    lo = Math.min(lo, 0);
+    hi = Math.max(hi, 0);
+    if (lo === hi) return { ticks: [0, 1], domainMin: 0, domainMax: 1 };
+  }
+
+  const rawStep = (hi - lo) / Math.max(1, targetCount - 1);
+  const magnitude = 10 ** Math.floor(Math.log10(rawStep));
+  const norm = rawStep / magnitude;
+  const step =
+    (norm <= 1 ? 1 : norm <= 2 ? 2 : norm <= 2.5 ? 2.5 : norm <= 5 ? 5 : 10) *
+    magnitude;
+
+  const floorLo = Math.floor(lo / step) * step;
+  const ceilHi = Math.ceil(hi / step) * step;
+  const domainMin = lo - floorLo <= step / 2 ? floorLo : lo;
+  const domainMax = ceilHi - hi <= step / 2 ? ceilHi : hi;
+
+  const epsilon = step * 1e-9;
+  const first = Math.ceil((domainMin - epsilon) / step) * step;
+  const ticks: number[] = [];
+  for (let tick = first; tick <= domainMax + epsilon; tick += step) {
+    // Clean float drift; −0 must never label as "−₦0".
+    ticks.push(Math.abs(tick) < epsilon ? 0 : Number(tick.toPrecision(12)));
+  }
+  return { ticks, domainMin, domainMax };
+};

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatMoney } from "./format";
+import { formatMoney, formatMoneyCompact } from "./format";
 
 describe("formatMoney", () => {
   it("formats NGN with tabular decimals", () => {
@@ -13,5 +13,32 @@ describe("formatMoney", () => {
 
   it("zero carries no sign", () => {
     expect(formatMoney(0)).toBe("₦0.00");
+  });
+});
+
+describe("formatMoneyCompact (chart y ticks — Figma Chart/Line master)", () => {
+  it("abbreviates magnitudes: ₦0 / ₦2M / ₦550.6K / ₦1.2B", () => {
+    expect(formatMoneyCompact(0)).toBe("₦0");
+    expect(formatMoneyCompact(2_000_000)).toBe("₦2M");
+    expect(formatMoneyCompact(550_600)).toBe("₦550.6K");
+    expect(formatMoneyCompact(1_200_000_000)).toBe("₦1.2B");
+  });
+
+  it("keeps at most one decimal (₦2.5M, never ₦2.50M)", () => {
+    expect(formatMoneyCompact(2_500_000)).toBe("₦2.5M");
+    expect(formatMoneyCompact(2_040_000)).toBe("₦2M");
+  });
+
+  it("preserves the sign on negative ticks (dipping cash-flow domains)", () => {
+    expect(formatMoneyCompact(-2_000_000)).toBe("−₦2M");
+    expect(formatMoneyCompact(-2_500_000)).toBe("−₦2.5M");
+  });
+
+  it("respects the org currency", () => {
+    expect(formatMoneyCompact(4_000_000, "USD")).toBe("$4M");
+  });
+
+  it("sub-thousand values render unabbreviated", () => {
+    expect(formatMoneyCompact(15)).toBe("₦15");
   });
 });

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -32,6 +32,30 @@ export const formatMoney = (
   return `${sign}${currencySymbol(currency)}${formatted}`;
 };
 
+/**
+ * Compact axis money — the chart y-tick format from the Figma Chart/Line
+ * master (₦0 / ₦2M / ₦4M / ₦6M): abbreviated magnitude, at most one
+ * decimal, sign preserved (−₦2.5M) for negative-dipping domains.
+ */
+export const formatMoneyCompact = (
+  amount: number,
+  currency = "NGN",
+): string => {
+  const sign = amount < 0 ? "−" : "";
+  const abs = Math.abs(amount);
+  const [suffix, divisor] =
+    abs >= 1e9
+      ? ["B", 1e9]
+      : abs >= 1e6
+        ? ["M", 1e6]
+        : abs >= 1e3
+          ? ["K", 1e3]
+          : ["", 1];
+  const value = Math.round((abs / divisor) * 10) / 10;
+  const text = Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1);
+  return `${sign}${currencySymbol(currency)}${text}${suffix}`;
+};
+
 export const formatPercent = (value: number, decimals = 1): string =>
   `${(value * 100).toFixed(decimals)}%`;
 


### PR DESCRIPTION
## Problem (user-reported Figma deviation)

The built `Chart/Line` rendered **no y-axis labels and no gridlines**. The Figma master (`125:1109`, file `P2lGfKFLJPS9k9kTKlii1n`) pins the construction, verified via the Figma MCP before implementation:

- 44px y-axis column left of the plot — Table/13 Regular, `--text-2`, right-aligned, 4 nice-scaled ticks (₦0 / ₦2M / ₦4M / ₦6M in the master)
- 1px `--border` gridline across the plot at each tick; the lowest gridline is the baseline (no separate axis hairlines)
- 13px `--text-2` x labels below the plot (`pl-52` = 44px column + 8px gap)
- The B6b trends instance (`187:3547`) carries the same construction with a per-content-kind tick format (its mock shows `12%/9%/6%/3%` — instance override)

## Fix

- **`lib/chart-scale.ts` (new)** — `niceScale`: 1/2/2.5/5×10^k tick ladder. Bounds snap outward to a step multiple only when the dead band is ≤ half a step, so a ₦−130k net-income dip never drags the ₦128M revenue axis a whole step down (the first tick sits inside the domain instead; the series may ride slightly past the outer gridline, absorbed by the plot pad). Reproduces the Figma ₦0/2/4/6M ladder exactly on a 0..5.2M domain. **Negative domains tick below zero** — the personal org dips to −₦1.13M → ticks −₦1M/₦0/₦1M/₦2M; company burn months → −₦2.5M/₦0/₦2.5M/₦5M.
- **`lib/format.ts`** — `formatMoneyCompact`: ₦0 / ₦2M / ₦550.6K / −₦2.5M, org-currency aware.
- **`ChartLine`** — y-axis on by default (`yAxis={false}` keeps the old bare hairline variant); `yTickFormat` is the per-content-kind instance override. X labels moved out of the SVG to fixed-13px HTML at their data positions (in-SVG 10px text scaled with the viewBox — off-spec). Below `sm` the axes thin to domain edges + the zero baseline (**no Part C mobile frame exists** — pages.md defers mobile; thinning follows the responsive canons, verified at 390: no crowding, no overflow).
- **Applied where the Figma shows it**: B1 overview (both orgs + the MI-16 demo block), B6b trends, home embeds/demo/dev gallery (default).

## Per-chart sweep verdicts (vs their Figma frames)

| Chart | Verdict |
| --- | --- |
| Chart/Line — B1 overview | **deviated (no y axis/gridlines) → fixed** |
| Chart/Line — B6b trends | **deviated (same class) → fixed** (₦-compact format; construction scales with more FYs) |
| Chart/Line — home hero embed / demo section / gallery | **fixed via component default** (embeds mirror B1 per the Figma home frame) |
| StatCard sparkline | **intentionally bare per spec** (B1 frame shows no axes on mini lines) |
| Chart/Donut | **intentionally bare per spec** (legend + center total only) |
| RatioGauge | **intentionally bare per spec** (band gauge construction, node 66:266) |

## Tests & gates

- Unit **401/401** ✅ — new: `niceScale` (Figma ladder reproduction, negative domains, tiny-dip guard, degenerates), `formatMoneyCompact`, ChartLine axis/gridline/format-override/bare-variant/marker suites
- E2E **48/48** ✅ — asserts ₦ tick labels on the personal overview (−₦1M/₦0/₦2M), company overview (−₦2.5M/₦5M), and trends (₦0/₦100M); one unrelated home smooth-scroll flake passed 3/3 on rerun
- lint + boundaries ✅ · typecheck ✅ · build ✅
- Screenshots vs the Figma reference at 1440 and 390, light + dark — construction matches (tick values, gridline token, label type/color, column width)

## Docs

- `web-implementation.md`: as-built note on the axis construction (tokens table notes) — which charts carry it and which stay bare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)