### PR TITLE
fix(web): Figma convergence — code lane of the adjudicated audit ledger

### DIFF
--- a/docs/pages.md
+++ b/docs/pages.md
@@ -76,16 +76,28 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   `POST /expense/create` / `POST /income/create` endpoints).
 - Bulk select → bulk re-categorize / export selection.
 - Anomaly-explain inspector state: AnomalyBadge click opens the Inspector
-  `anomaly-explain` variant (design.md §8.2) — what flagged, severity,
-  comparable txns, dismiss/confirm **[Directive 2026-07-18]**.
+  `anomaly-explain` variant (design.md §8.2) — inline row badges are the
+  entry point (row-reachable, not deep-link-only). Panel anatomy: what
+  flagged, human-cased severity, provenance line (detected date +
+  `rule_id` rule version), comparable transactions named by category with
+  a median footer; actions **Cancel / Mark expected** — Mark expected
+  clears the flags (the AI-trust affordance) **[Directive 2026-07-18]**.
 - Empty + loading frames per the screen-state rule (design.md §8.1)
   **[Directive 2026-07-18]**.
 
 ### B3 `/imports` — Import hub
-- UploadDropzone (CSV/PDF/receipt image) (MI-2) + import-job history table
-  (status, counts, anomalies found).
+- UploadDropzone (CSV/PDF/receipt image) (MI-2) + "Import history" job list
+  (status, counts, anomalies found). Parked review jobs tag blue **Ready
+  for review**; failed rows read a human failure sentence with the raw
+  taxonomy code demoted to a details disclosure; dates are absolute (the
+  finance-date idiom).
 - Job detail: staged-review table (AI categories ✨, duplicates pre-flagged),
-  per-row category fix (MI-4), then confirm/discard (MI-3).
+  per-row category fix (MI-4), then confirm/discard (MI-3). CTAs per the
+  B3b frame: secondary **Discard N duplicates** (flags every duplicate for
+  discard; the commit performs it) + primary **Import N**; whole-job abort
+  is a quiet "Discard import" in the page header. Footer reassurance:
+  "N rows will join your ledger. Discarded duplicates stay recoverable for
+  30 days."
 - Async model (202 + polling) per architecture.md §4.2.
 - Import failure state: a `failed` job renders the error screen —
   failure-taxonomy copy + retry (new job), flows/import.md §3
@@ -100,7 +112,9 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
 - Synced transactions land in the same staged-review pipeline as uploads
   (single ingestion path **[Proposed]**), auto-confirm option per account
   once trust is established.
-- Re-auth banners when a link expires (design.md banners).
+- Re-auth banners when a link expires (design.md banners) — amber (a
+  recoverable pause): "Access Bank link expired — sync paused since
+  12 Jul" + **Re-authenticate**.
 - Bank-link journey states as screens: consent (Mono widget hand-off) /
   syncing (progress + live txn counter) / done — the MI-9 stepper,
   flows/bank-link.md **[Directive 2026-07-18]**.
@@ -109,7 +123,9 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
 - Generate: monthly summary / cash-movement / category deep-dive
   (`kind: category_deep_dive` + `category` param, api.md §2); period picker;
   format PDF/CSV.
-- Artifact history table (TTL'd) with download (MI-14).
+- "Artifact history" list (TTL'd) with download (MI-14); expiry caption
+  under the list: "Artifacts expire after 30 days. You can regenerate any
+  report at any time."
 - Scheduled reports (monthly email) **[Proposed, later]**.
 
 ### B6 `/company` — Company financials **[Directive — new]**
@@ -127,10 +143,18 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   ManualStatementRow add-row for parser-missed lines —
   flows/statement-mapping.md **[Directive 2026-07-18]**.
 - **Statement view**: per confirmed statement (kind × period), render the
-  normalized statement — canonical rows, *(derived)* rows flagged with their
-  formula, `mapping_warning` badges, period-selector header (StatementView,
+  normalized statement — rows read as the vocabulary's **human labels**
+  (`CANONICAL_KEY_LABELS`, raw key preserved as the row title), derived
+  rows bold with a **ƒ derived** chip carrying the formula tooltip,
+  unmapped rows tagged per row with a header count tag,
+  `mapping_warning` badges, an **identity-check footer** per kind (green
+  "Assets = Liabilities + Equity" when the statement ties out within the
+  ±1% tolerance, amber when not), period-selector header (StatementView,
   design.md §8.2); export to report artifact
   (`kind: financial_statement`, api.md §2).
+- Archive tab **[Proposed — deferred]**: the B6 hub frame carries a
+  Statements / Ratios / Trends / Archive tab row; the built IA stays two
+  nav pages (adjudicated parity) and no Archive surface ships yet.
 - **Ratios** (`/company/ratios` — screen B6b): RatioGauge grid (MI-8),
   grouped:
   - *Liquidity*: current ratio, quick ratio, cash ratio
@@ -140,7 +164,10 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   - *Cash flow & scale*: working capital, operating cash-flow ratio, free
     cash flow, CFO-to-total-debt — currency values render as
     StatCard/MoneyCell, not gauges (line-items.md §5)
-  - Each gauge: value, period delta, benchmark band, "how we got this"
+  - Each gauge: value, period delta (real `period_delta` — current minus
+    the prior same-kind period, computed by the ratio engine; the caption
+    names the prior period, e.g. "vs FY2024"; growth metrics carry none —
+    they already are comparisons), benchmark band, "how we got this"
     formula trace (MI-8 tooltip → inspector with line items). **Benchmark
     bands [Decided v1]: static per-ratio healthy ranges shipped as constants
     in the ratio registry** (line-items.md §5), clearly labeled "general
@@ -150,7 +177,9 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   across periods; export to report artifact. As built: the periods are
   discrete annual observations — point markers at each confirmed FY with
   FY ticks at the data positions, so a two-year history reads as two
-  observations, not a continuous trend (scales unchanged as FYs accrue).
+  observations, not a continuous trend (scales unchanged as FYs accrue);
+  the card carries a **Data table** toggle (mirrors the B1 cash-flow
+  toggle: Period / Revenue / Gross profit / Net income).
 - Requires ≥1 mapped statement period; empty state explains inputs needed
   and which org kind captures statements (data-model.md §5 "Who uses which
   org kind"); empty + loading frames per the screen-state rule
@@ -193,16 +222,24 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   center ships its empty + loading frames.
 
 ### B8 `/categories`, B9 `/settings`
-- Categories: CRUD + color/dot, merge tool, AI-training note.
+- Categories: CRUD + color/dot, merge tool, AI-training note. Rows carry
+  the usage meta "N transactions this year" (calendar-year count enriched
+  on the list response — merge-safety context) and the **AI-proposed row
+  state** (✨ chip + provenance note, e.g. "AI proposed from 3 vendors"; a
+  human edit confirms the entry). Per-row Delete confirms before firing
+  (danger pattern); `category_in_use` pivots to merge.
 - Settings: org members/roles (company orgs), organization profile — name,
   registered address, fiscal year end (company orgs; data-model.md §5,
-  FormRow), data & privacy (export-all USR-001, purge USR-002 with MI-15),
-  AI-processing consent, bank-link permissions, notifications,
-  theme/density.
+  FormRow; FYE is a human month-end select, "31 December", writing the
+  MM-DD wire format), data & privacy (export-all USR-001, purge USR-002
+  with MI-15), AI-processing consent, bank-link permissions,
+  notifications, theme/density (theme control order Light | Dark | System
+  — the toggle's cycle order).
 - Rights & data screens: export-all progress (202 job → running/completed
   with signed-url download, flows/rights.md §1) and delete-account
-  typed-confirm (MI-15, 7-day grace, flows/rights.md §2)
-  **[Directive 2026-07-18]**.
+  typed-confirm (MI-15: type the **org name**, 5s danger-armed CTA, an
+  **Export first** secondary that kicks off USR-001; 7-day grace,
+  flows/rights.md §2) **[Directive 2026-07-18]**.
 
 ## Part C — Mobile app (later phase; parity direction **[Directive]**)
 

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -272,12 +272,62 @@ flip, no reload). The pre-paint init script applies the resolved theme
 (no FOUC in any mode). `ThemeToggle` (marketing nav + dashboard chrome)
 cycles light → dark → system with distinct icons (sun / moon / monitor);
 its aria-label announces the active mode. The B9 Appearance section
-keeps the three-way Light/System/Dark segmented control over the same
-store (`useThemeController` delegates to the provider). The Scalar embed
+keeps the three-way Light/Dark/System segmented control (the toggle's
+cycle order) over the same store (`useThemeController` delegates to the
+provider). The Scalar embed
 follows `resolvedTheme` (X-2 note above). Unit tests pin the storage
 convention, live system tracking, the cycle order and the storage-
 blocked fallbacks; e2e pins the cycle, an emulated OS flip in system
 mode and reload persistence.
+
+**Figma-convergence as-built notes (2026-07-20, code lane of the
+adjudicated audit ledger):**
+
+- **B1 overview**: the mid-band grid is `lg:grid-cols-[2fr_1fr]` — the
+  comma form is invalid CSS (browsers drop the declaration, collapsing
+  the band to one column); an e2e asserts two computed tracks at lg. The
+  donut center follows the master: caption above, compact 2-decimal value
+  below (`formatMoneyCompact` gains an opt-in `decimals`).
+- **StatementView reads human**: vocabulary labels over raw canonical
+  keys (raw key kept as the row `title`), bold derived rows with the
+  "ƒ derived" chip (formula tooltip), per-row + header unmapped tags, and
+  a per-kind identity-check footer (green within the ±1% tolerance,
+  amber outside, hidden when a side is absent).
+- **Purge model converged** (MI-15, one construction): typed confirm is
+  the ORG NAME, the 5s danger-armed CTA stays, and an "Export first"
+  secondary kicks off the USR-001 export from the modal; grace states as
+  previously built.
+- **Ratio gauges carry real deltas**: the mock engine computes the prior
+  same-kind period per metric and attaches `period_delta` (skipped for
+  growth metrics and when either side is n/a); `previousPeriod` lives in
+  the models registry (period grammar is contract); captions name the
+  prior period ("vs FY2024"). The B6b trends card gains the frame's
+  "Data table" toggle, mirroring B1's.
+- **Imports copy deck**: blue "Ready for review" tag on parked jobs,
+  human failure sentences with the raw taxonomy code in a details
+  disclosure, "Import history" heading; B3b splits the CTAs (secondary
+  "Discard N duplicates" + primary "Import N"; whole-job abort demoted to
+  a quiet page-header action) and restores the 30-day recoverability
+  footer. Absolute dates stay (adjudicated finance-date idiom).
+- **B8 categories**: usage meta "N transactions this year"
+  (`txn_count_ytd` list-response enrichment), the AI-proposed row state
+  (`ai_proposed`/`ai_note` on the seeded "Logistics"; a human PUT
+  confirms), and a delete-confirm modal ahead of the `category_in_use`
+  merge pivot.
+- **B2b anomaly explain**: reachable from the inline row badges;
+  human-cased severity; provenance line (detected date + rule version —
+  `Anomaly` gains optional `detected_at`/`rule_version`); category-named
+  comparables with a median footer; actions Cancel / **Mark expected**
+  (PUT `{anomalies: []}` — the only anomaly write the mock accepts).
+- **Low sweep**: amber re-auth banner ("… link expired — sync paused
+  since 12 Jul" + Re-authenticate), AppNav icons per the master (Reports
+  file-text, Statements file-spreadsheet), the marketing-nav wordmark
+  accent dot, CodeSnippet copy-button backdrop (no text showing through),
+  "Artifact history" heading + 30-day expiry caption, pluralized
+  "1 anomaly", humanized fiscal-year-end select, Light | Dark | System
+  order.
+- **/docs/api**: Scalar's dev toolbar is disabled via configuration
+  (`showToolbar: "never"`), never a fork.
 
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -327,7 +327,8 @@ adjudicated audit ledger):**
   "1 anomaly", humanized fiscal-year-end select, Light | Dark | System
   order.
 - **/docs/api**: Scalar's dev toolbar is disabled via configuration
-  (`showToolbar: "never"`), never a fork.
+  (`showDeveloperTools: "never"` — `showToolbar` is its deprecated
+  alias), never a fork.
 
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -358,3 +358,20 @@ test("semantic chrome — one main landmark, labeled nav, real ledger table", as
   await expect(page.locator("table").first()).toBeVisible();
   expect(await page.getByRole("columnheader").count()).toBeGreaterThan(2);
 });
+
+test("overview mid-band forms two columns at lg (Figma 179:12)", async ({
+  page,
+}) => {
+  // The chart card (2fr) sits beside the donut/anomalies rail (1fr) at
+  // lg+ — regression guard for the invalid `grid-cols-[2fr,1fr]`
+  // arbitrary value (comma is dropped by browsers, collapsing the band
+  // to a single column at every width).
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await signIn(page);
+  const band = page.getByTestId("overview-mid-band");
+  await expect(band).toBeVisible();
+  const trackCount = await band.evaluate(
+    (el) => getComputedStyle(el).gridTemplateColumns.trim().split(/\s+/).length,
+  );
+  expect(trackCount).toBe(2);
+});

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -382,3 +382,32 @@ test("overview mid-band forms two columns at lg (Figma 179:12)", async ({
   );
   expect(trackCount).toBe(2);
 });
+
+test("purge modal — org-name typed confirm + Export first escape hatch (MI-15)", async ({
+  page,
+}) => {
+  await signIn(page);
+  await openNav(page, "Settings").click();
+  await page.waitForURL("**/dashboard/settings");
+
+  await page.getByRole("button", { name: "Delete everything…" }).click();
+  const modal = page.getByRole("dialog", { name: "Delete account & all data" });
+  await expect(modal).toBeVisible();
+
+  // Converged construction (B9 + B9b): Export-first secondary present,
+  // CTA locked until the ORG NAME is typed (not a literal phrase).
+  await expect(
+    modal.getByRole("button", { name: "Export first" }),
+  ).toBeVisible();
+  const schedule = modal.getByRole("button", { name: /Schedule deletion/ });
+  await expect(schedule).toBeDisabled();
+  const confirmInput = modal.getByLabel(/Type "Personal" to confirm/);
+  await confirmInput.fill("DELETE EVERYTHING");
+  await expect(schedule).toBeDisabled();
+  await confirmInput.fill("Personal");
+  // Unlocks once the 5s danger-arming countdown elapses; nothing is
+  // scheduled — the flow exits via Cancel (no store mutation).
+  await expect(schedule).toBeEnabled({ timeout: 10_000 });
+  await modal.getByRole("button", { name: "Cancel", exact: true }).click();
+  await expect(modal).not.toBeVisible();
+});

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -421,3 +421,32 @@ test("purge modal — org-name typed confirm + Export first escape hatch (MI-15)
   await modal.getByRole("button", { name: "Cancel", exact: true }).click();
   await expect(modal).not.toBeVisible();
 });
+
+test("anomaly explain opens from the ledger row (B2b frame anatomy)", async ({
+  page,
+}) => {
+  await signIn(page);
+  await openNav(page, "Transactions").click();
+  await page.waitForURL("**/dashboard/transactions");
+  await expect(page.locator("table tbody tr").first()).toBeVisible();
+
+  // Inline anomaly badges are the row-level entry point — no deep link.
+  await page
+    .locator("tbody")
+    .getByRole("button", {
+      name: /Large transaction|Spending spike|Unusual category|Possible duplicate/,
+    })
+    .first()
+    .click();
+  const explain = page.getByRole("dialog", { name: "Why this was flagged" });
+  await expect(explain).toBeVisible();
+  // Humanized severity, provenance/rule-version line, frame actions.
+  await expect(explain.getByText(/^(Info|Warning)$/)).toBeVisible();
+  await expect(explain.getByText(/Detected .* · rule:/)).toBeVisible();
+  await expect(
+    explain.getByRole("button", { name: "Mark expected" }),
+  ).toBeVisible();
+  // Exit via Cancel — nothing is mutated in the serial narrative.
+  await explain.getByRole("button", { name: "Cancel", exact: true }).click();
+  await expect(explain).not.toBeVisible();
+});

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -237,6 +237,16 @@ test("core journey — overview, ledger CRUD, import, statements, ratios, tax wi
   await expect(
     trends.getByTestId("chart-y-axis").getByText("₦0", { exact: true }),
   ).toBeVisible();
+  // Data-table toggle (B6b frame, mirrors B1): chart ⇄ accessible table.
+  await trends.getByRole("button", { name: "Data table" }).click();
+  const trendsTable = trends.getByRole("table", { name: "Trends data" });
+  await expect(trendsTable).toBeVisible();
+  await expect(
+    trendsTable.getByRole("columnheader", { name: "Gross profit" }),
+  ).toBeVisible();
+  await expect(trendsTable.locator("tbody tr")).toHaveCount(2);
+  await trends.getByRole("button", { name: "Chart", exact: true }).click();
+  await expect(trends.getByTestId("chart-y-axis")).toBeVisible();
 
   // --- B7 tax center → B7b filing wizard → filing history ----------------
   await openNav(page, "Tax center").click();

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -193,9 +193,16 @@ test("core journey — overview, ledger CRUD, import, statements, ratios, tax wi
       page.getByText(/Statement confirmed — ratios recomputed/),
     ).toBeVisible({ timeout: 15_000 });
   }
-  // Statement view (normalized rows incl. derived totals — the registry
-  // StatementView renders mono canonical keys, design.md §8.2).
-  await expect(page.getByText("total_assets").first()).toBeVisible();
+  // Statement view (normalized rows incl. derived totals): human reading
+  // labels from the canonical vocabulary (Figma 98:743), derived rows
+  // carry the ƒ chip, and the identity-check footer ties out green.
+  await expect(page.getByText("Total assets").first()).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "ƒ derived" }).first(),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/Identity check — Assets = Liabilities \+ Equity/),
+  ).toBeVisible();
 
   // --- B6b ratios: gauges + MI-8 trace inspector -------------------------
   await openNav(page, "Ratios").click();

--- a/web/e2e/docs-api.spec.ts
+++ b/web/e2e/docs-api.spec.ts
@@ -25,6 +25,11 @@ test.describe("API reference — /docs/api", () => {
       page.getByRole("heading", { name: "Expendit API" }),
     ).toBeVisible({ timeout: 20_000 });
     await expect(page.getByText("List expenses").first()).toBeVisible();
+
+    // Scalar's dev toolbar stays off the public reference
+    // (showDeveloperTools: "never") — it would otherwise render on
+    // 127.0.0.1, where this suite runs.
+    await expect(page.locator("header.api-reference-toolbar")).toHaveCount(0);
   });
 
   test("the OpenAPI document is served at /docs/api/openapi.yaml", async ({

--- a/web/src/app/api/mock/categories/[id]/route.ts
+++ b/web/src/app/api/mock/categories/[id]/route.ts
@@ -42,6 +42,11 @@ export async function PUT(request: Request, context: Context) {
   if (body.vat_treatment !== undefined)
     category.vat_treatment = body.vat_treatment;
   if (body.vat_basis !== undefined) category.vat_basis = body.vat_basis;
+  // A human edit confirms an AI-proposed registry entry (B8 row state).
+  if (category.ai_proposed) {
+    category.ai_proposed = false;
+    category.ai_note = null;
+  }
   return ok(category);
 }
 

--- a/web/src/app/api/mock/categories/route.ts
+++ b/web/src/app/api/mock/categories/route.ts
@@ -2,12 +2,27 @@
 
 import type { Category } from "@/models";
 import { getDb, nextId } from "@/mock/db";
+import { mockNow } from "@/mock/clock";
 import { fail, ok, resolveOrgId, writeBlocked } from "@/mock/http";
 
 export async function GET(request: Request) {
   const orgId = resolveOrgId(request);
   if (!orgId) return fail(404, "not_found", "Unknown org");
-  const items = getDb().categories.filter((cat) => cat.org_id === orgId);
+  const db = getDb();
+  // Usage enrichment (B8 "N transactions this year" — merge-safety
+  // context): calendar-year count per category, derived at read time.
+  const year = String(mockNow().getFullYear());
+  const items = db.categories
+    .filter((cat) => cat.org_id === orgId)
+    .map((cat) => ({
+      ...cat,
+      txn_count_ytd: db.transactions.filter(
+        (txn) =>
+          txn.org_id === orgId &&
+          txn.category_id === cat.id &&
+          txn.txn_date.startsWith(year),
+      ).length,
+    }));
   return ok({ items });
 }
 

--- a/web/src/app/api/mock/transactions/[id]/route.ts
+++ b/web/src/app/api/mock/transactions/[id]/route.ts
@@ -45,6 +45,18 @@ export async function PUT(request: Request, context: Context) {
   if (body.txn_date !== undefined) txn.txn_date = body.txn_date;
   if (body.excluded_from_reports !== undefined)
     txn.excluded_from_reports = body.excluded_from_reports;
+  // B2b "Mark expected": the only anomaly write is clearing the flags —
+  // the user telling the AI this pattern is normal. Anything else 422s.
+  if (body.anomalies !== undefined) {
+    if (!Array.isArray(body.anomalies) || body.anomalies.length > 0) {
+      return fail(
+        422,
+        "validation_failed",
+        "anomalies only accepts [] (mark expected)",
+      );
+    }
+    txn.anomalies = [];
+  }
   if (body.category_id !== undefined) {
     txn.category_id = body.category_id;
     txn.ai_categorized = false; // human confirmation clears the ✨ (MI-4)

--- a/web/src/app/dashboard/DashboardShell.tsx
+++ b/web/src/app/dashboard/DashboardShell.tsx
@@ -14,9 +14,9 @@ import { usePathname, useRouter } from "next/navigation";
 import * as Dialog from "@radix-ui/react-dialog";
 import {
   ArrowLeftRight,
-  Building2,
   Calculator,
-  Download,
+  FileSpreadsheet,
+  FileText,
   Landmark,
   LayoutDashboard,
   LogOut,
@@ -61,11 +61,13 @@ const NAV_ROUTES: NavRoute[] = [
   },
   { href: "/dashboard/imports", label: "Imports", icon: Upload, nested: true },
   { href: "/dashboard/accounts", label: "Accounts", icon: Landmark },
-  { href: "/dashboard/reports", label: "Reports", icon: Download },
+  // Icons per the AppNav master: file-text (Reports), file-spreadsheet
+  // (Statements) — audit B1/B6 low rows.
+  { href: "/dashboard/reports", label: "Reports", icon: FileText },
   {
     href: "/dashboard/company",
     label: "Statements",
-    icon: Building2,
+    icon: FileSpreadsheet,
     nested: true,
     group: "Company",
   },

--- a/web/src/app/dashboard/OverviewView.tsx
+++ b/web/src/app/dashboard/OverviewView.tsx
@@ -94,7 +94,7 @@ export const OverviewView: React.FC = () => {
             <StatCard key={i} label="" value={0} loading />
           ))}
         </div>
-        <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[2fr,1fr]">
+        <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[2fr_1fr]">
           <ChartLine state="loading" />
           <ChartDonut state="loading" />
         </div>
@@ -158,7 +158,7 @@ export const OverviewView: React.FC = () => {
             ),
           )}
         </div>
-        <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[2fr,1fr]">
+        <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[2fr_1fr]">
           <Card title="Cash flow — trailing 12 months">
             <ChartLine
               series={[
@@ -346,7 +346,10 @@ export const OverviewView: React.FC = () => {
       </div>
 
       {/* Figma 179:12: chart left (2/3), donut + anomalies right (1/3). */}
-      <div className="mt-4 grid grid-cols-1 items-start gap-4 lg:grid-cols-[2fr,1fr]">
+      <div
+        data-testid="overview-mid-band"
+        className="mt-4 grid grid-cols-1 items-start gap-4 lg:grid-cols-[2fr_1fr]"
+      >
         <Card
           // The monthly series starts at ledger onset (no fabricated
           // pre-onset months) — the title states the span it actually has.
@@ -444,8 +447,10 @@ export const OverviewView: React.FC = () => {
               <div className="flex items-center gap-4">
                 <ChartDonut
                   slices={donutSlices}
-                  centerTotal={formatMoney(donutTotal, currency, {
-                    decimals: 0,
+                  // Compact center total per the ChartDonut master
+                  // ("₦3.61M" — caption above, value below).
+                  centerTotal={formatMoneyCompact(donutTotal, currency, {
+                    decimals: 2,
                   })}
                   centerCaption="Expenses"
                   legend="none"

--- a/web/src/app/dashboard/accounts/AccountsView.tsx
+++ b/web/src/app/dashboard/accounts/AccountsView.tsx
@@ -16,6 +16,7 @@ import { useAccountsController, useOrg } from "@/controllers";
 import { importsRepo, ApiError } from "@/models/repositories";
 import type { BankLink } from "@/models";
 import { useReducedMotion } from "@/lib/use-reduced-motion";
+import { formatIso } from "@/lib/dates";
 import Banner from "@/components/ui/Banner";
 import Button from "@/components/ui/Button";
 import EmptyState from "@/components/ui/EmptyState";
@@ -185,10 +186,12 @@ export const AccountsView: React.FC = () => {
         </div>
       ) : null}
 
+      {/* B4 frame (184:1319): expired links banner amber — a recoverable
+          pause, not a failure — with the "Re-authenticate" action. */}
       {reauthLinks.map((link) => (
         <div key={link.id} className="mb-3">
           <Banner
-            kind="error"
+            kind="warn"
             action={
               <Button
                 size="sm"
@@ -198,12 +201,15 @@ export const AccountsView: React.FC = () => {
                   setJourneyOpen(true);
                 }}
               >
-                Reconnect
+                Re-authenticate
               </Button>
             }
           >
-            {link.institution} {link.masked_account} needs re-authentication —
-            syncs are paused until you reconnect.
+            {link.institution} link expired — sync paused
+            {link.last_synced_at
+              ? ` since ${formatIso(link.last_synced_at, "d MMM")}`
+              : ""}
+            .
           </Banner>
         </div>
       ))}

--- a/web/src/app/dashboard/categories/CategoriesView.tsx
+++ b/web/src/app/dashboard/categories/CategoriesView.tsx
@@ -9,7 +9,7 @@
 
 import React, { useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { Plus, Sparkles } from "lucide-react";
+import { Plus } from "lucide-react";
 import { useCategoriesController, useOrg } from "@/controllers";
 import { ApiError } from "@/models/repositories";
 import type { Category, CategoryType } from "@/models";
@@ -52,6 +52,13 @@ interface CategoryListProps {
   onDelete: (category: Category) => void;
 }
 
+/** B8 usage meta: "N transactions this year" (+ AI-proposal provenance). */
+const usageMeta = (category: Category): string => {
+  const count = category.txn_count_ytd ?? 0;
+  const usage = `${count} ${count === 1 ? "transaction" : "transactions"} this year`;
+  return category.ai_note ? `${usage} · ${category.ai_note}` : usage;
+};
+
 const CategoryList: React.FC<CategoryListProps> = ({
   title,
   items,
@@ -70,6 +77,7 @@ const CategoryList: React.FC<CategoryListProps> = ({
         {items.map((category) => (
           <li
             key={category.id}
+            data-ai-proposed={category.ai_proposed || undefined}
             // flex-wrap: at narrow widths the action cluster wraps under
             // the chip instead of pushing the page wide (mobile canon).
             className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b border-border px-4 py-2 last:border-b-0"
@@ -80,8 +88,14 @@ const CategoryList: React.FC<CategoryListProps> = ({
                 name: category.name,
                 color: category.color,
               }}
+              // ✨ on AI-proposed rows (B8 frame) until a human edit
+              // confirms the registry entry.
+              aiSuggested={category.ai_proposed ?? false}
             />
-            <span className="min-w-0 flex-1" />
+            {/* Usage meta — merge-safety context (B8 frame). */}
+            <span className="min-w-0 flex-1 truncate text-[12px] text-text-2">
+              {usageMeta(category)}
+            </span>
             <span className="flex shrink-0 items-center gap-3">
               <Button kind="quiet" size="sm" onClick={() => onEdit(category)}>
                 Edit
@@ -118,6 +132,8 @@ export const CategoriesView: React.FC = () => {
   const [busy, setBusy] = useState(false);
   const [mergeSource, setMergeSource] = useState<Category | null>(null);
   const [mergeTarget, setMergeTarget] = useState<string | null>(null);
+  // Danger pattern: per-row delete confirms before it fires (B8 review).
+  const [confirmDelete, setConfirmDelete] = useState<Category | null>(null);
   const [toast, setToast] = useState<string | null>(null);
 
   const expenseCategories = useMemo(
@@ -224,8 +240,9 @@ export const CategoriesView: React.FC = () => {
       ) : null}
 
       <div className="mb-4">
+        {/* Banner kind="info" supplies its own leading icon — no manual
+            Sparkles (double-icon bug, audit B8). */}
         <Banner kind="info">
-          <Sparkles aria-hidden className="mr-1 inline h-3.5 w-3.5" />
           Your category corrections train the AI — re-categorized imports
           improve future suggestions for this workspace.
         </Banner>
@@ -251,7 +268,7 @@ export const CategoriesView: React.FC = () => {
               })
             }
             onMerge={setMergeSource}
-            onDelete={(category) => void removeCategory(category)}
+            onDelete={setConfirmDelete}
           />
           <CategoryList
             title="Income categories"
@@ -265,7 +282,7 @@ export const CategoriesView: React.FC = () => {
               })
             }
             onMerge={setMergeSource}
-            onDelete={(category) => void removeCategory(category)}
+            onDelete={setConfirmDelete}
           />
         </div>
       )}
@@ -333,6 +350,36 @@ export const CategoriesView: React.FC = () => {
           </div>
         ) : null}
       </Modal>
+
+      {/* Delete confirm — the danger pattern applies to every
+          destructive row action (B8 review; category_in_use pivots the
+          confirmed delete to the merge tool). */}
+      <Modal
+        open={confirmDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmDelete(null);
+        }}
+        title={`Delete "${confirmDelete?.name ?? ""}"?`}
+        description="Unused categories are removed immediately; in-use ones pivot to the merge tool so history is never orphaned."
+        size="sm"
+        footer={
+          <div className="flex w-full justify-end gap-2">
+            <Button kind="quiet" onClick={() => setConfirmDelete(null)}>
+              Cancel
+            </Button>
+            <Button
+              kind="destructive"
+              onClick={() => {
+                const category = confirmDelete;
+                setConfirmDelete(null);
+                if (category) void removeCategory(category);
+              }}
+            >
+              Delete category
+            </Button>
+          </div>
+        }
+      />
 
       {/* Merge tool */}
       <Modal

--- a/web/src/app/dashboard/company/ratios/RatiosView.tsx
+++ b/web/src/app/dashboard/company/ratios/RatiosView.tsx
@@ -22,6 +22,7 @@ import {
   RATIO_REGISTRY,
   type MetricGroup,
 } from "@/models/registry/ratios";
+import { previousPeriod } from "@/models/registry/line-items";
 import type { RatioResult } from "@/models";
 import {
   formatMoney,
@@ -252,7 +253,13 @@ export const RatiosView: React.FC = () => {
                             status={result.status}
                             band={result.status === "na" ? null : domain.band}
                             delta={result.period_delta ?? undefined}
-                            deltaCaption="vs prior period"
+                            // Name the prior period ("vs FY2024"), not a
+                            // generic "vs prior period" (B6b frame copy).
+                            deltaCaption={
+                              (period && previousPeriod(period)
+                                ? `vs ${previousPeriod(period)}`
+                                : undefined) ?? "vs prior period"
+                            }
                             formula={result.formula}
                             naReason={result.na_reason}
                             caption={result.benchmark_band ?? undefined}

--- a/web/src/app/dashboard/company/ratios/RatiosView.tsx
+++ b/web/src/app/dashboard/company/ratios/RatiosView.tsx
@@ -130,6 +130,8 @@ export const RatiosView: React.FC = () => {
   // Trend series: revenue / gross_profit / net_income across confirmed
   // income-statement periods (line-items.md §5 trend rows).
   const { trend } = useTrendsController(statements.statements, activeOrgId);
+  // B6b frame: the trends chart offers a "Data table" toggle (mirrors B1).
+  const [showTrendTable, setShowTrendTable] = useState(false);
 
   const grouped = useMemo(() => {
     const map = new Map<MetricGroup, RatioResult[]>();
@@ -301,39 +303,111 @@ export const RatiosView: React.FC = () => {
           })}
 
           <section aria-label="Trends" className="mb-6">
-            <h2 className="mb-2 text-[13px] font-medium uppercase tracking-wide text-text-2">
-              Trends
-            </h2>
+            <div className="mb-2 flex items-center justify-between">
+              <h2 className="text-[13px] font-medium uppercase tracking-wide text-text-2">
+                Trends
+              </h2>
+              {trend && trend.labels.length >= 2 ? (
+                // Chart data-table toggle per the B6b frame (mirrors B1).
+                <button
+                  type="button"
+                  onClick={() => setShowTrendTable((prev) => !prev)}
+                  className="rounded border border-border bg-bg-elev px-2 py-0.5 text-[12px] font-medium text-text-2 transition-colors duration-fast ease-standard hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                >
+                  {showTrendTable ? "Chart" : "Data table"}
+                </button>
+              ) : null}
+            </div>
             {trend && trend.labels.length >= 2 ? (
               <div className="rounded border border-border bg-bg p-4">
-                {/* Annual observations, not a continuous series — point
-                    markers + FY ticks at the data positions so N=2 reads
-                    as two observations (scales to more FYs). */}
-                <ChartLine
-                  pointMarkers
-                  yTickFormat={(value) => formatMoneyCompact(value, currency)}
-                  series={[
-                    {
-                      id: "revenue",
-                      label: "Revenue",
-                      color: "accent",
-                      points: trend.revenue,
-                    },
-                    {
-                      id: "gross",
-                      label: "Gross profit",
-                      color: "income",
-                      points: trend.grossProfit,
-                    },
-                    {
-                      id: "net",
-                      label: "Net income",
-                      color: "expense",
-                      points: trend.netIncome,
-                    },
-                  ]}
-                  xLabels={trend.labels}
-                />
+                {showTrendTable ? (
+                  <div className="max-lg:overflow-x-auto">
+                    <table
+                      className="w-full min-w-[420px] text-[13px]"
+                      aria-label="Trends data"
+                    >
+                      <thead>
+                        <tr className="border-b border-border text-left text-[11px] uppercase tracking-wide text-text-2">
+                          <th scope="col" className="py-1.5 font-medium">
+                            Period
+                          </th>
+                          <th
+                            scope="col"
+                            className="py-1.5 text-right font-medium"
+                          >
+                            Revenue
+                          </th>
+                          <th
+                            scope="col"
+                            className="py-1.5 text-right font-medium"
+                          >
+                            Gross profit
+                          </th>
+                          <th
+                            scope="col"
+                            className="py-1.5 text-right font-medium"
+                          >
+                            Net income
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {trend.labels.map((label, index) => (
+                          <tr
+                            key={label}
+                            className="border-b border-border last:border-b-0"
+                          >
+                            <td className="py-1.5 tabular-nums">{label}</td>
+                            <td className="py-1.5 text-right tabular-nums">
+                              {formatMoney(trend.revenue[index], currency, {
+                                decimals: 0,
+                              })}
+                            </td>
+                            <td className="py-1.5 text-right tabular-nums">
+                              {formatMoney(trend.grossProfit[index], currency, {
+                                decimals: 0,
+                              })}
+                            </td>
+                            <td className="py-1.5 text-right tabular-nums">
+                              {formatMoney(trend.netIncome[index], currency, {
+                                decimals: 0,
+                              })}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  /* Annual observations, not a continuous series — point
+                     markers + FY ticks at the data positions so N=2 reads
+                     as two observations (scales to more FYs). */
+                  <ChartLine
+                    pointMarkers
+                    yTickFormat={(value) => formatMoneyCompact(value, currency)}
+                    series={[
+                      {
+                        id: "revenue",
+                        label: "Revenue",
+                        color: "accent",
+                        points: trend.revenue,
+                      },
+                      {
+                        id: "gross",
+                        label: "Gross profit",
+                        color: "income",
+                        points: trend.grossProfit,
+                      },
+                      {
+                        id: "net",
+                        label: "Net income",
+                        color: "expense",
+                        points: trend.netIncome,
+                      },
+                    ]}
+                    xLabels={trend.labels}
+                  />
+                )}
               </div>
             ) : (
               <p className="rounded border border-border bg-bg px-4 py-6 text-center text-[13px] text-text-2">

--- a/web/src/app/dashboard/imports/ImportsView.tsx
+++ b/web/src/app/dashboard/imports/ImportsView.tsx
@@ -176,7 +176,9 @@ export const ImportsView: React.FC = () => {
       </section>
 
       <section aria-label="Import history" className="mt-6">
-        <h2 className="mb-2 text-[13px] font-medium text-text">History</h2>
+        <h2 className="mb-2 text-[13px] font-medium text-text">
+          Import history
+        </h2>
         {imports.loading && sortedJobs.length === 0 ? (
           <div>
             {[...Array(4)].map((_, i) => (
@@ -191,6 +193,11 @@ export const ImportsView: React.FC = () => {
               <ImportJobRow
                 key={job.id}
                 job={job}
+                failureMessage={
+                  job.status === "failed"
+                    ? failureMessage(job.error_code)
+                    : undefined
+                }
                 onOpen={() => router.push(`/dashboard/imports/${job.id}`)}
               />
             ))}

--- a/web/src/app/dashboard/imports/[jobId]/JobDetailView.tsx
+++ b/web/src/app/dashboard/imports/[jobId]/JobDetailView.tsx
@@ -57,7 +57,10 @@ export const JobDetailView: React.FC = () => {
   const imports = useImportsController(activeOrgId);
   const { items: categories } = useCategoriesController(activeOrgId);
   const [committing, setCommitting] = useState(false);
-  const [toast, setToast] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    kind: "info" | "error";
+  } | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -104,7 +107,10 @@ export const JobDetailView: React.FC = () => {
       const result = await imports.confirm(job.id);
       router.push(`/dashboard/transactions?imported=${result.imported}`);
     } catch (err) {
-      setToast(err instanceof Error ? err.message : "Confirm failed");
+      setToast({
+        message: err instanceof Error ? err.message : "Confirm failed",
+        kind: "error",
+      });
       setCommitting(false);
     }
   };
@@ -113,6 +119,25 @@ export const JobDetailView: React.FC = () => {
     if (!job) return;
     await imports.discard(job.id);
     router.push("/dashboard/imports");
+  };
+
+  /**
+   * B3b "Discard N duplicates": flags every duplicate for discard —
+   * resets explicit re-includes; the commit performs the actual discard
+   * (flows/import.md §2, duplicates excluded unless re-included).
+   */
+  const discardDuplicates = async () => {
+    const reIncluded = staged.filter(
+      (row) => row.is_duplicate && row.include_duplicate,
+    );
+    for (const row of reIncluded) {
+      await imports.setIncludeDuplicate(row.id, false);
+    }
+    const flagged = staged.filter((row) => row.is_duplicate).length;
+    setToast({
+      message: `${flagged} ${flagged === 1 ? "duplicate" : "duplicates"} flagged for discard — recoverable for 30 days after import.`,
+      kind: "info",
+    });
   };
 
   if (loadError) {
@@ -240,11 +265,19 @@ export const JobDetailView: React.FC = () => {
         title={title}
         description={job.ai_summary ?? undefined}
         actions={
-          job.anomalies.length > 0 ? (
-            <Tag tint="warn" size="md">
-              {job.anomalies.length} anomalies found
-            </Tag>
-          ) : undefined
+          <div className="flex items-center gap-2">
+            {job.anomalies.length > 0 ? (
+              <Tag tint="warn" size="md">
+                {job.anomalies.length}{" "}
+                {job.anomalies.length === 1 ? "anomaly" : "anomalies"} found
+              </Tag>
+            ) : null}
+            {/* Whole-job abort — demoted out of the review band (the B3b
+                frame's band carries only the discard-dupes/import pair). */}
+            <Button kind="quiet" size="sm" onClick={() => void discard()}>
+              Discard import
+            </Button>
+          </div>
         }
       />
 
@@ -253,7 +286,7 @@ export const JobDetailView: React.FC = () => {
         duplicateCount={duplicateCount}
         state={committing ? "committing" : "reviewing"}
         onCommit={() => void confirm()}
-        onDiscardAll={() => void discard()}
+        onDiscardDuplicates={() => void discardDuplicates()}
         warnings={
           job.warnings.length > 0 ? (
             <Banner kind="warn">{job.warnings.join(" · ")}</Banner>
@@ -319,9 +352,19 @@ export const JobDetailView: React.FC = () => {
         </table>
       </section>
 
+      {/* Reassurance footer (B3b frame): the 30-day recoverability is a
+          trust promise — same copy family as the Reports expiry caption. */}
+      <p className="mt-3 text-[12px] text-text-2">
+        {importCount} {importCount === 1 ? "row" : "rows"} will join your
+        ledger.
+        {duplicateCount > 0
+          ? " Discarded duplicates stay recoverable for 30 days."
+          : ""}
+      </p>
+
       <ToastLayer
-        message={toast}
-        kind="error"
+        message={toast?.message ?? null}
+        kind={toast?.kind ?? "info"}
         onDismiss={() => setToast(null)}
       />
     </>

--- a/web/src/app/dashboard/reports/ReportsView.tsx
+++ b/web/src/app/dashboard/reports/ReportsView.tsx
@@ -204,7 +204,9 @@ export const ReportsView: React.FC = () => {
       </section>
 
       <section aria-label="Artifact history" className="mt-6">
-        <h2 className="mb-2 text-[13px] font-medium text-text">History</h2>
+        <h2 className="mb-2 text-[13px] font-medium text-text">
+          Artifact history
+        </h2>
         {reports.loading && reports.artifacts.length === 0 ? (
           <div>
             {[...Array(4)].map((_, i) => (
@@ -233,6 +235,12 @@ export const ReportsView: React.FC = () => {
             ))}
           </ul>
         )}
+        {/* Expiry caption (B5 frame) — same trust-copy family as the
+            B3b recoverability footer. */}
+        <p className="mt-2 text-[12px] text-text-2">
+          Artifacts expire after 30 days. You can regenerate any report at any
+          time.
+        </p>
       </section>
 
       <ToastLayer message={toast} onDismiss={() => setToast(null)} />

--- a/web/src/app/dashboard/settings/SettingsView.tsx
+++ b/web/src/app/dashboard/settings/SettingsView.tsx
@@ -33,6 +33,25 @@ import Switch from "@/components/ui/Switch";
 import PageHeader from "../PageHeader";
 import ToastLayer from "../ToastLayer";
 
+/**
+ * Fiscal-year-end options — the wire format stays MM-DD (api.md), the
+ * labels read human ("31 December") per the B9 frame.
+ */
+const FISCAL_YEAR_END_OPTIONS = [
+  { value: "01-31", label: "31 January" },
+  { value: "02-28", label: "28 February" },
+  { value: "03-31", label: "31 March" },
+  { value: "04-30", label: "30 April" },
+  { value: "05-31", label: "31 May" },
+  { value: "06-30", label: "30 June" },
+  { value: "07-31", label: "31 July" },
+  { value: "08-31", label: "31 August" },
+  { value: "09-30", label: "30 September" },
+  { value: "10-31", label: "31 October" },
+  { value: "11-30", label: "30 November" },
+  { value: "12-31", label: "31 December" },
+];
+
 const Section: React.FC<{
   title: string;
   description?: string;
@@ -245,18 +264,28 @@ export const SettingsView: React.FC = () => {
                 </FormRow>
                 <FormRow
                   label="Fiscal year end"
-                  helper="MM-DD — defines FY periods for statements and CIT."
+                  helper="Defines FY periods for statements and CIT."
                 >
-                  {(id) => (
-                    <Input
-                      id={id}
-                      value={
-                        fiscalYearEnd ?? activeOrg?.fiscal_year_end ?? "12-31"
-                      }
-                      onChange={(event) => setFiscalYearEnd(event.target.value)}
-                      placeholder="12-31"
-                    />
-                  )}
+                  {() => {
+                    const fyeValue =
+                      fiscalYearEnd ?? activeOrg?.fiscal_year_end ?? "12-31";
+                    // Non-month-end legacy values stay selectable raw.
+                    const options = FISCAL_YEAR_END_OPTIONS.some(
+                      (option) => option.value === fyeValue,
+                    )
+                      ? FISCAL_YEAR_END_OPTIONS
+                      : [
+                          { value: fyeValue, label: fyeValue },
+                          ...FISCAL_YEAR_END_OPTIONS,
+                        ];
+                    return (
+                      <Select
+                        options={options}
+                        value={fyeValue}
+                        onValueChange={setFiscalYearEnd}
+                      />
+                    );
+                  }}
                 </FormRow>
               </>
             ) : null}
@@ -453,10 +482,12 @@ export const SettingsView: React.FC = () => {
             {() => (
               <SegmentedControl
                 aria-label="Theme"
+                // Light | Dark | System — mirrors the toggle's cycle
+                // order (Figma B9 frame).
                 options={[
                   { value: "light", label: "Light" },
-                  { value: "system", label: "System" },
                   { value: "dark", label: "Dark" },
+                  { value: "system", label: "System" },
                 ]}
                 value={theme}
                 onValueChange={(value) =>
@@ -468,16 +499,31 @@ export const SettingsView: React.FC = () => {
         </Section>
       </div>
 
-      {/* MI-15 danger flow: typed confirm; grace handled by the controller */}
+      {/* MI-15 danger flow (converged model, Figma B9 190:4223 + B9b
+          208:4194): type the ORG NAME to confirm, 5s danger-armed CTA,
+          "Export first" escape hatch; grace handled by the controller. */}
       <Modal
         open={purgeOpen}
         onOpenChange={setPurgeOpen}
         title="Delete account & all data"
         description="Everything — ledger, statements, filings, links — is deleted after a 7-day grace window. Writes are blocked while the window is open."
         variant="danger"
-        confirmPhrase="DELETE EVERYTHING"
+        confirmPhrase={activeOrg?.name ?? ""}
         confirmLabel="Schedule deletion"
         onConfirm={() => void startPurge()}
+        footer={
+          <Button
+            size="sm"
+            kind="quiet"
+            onClick={() => {
+              setPurgeOpen(false);
+              void startExport();
+              setToast("Preparing your export — deletion can wait.");
+            }}
+          >
+            Export first
+          </Button>
+        }
       />
 
       <ToastLayer message={toast} onDismiss={() => setToast(null)} />

--- a/web/src/app/dashboard/transactions/TransactionsView.tsx
+++ b/web/src/app/dashboard/transactions/TransactionsView.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/controllers";
 import { useTransactionsController } from "@/controllers/use-transactions";
 import { formatMoney } from "@/lib/format";
-import type { TxnEntry, TxnFilters } from "@/models";
+import type { AnomalySeverity, TxnEntry, TxnFilters } from "@/models";
 import AnomalyBadge from "@/components/ui/AnomalyBadge";
 import Banner from "@/components/ui/Banner";
 import BulkActionBar from "@/components/ui/BulkActionBar";
@@ -52,6 +52,21 @@ import ToastLayer from "../ToastLayer";
 // Registry default category color — data, not styling (documented raw-hex
 // exception; mirrors the mock categories default).
 const FALLBACK_CATEGORY_COLOR = "#6E6E76";
+
+/** B2b explain panel: severity reads human, never the raw enum. */
+const SEVERITY_LABEL: Record<AnomalySeverity, string> = {
+  info: "Info",
+  warn: "Warning",
+};
+
+/** Median amount of the comparable set (B2b explain footer). */
+const median = (txns: TxnEntry[]): number => {
+  const sorted = [...txns].map((txn) => txn.amount).sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+};
 
 const SOURCE_OPTIONS = [
   { value: "all", label: "All sources" },
@@ -347,6 +362,21 @@ export const TransactionsView: React.FC = () => {
       closeInspector();
     } catch (err) {
       setDraftError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  /** B2b "Mark expected": clears the flags — the AI-trust affordance. */
+  const markExpected = async () => {
+    if (!activeTxn) return;
+    setSaving(true);
+    try {
+      await txns.update(activeTxn.id, { anomalies: [] });
+      setToast("Marked expected — this pattern won't be flagged again.");
+      closeInspector();
+    } catch (err) {
+      setToast(err instanceof Error ? err.message : "Update failed");
     } finally {
       setSaving(false);
     }
@@ -692,6 +722,11 @@ export const TransactionsView: React.FC = () => {
                       excluded_from_reports: !txn.excluded_from_reports,
                     })
                   }
+                  onExplainAnomaly={
+                    txn.anomalies.length > 0
+                      ? () => openInspector({ kind: "anomaly", txnId: txn.id })
+                      : undefined
+                  }
                 />
               ))}
             </tbody>
@@ -984,7 +1019,9 @@ export const TransactionsView: React.FC = () => {
         </div>
       </Inspector>
 
-      {/* Anomaly-explain inspector (design.md §8.2 variant) */}
+      {/* Anomaly-explain inspector (design.md §8.2 variant, B2b frame
+          208:3967: humanized severity, provenance/rule-version line,
+          median footer, Cancel / Mark expected actions) */}
       <Inspector
         open={inspector.kind === "anomaly"}
         onClose={closeInspector}
@@ -993,16 +1030,16 @@ export const TransactionsView: React.FC = () => {
         footer={
           <div className="flex justify-end gap-2">
             <Button kind="quiet" size="sm" onClick={closeInspector}>
-              Dismiss
+              Cancel
             </Button>
+            {/* The AI-trust affordance: expected patterns stop flagging. */}
             <Button
               size="sm"
-              onClick={() =>
-                activeTxn &&
-                openInspector({ kind: "record", txnId: activeTxn.id })
-              }
+              loading={saving}
+              disabled={!activeTxn || activeTxn.anomalies.length === 0}
+              onClick={() => void markExpected()}
             >
-              Review transaction
+              Mark expected
             </Button>
           </div>
         }
@@ -1032,32 +1069,63 @@ export const TransactionsView: React.FC = () => {
               </div>
               <div className="flex justify-between gap-2">
                 <dt className="text-text-2">Severity</dt>
-                <dd className="uppercase">{activeTxn.anomalies[0].severity}</dd>
+                {/* Human-cased, never the raw enum (B2b frame). */}
+                <dd>{SEVERITY_LABEL[activeTxn.anomalies[0].severity]}</dd>
               </div>
             </dl>
+            {/* Provenance line (B2b frame): when + which rule build. */}
+            <p className="text-[12px] text-text-2">
+              Detected{" "}
+              {formatIso(
+                activeTxn.anomalies[0].detected_at ?? activeTxn.created_at,
+                "d MMM yyyy",
+              )}{" "}
+              · rule:{" "}
+              <span className="font-mono">
+                {activeTxn.anomalies[0].rule_id}{" "}
+                {activeTxn.anomalies[0].rule_version ?? "v1"}
+              </span>
+            </p>
             <section aria-label="Comparable transactions">
               <h3 className="mb-1 text-[11px] font-medium uppercase tracking-wide text-text-2">
                 Comparable transactions
+                {" — "}
+                {categoryById.get(activeTxn.category_id)?.name ??
+                  activeTxn.category_id}
               </h3>
               {comparableTxns.length === 0 ? (
                 <p className="text-[13px] text-text-2">
                   No comparable transactions in this category yet.
                 </p>
               ) : (
-                <ul className="space-y-1 text-[13px]">
-                  {comparableTxns.map((txn) => (
-                    <li key={txn.id} className="flex justify-between gap-2">
-                      <span className="truncate text-text-2">
-                        {formatIso(txn.txn_date, "d MMM")} · {txn.description}
-                      </span>
-                      <MoneyCell
-                        amount={txn.amount}
-                        direction={txn.direction}
-                        currency={currency}
-                      />
-                    </li>
-                  ))}
-                </ul>
+                <>
+                  <ul className="space-y-1 text-[13px]">
+                    {comparableTxns.map((txn) => (
+                      <li key={txn.id} className="flex justify-between gap-2">
+                        <span className="truncate text-text-2">
+                          {formatIso(txn.txn_date, "d MMM")} · {txn.description}
+                        </span>
+                        <MoneyCell
+                          amount={txn.amount}
+                          direction={txn.direction}
+                          currency={currency}
+                        />
+                      </li>
+                    ))}
+                  </ul>
+                  {/* Median footer (B2b frame) — the flagged amount reads
+                      against the category's normal. */}
+                  <p className="mt-2 border-t border-border pt-2 text-[12px] text-text-2">
+                    Median{" "}
+                    {formatMoney(median(comparableTxns), currency, {
+                      decimals: 0,
+                    })}{" "}
+                    across {comparableTxns.length} comparable{" "}
+                    {comparableTxns.length === 1
+                      ? "transaction"
+                      : "transactions"}
+                  </p>
+                </>
               )}
             </section>
           </div>

--- a/web/src/components/docs/ScalarApiReference.tsx
+++ b/web/src/components/docs/ScalarApiReference.tsx
@@ -43,6 +43,9 @@ export function ScalarApiReference() {
         forceDarkModeState: resolvedTheme,
         hideDarkModeToggle: true,
         withDefaultFonts: false,
+        // Scalar's dev toolbar stays off the public reference —
+        // configuration, not a fork (defaults to "localhost").
+        showToolbar: "never",
       }}
     />
   );

--- a/web/src/components/docs/ScalarApiReference.tsx
+++ b/web/src/components/docs/ScalarApiReference.tsx
@@ -44,8 +44,9 @@ export function ScalarApiReference() {
         hideDarkModeToggle: true,
         withDefaultFonts: false,
         // Scalar's dev toolbar stays off the public reference —
-        // configuration, not a fork (defaults to "localhost").
-        showToolbar: "never",
+        // configuration, not a fork (defaults to "localhost";
+        // `showToolbar` is the deprecated alias of this option).
+        showDeveloperTools: "never",
       }}
     />
   );

--- a/web/src/components/ui/ChartDonut.test.tsx
+++ b/web/src/components/ui/ChartDonut.test.tsx
@@ -23,6 +23,10 @@ describe("Chart/Donut (design.md §8.2b)", () => {
     );
     expect(screen.getByText("₦100k")).toBeInTheDocument();
     expect(screen.getByText("June")).toBeInTheDocument();
+    // Center stack order per the Figma master: caption above, value below.
+    const captionY = Number(screen.getByText("June").getAttribute("y"));
+    const valueY = Number(screen.getByText("₦100k").getAttribute("y"));
+    expect(captionY).toBeLessThan(valueY);
   });
 
   it("legend variants right / bottom / none", () => {

--- a/web/src/components/ui/ChartDonut.tsx
+++ b/web/src/components/ui/ChartDonut.tsx
@@ -98,26 +98,28 @@ export const ChartDonut: React.FC<ChartDonutProps> = ({
             />
           ))}
         </g>
+        {/* Center stack per the Figma master (126:1183): caption on top,
+            compact value below. */}
         {centerTotal ? (
           <>
-            <text
-              x="60"
-              y="58"
-              textAnchor="middle"
-              className="fill-text text-[14px] font-semibold tabular-nums"
-            >
-              {centerTotal}
-            </text>
             {centerCaption ? (
               <text
                 x="60"
-                y="72"
+                y="54"
                 textAnchor="middle"
-                className="fill-text-2 text-[9px]"
+                className="fill-text-2 text-[10px]"
               >
                 {centerCaption}
               </text>
             ) : null}
+            <text
+              x="60"
+              y={centerCaption ? 70 : 64}
+              textAnchor="middle"
+              className="fill-text text-[15px] font-semibold tabular-nums"
+            >
+              {centerTotal}
+            </text>
           </>
         ) : null}
       </svg>

--- a/web/src/components/ui/CodeSnippet.tsx
+++ b/web/src/components/ui/CodeSnippet.tsx
@@ -59,7 +59,10 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({
         data-state={copied ? "copied" : "idle"}
         onClick={onCopy}
         className={cn(
-          "absolute right-2 top-2 rounded border border-border p-1.5",
+          // Solid backdrop: long single-line commands scroll beneath the
+          // floated button — the fill keeps the tail from showing through
+          // (audit: copy button clipped "… redis" at 1440).
+          "absolute right-2 top-2 rounded border border-border bg-bg-editorial p-1.5",
           "transition-colors duration-fast ease-standard",
           copied ? "text-income" : "text-text-2 hover:text-text",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",

--- a/web/src/components/ui/ImportJobRow.test.tsx
+++ b/web/src/components/ui/ImportJobRow.test.tsx
@@ -51,13 +51,25 @@ describe("ImportJobRow (design.md §8.2b)", () => {
     expect(screen.getByText("Processing")).toBeInTheDocument();
   });
 
-  it("failed renders the taxonomy code", () => {
+  it("failed reads human; the taxonomy code demotes to a details disclosure", () => {
     render(
       <ImportJobRow
         job={job({ status: "failed", error_code: "unreadable_file" })}
+        failureMessage="We could not read this file — try a CSV export."
       />,
     );
+    expect(
+      screen.getByText("We could not read this file — try a CSV export."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Details")).toBeInTheDocument();
     expect(screen.getByText("unreadable_file")).toBeInTheDocument();
+  });
+
+  it("parked review jobs tag blue 'Ready for review' (B3 frame)", () => {
+    render(<ImportJobRow job={job({ confirmed: false, imported: 0 })} />);
+    const tag = screen.getByText("Ready for review");
+    expect(tag).toBeInTheDocument();
+    expect(tag).toHaveAttribute("data-tint", "info");
   });
 
   it("completed-empty and completed-bank variants", () => {

--- a/web/src/components/ui/ImportJobRow.tsx
+++ b/web/src/components/ui/ImportJobRow.tsx
@@ -47,12 +47,18 @@ const FILE_ICON = {
 } as const;
 
 /** Figma caption line per status. */
-const caption = (job: ImportJob, status: ImportJobRowStatus): string => {
+const caption = (
+  job: ImportJob,
+  status: ImportJobRowStatus,
+  failureMessage?: string,
+): string => {
   switch (status) {
     case "processing":
       return "Parsing…";
     case "failed":
-      return job.error_code ?? "failed";
+      // Human sentence (B3 frame tone); the raw taxonomy code moves to
+      // the details disclosure under the row.
+      return failureMessage ?? "Import failed — nothing was imported.";
     case "completed-empty":
       return "0 transactions found — check file contents";
     case "needs-review": {
@@ -94,7 +100,9 @@ const STATUS_TAG: Record<
 > = {
   processing: { label: "Processing", tint: "info" },
   completed: { label: "Completed", tint: "success" },
-  "needs-review": { label: "Needs review", tint: "warn" },
+  // B3 frame (ImportJobRow 127:1238): blue "Ready for review" — an
+  // invitation, not a warning.
+  "needs-review": { label: "Ready for review", tint: "info" },
   "completed-bank": { label: "Completed", tint: "success" },
   "completed-empty": { label: "Empty", tint: "neutral" },
   failed: { label: "Failed", tint: "error" },
@@ -102,12 +110,15 @@ const STATUS_TAG: Record<
 
 export interface ImportJobRowProps {
   job: ImportJob;
+  /** Human failure sentence (flows/import.md §3 taxonomy copy). */
+  failureMessage?: string;
   onOpen?: () => void;
   className?: string;
 }
 
 export const ImportJobRow: React.FC<ImportJobRowProps> = ({
   job,
+  failureMessage,
   onOpen,
   className,
 }) => {
@@ -139,10 +150,10 @@ export const ImportJobRow: React.FC<ImportJobRowProps> = ({
           <span
             className={cn(
               "block truncate leading-4",
-              status === "failed" ? "font-mono text-expense" : "text-text-2",
+              status === "failed" ? "text-expense" : "text-text-2",
             )}
           >
-            {caption(job, status)}
+            {caption(job, status, failureMessage)}
           </span>
         </span>
         <Tag tint={tag.tint}>{tag.label}</Tag>
@@ -150,6 +161,16 @@ export const ImportJobRow: React.FC<ImportJobRowProps> = ({
           {when}
         </span>
       </button>
+      {status === "failed" && job.error_code ? (
+        // Raw taxonomy code demoted to a disclosure (B3 frame: failed
+        // meta reads human; the code stays reachable for support).
+        <details className="border-b border-border px-3 py-1.5 text-[11px] text-text-2">
+          <summary className="cursor-pointer select-none">Details</summary>
+          <code className="mt-1 block font-mono text-expense">
+            {job.error_code}
+          </code>
+        </details>
+      ) : null}
     </li>
   );
 };

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -175,7 +175,9 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
           href="/"
           className="mr-4 rounded text-sm font-semibold tracking-tight text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
-          expendit
+          {/* Brand mark with the accent dot — matches the footer
+              wordmark (frames carry it on nav + footer). */}
+          expendit<span className="text-accent">.</span>
         </Link>
 
         {links.map((link) =>

--- a/web/src/components/ui/StagedReviewHeader.test.tsx
+++ b/web/src/components/ui/StagedReviewHeader.test.tsx
@@ -4,26 +4,31 @@ import userEvent from "@testing-library/user-event";
 import StagedReviewHeader from "./StagedReviewHeader";
 
 describe("StagedReviewHeader (design.md §8.2b, MI-3)", () => {
-  it("confirm button carries the MI-3 counts", async () => {
+  it("splits the CTAs per the B3b frame — Import N primary, Discard N duplicates secondary", async () => {
     const onCommit = vi.fn();
+    const onDiscardDuplicates = vi.fn();
     render(
       <StagedReviewHeader
         importCount={209}
         duplicateCount={5}
         onCommit={onCommit}
+        onDiscardDuplicates={onDiscardDuplicates}
       />,
     );
-    const commit = screen.getByRole("button", {
-      name: "Import 209, discard 5 duplicates",
-    });
-    expect(commit).toHaveTextContent("Import 209 / discard 5 duplicates");
+    const commit = screen.getByRole("button", { name: "Import 209" });
     await userEvent.click(commit);
     expect(onCommit).toHaveBeenCalled();
+    const discard = screen.getByRole("button", {
+      name: "Discard 5 duplicates",
+    });
+    await userEvent.click(discard);
+    expect(onDiscardDuplicates).toHaveBeenCalled();
   });
 
-  it("no-duplicates copy drops the discard clause", () => {
+  it("no-duplicates state drops the discard affordance", () => {
     render(<StagedReviewHeader importCount={42} duplicateCount={0} />);
     expect(screen.getByText("Import 42")).toBeInTheDocument();
+    expect(screen.queryByText(/Discard/)).not.toBeInTheDocument();
   });
 
   it("committing state disables and shows progress copy", () => {
@@ -35,9 +40,7 @@ describe("StagedReviewHeader (design.md §8.2b, MI-3)", () => {
       />,
     );
     expect(screen.getByText("Committing…")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /Import 209, discard/ }),
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Committing/ })).toBeDisabled();
   });
 
   it("renders the warnings-banner slot", () => {

--- a/web/src/components/ui/StagedReviewHeader.tsx
+++ b/web/src/components/ui/StagedReviewHeader.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 /**
- * StagedReviewHeader — design.md §8.2b (MI-3): counts ("Import 209 /
- * discard 5 duplicates") · state reviewing / committing (cascade at the
+ * StagedReviewHeader — design.md §8.2b (MI-3), CTA semantics per the
+ * B3b frame (183:2437): counts line · secondary "Discard N duplicates"
+ * (the discard decision is its own affordance) · primary "Import N"
+ * (single verb — the commit discards flagged duplicates per
+ * flows/import.md §2) · state reviewing / committing (cascade at the
  * table) · warnings-banner slot.
  */
 
@@ -12,10 +15,12 @@ import Button from "./Button";
 
 export interface StagedReviewHeaderProps {
   importCount: number;
+  /** Flagged duplicates currently marked for discard. */
   duplicateCount: number;
   state?: "reviewing" | "committing";
   onCommit?: () => void;
-  onDiscardAll?: () => void;
+  /** Flags every duplicate for discard (resets explicit re-includes). */
+  onDiscardDuplicates?: () => void;
   /** Warnings-banner slot (partial-extraction notices). */
   warnings?: React.ReactNode;
   className?: string;
@@ -26,7 +31,7 @@ export const StagedReviewHeader: React.FC<StagedReviewHeaderProps> = ({
   duplicateCount,
   state = "reviewing",
   onCommit,
-  onDiscardAll,
+  onDiscardDuplicates,
   warnings,
   className,
 }) => (
@@ -47,29 +52,20 @@ export const StagedReviewHeader: React.FC<StagedReviewHeaderProps> = ({
             · <span className="tabular-nums text-warn">
               {duplicateCount}
             </span>{" "}
-            {duplicateCount === 1 ? "duplicate" : "duplicates"} flagged
+            {duplicateCount === 1 ? "duplicate" : "duplicates"} flagged for
+            discard
           </span>
         ) : null}
       </p>
-      <Button kind="quiet" size="sm" onClick={onDiscardAll}>
-        Discard all
-      </Button>
-      {/* MI-3: the confirm button carries the counts. */}
-      <Button
-        size="sm"
-        loading={state === "committing"}
-        onClick={onCommit}
-        aria-label={`Import ${importCount}, discard ${duplicateCount} ${
-          duplicateCount === 1 ? "duplicate" : "duplicates"
-        }`}
-      >
-        {state === "committing"
-          ? "Committing…"
-          : duplicateCount > 0
-            ? `Import ${importCount} / discard ${duplicateCount} ${
-                duplicateCount === 1 ? "duplicate" : "duplicates"
-              }`
-            : `Import ${importCount}`}
+      {duplicateCount > 0 ? (
+        <Button kind="quiet" size="sm" onClick={onDiscardDuplicates}>
+          Discard {duplicateCount}{" "}
+          {duplicateCount === 1 ? "duplicate" : "duplicates"}
+        </Button>
+      ) : null}
+      {/* MI-3: the confirm button carries the import count. */}
+      <Button size="sm" loading={state === "committing"} onClick={onCommit}>
+        {state === "committing" ? "Committing…" : `Import ${importCount}`}
       </Button>
     </div>
   </header>

--- a/web/src/components/ui/StatementView.test.tsx
+++ b/web/src/components/ui/StatementView.test.tsx
@@ -39,11 +39,13 @@ describe("StatementView (design.md §8.2, B6)", () => {
     );
     expect(screen.getByText("Balance sheet")).toBeInTheDocument();
     expect(screen.getByText("2026-Q2")).toBeInTheDocument();
-    expect(screen.getByText("total_assets")).toBeInTheDocument();
+    // Human reading labels, not raw canonical keys (Figma 98:743).
+    expect(screen.getByText("Total assets")).toBeInTheDocument();
+    expect(screen.queryByText("total_assets")).not.toBeInTheDocument();
     expect(screen.getByText("₦5,000,000.00")).toHaveClass("tabular-nums");
   });
 
-  it("flags derived rows with the formula affordance", () => {
+  it("flags derived rows with the ƒ derived chip (formula tooltip)", () => {
     render(
       <StatementView
         kind="balance_sheet"
@@ -53,9 +55,63 @@ describe("StatementView (design.md §8.2, B6)", () => {
       />,
     );
     expect(
-      screen.getByRole("button", { name: "Derived — how we got this" }),
+      screen.getByRole("button", { name: "ƒ derived" }),
     ).toBeInTheDocument();
     expect(document.querySelector('[data-derived="true"]')).not.toBeNull();
+  });
+
+  it("renders the identity-check footer when the statement ties out", () => {
+    render(
+      <StatementView
+        kind="balance_sheet"
+        period="2026-Q2"
+        lineItems={[
+          ...lineItems,
+          {
+            id: "li-3",
+            statement_id: "st-1",
+            canonical_key: "total_liabilities",
+            source_label: "Total liabilities",
+            amount: 3000000,
+            status: "mapped",
+            confidence: 0.97,
+            mapped_by: "ai",
+            derived: false,
+          },
+        ]}
+      />,
+    );
+    const footer = document.querySelector('[data-identity="pass"]');
+    expect(footer).not.toBeNull();
+    expect(footer).toHaveTextContent(
+      "Identity check — Assets = Liabilities + Equity",
+    );
+  });
+
+  it("counts unmapped rows in the header tag and tags the row", () => {
+    render(
+      <StatementView
+        kind="balance_sheet"
+        period="2026-Q2"
+        lineItems={[
+          ...lineItems,
+          {
+            id: "li-4",
+            statement_id: "st-1",
+            canonical_key: null,
+            source_label: "Sundry accruals",
+            amount: 120000,
+            status: "unmapped",
+            confidence: 0.4,
+            mapped_by: "ai",
+            derived: false,
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("1 unmapped")).toBeInTheDocument();
+    expect(screen.getByText("Sundry accruals")).toBeInTheDocument();
+    expect(screen.getByText("unmapped")).toBeInTheDocument();
   });
 
   it("renders mapping-warning badges and the period-selector slot", () => {

--- a/web/src/components/ui/StatementView.tsx
+++ b/web/src/components/ui/StatementView.tsx
@@ -1,22 +1,69 @@
 "use client";
 
 /**
- * StatementView — design.md §8.2: kind balance_sheet / income_statement /
- * cash_flow · derived rows flagged (formula note) · mapping-warning
- * badges · period-selector header (pages.md B6 statement view).
+ * StatementView — design.md §8.2 + Figma 98:743: kind balance_sheet /
+ * income_statement / cash_flow · human line labels from the canonical
+ * vocabulary (models registry) · derived rows bold + "ƒ derived" chip
+ * (formula tooltip) · unmapped count tag in the header · identity-check
+ * footer (green when the statement ties out) · mapping-warning badges ·
+ * period-selector header (pages.md B6 statement view).
  */
 
 import React from "react";
-import { Calculator, TriangleAlert } from "lucide-react";
+import { Check, TriangleAlert } from "lucide-react";
 import type { LineItem, StatementKind } from "@/models";
+import {
+  CANONICAL_KEY_LABELS,
+  IDENTITY_TOLERANCE,
+  type CanonicalKey,
+} from "@/models/registry/line-items";
 import { cn } from "@/lib/cn";
 import { formatMoney } from "@/lib/format";
+import Tag from "./Tag";
 import Tooltip from "./Tooltip";
 
 const KIND_LABEL: Record<StatementKind, string> = {
   balance_sheet: "Balance sheet",
   income_statement: "Income statement",
   cash_flow: "Cash flow",
+};
+
+/**
+ * Statement identities (line-items.md §4) rendered as the footer check —
+ * the Figma frame's green "Assets = Liabilities + Equity" band,
+ * generalized per kind.
+ */
+const IDENTITY_CHECKS: Record<
+  StatementKind,
+  { label: string; left: CanonicalKey; right: Array<[CanonicalKey, 1 | -1]> }
+> = {
+  balance_sheet: {
+    label: "Assets = Liabilities + Equity",
+    left: "total_assets",
+    right: [
+      ["total_liabilities", 1],
+      ["equity", 1],
+    ],
+  },
+  income_statement: {
+    label: "Net income = Operating profit + Interest income − Interest expense − Tax",
+    left: "net_income",
+    right: [
+      ["operating_profit", 1],
+      ["interest_income", 1],
+      ["interest_expense", -1],
+      ["tax_expense", -1],
+    ],
+  },
+  cash_flow: {
+    label: "Net change in cash = CFO + CFI + CFF",
+    left: "net_change_in_cash",
+    right: [
+      ["cfo", 1],
+      ["cfi", 1],
+      ["cff", 1],
+    ],
+  },
 };
 
 export interface StatementViewProps {
@@ -42,77 +89,144 @@ export const StatementView: React.FC<StatementViewProps> = ({
   formulaNotes = {},
   periodSelector,
   className,
-}) => (
-  <section
-    data-kind={kind}
-    className={cn("rounded border border-border", className)}
-  >
-    <header className="flex items-center justify-between gap-3 border-b border-border bg-bg-elev px-4 py-3">
-      <div>
-        <h3 className="text-sm font-semibold text-text">{KIND_LABEL[kind]}</h3>
-        <p className="text-[13px] tabular-nums text-text-2">{period}</p>
-      </div>
-      {periodSelector}
-    </header>
+}) => {
+  const unmappedCount = lineItems.filter(
+    (item) => item.status === "unmapped",
+  ).length;
 
-    {mappingWarnings.length > 0 ? (
-      <div className="border-b border-border px-4 py-2">
-        {mappingWarnings.map((warning) => (
-          <span
-            key={warning}
-            className="mr-1.5 inline-flex items-center gap-1 rounded border border-warn/40 bg-warn/10 px-1.5 py-0 text-[11px] font-medium text-warn"
-          >
-            <TriangleAlert aria-hidden className="h-3 w-3" />
-            {warning}
-          </span>
-        ))}
-      </div>
-    ) : null}
+  const valueOf = (key: CanonicalKey): number | undefined =>
+    lineItems.find((item) => item.canonical_key === key)?.amount;
+  const identity = IDENTITY_CHECKS[kind];
+  const leftValue = valueOf(identity.left);
+  const rightValue = identity.right.reduce<number | undefined>(
+    (sum, [key, sign]) => {
+      const value = valueOf(key);
+      return sum === undefined || value === undefined
+        ? undefined
+        : sum + sign * value;
+    },
+    0,
+  );
+  const identityHolds =
+    leftValue !== undefined && rightValue !== undefined
+      ? Math.abs(leftValue - rightValue) <=
+        IDENTITY_TOLERANCE * Math.max(Math.abs(leftValue), 1)
+      : null;
 
-    {/* Mobile canon: the statement grid scrolls inside its container
-        below lg — the page itself never side-scrolls. */}
-    <div className="max-lg:overflow-x-auto">
-      <table className="w-full text-[13px]">
-        <tbody>
-          {lineItems.map((item) => (
-            <tr
-              key={item.id}
-              data-derived={item.derived || undefined}
-              className="border-b border-border last:border-b-0"
+  return (
+    <section
+      data-kind={kind}
+      className={cn("rounded border border-border", className)}
+    >
+      <header className="flex items-center justify-between gap-3 border-b border-border bg-bg-elev px-4 py-3">
+        <div>
+          <h3 className="text-sm font-semibold text-text">
+            {KIND_LABEL[kind]}
+          </h3>
+          <p className="text-[13px] tabular-nums text-text-2">{period}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {unmappedCount > 0 ? (
+            <Tag tint="warn">{unmappedCount} unmapped</Tag>
+          ) : null}
+          {periodSelector}
+        </div>
+      </header>
+
+      {mappingWarnings.length > 0 ? (
+        <div className="border-b border-border px-4 py-2">
+          {mappingWarnings.map((warning) => (
+            <span
+              key={warning}
+              className="mr-1.5 inline-flex items-center gap-1 rounded border border-warn/40 bg-warn/10 px-1.5 py-0 text-[11px] font-medium text-warn"
             >
-              <td className="px-4 py-2 text-text">
-                <span className="flex items-center gap-1.5">
-                  <span className="font-mono text-[12px]">
-                    {item.canonical_key ?? item.source_label}
-                  </span>
-                  {item.derived ? (
-                    <Tooltip
-                      kind="formula"
-                      content={
-                        formulaNotes[item.canonical_key ?? ""] ??
-                        "Derived by identity, not present in the source"
-                      }
-                    >
-                      <button
-                        type="button"
-                        aria-label="Derived — how we got this"
-                        className="rounded p-0.5 text-info focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                      >
-                        <Calculator className="h-3.5 w-3.5" />
-                      </button>
-                    </Tooltip>
-                  ) : null}
-                </span>
-              </td>
-              <td className="px-4 py-2 text-right tabular-nums text-text">
-                {formatMoney(item.amount, currency)}
-              </td>
-            </tr>
+              <TriangleAlert aria-hidden className="h-3 w-3" />
+              {warning}
+            </span>
           ))}
-        </tbody>
-      </table>
-    </div>
-  </section>
-);
+        </div>
+      ) : null}
+
+      {/* Mobile canon: the statement grid scrolls inside its container
+          below lg — the page itself never side-scrolls. */}
+      <div className="max-lg:overflow-x-auto">
+        <table className="w-full text-[13px]">
+          <tbody>
+            {lineItems.map((item) => (
+              <tr
+                key={item.id}
+                data-derived={item.derived || undefined}
+                className="border-b border-border last:border-b-0"
+              >
+                <td className="px-4 py-2 text-text">
+                  <span className="flex items-center gap-1.5">
+                    {/* Human reading labels win over raw canonical keys
+                        (Figma 98:743); unmapped rows keep their source
+                        label with a row-level tag. */}
+                    <span
+                      className={cn(item.derived && "font-semibold")}
+                      title={item.canonical_key ?? undefined}
+                    >
+                      {item.canonical_key
+                        ? CANONICAL_KEY_LABELS[item.canonical_key]
+                        : item.source_label}
+                    </span>
+                    {item.status === "unmapped" ? (
+                      <Tag tint="warn">unmapped</Tag>
+                    ) : null}
+                    {item.derived ? (
+                      <Tooltip
+                        kind="formula"
+                        content={
+                          formulaNotes[item.canonical_key ?? ""] ??
+                          "Derived by identity, not present in the source"
+                        }
+                      >
+                        <button
+                          type="button"
+                          className="rounded border border-info/40 bg-info/10 px-1 py-px font-mono text-[10px] font-medium leading-4 text-info focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                        >
+                          ƒ derived
+                        </button>
+                      </Tooltip>
+                    ) : null}
+                  </span>
+                </td>
+                <td
+                  className={cn(
+                    "px-4 py-2 text-right tabular-nums text-text",
+                    item.derived && "font-semibold",
+                  )}
+                >
+                  {formatMoney(item.amount, currency)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Identity-check footer (Figma 98:743): green when the statement
+          ties out within tolerance; amber when it does not. Hidden when
+          either side of the identity is absent. */}
+      {identityHolds !== null ? (
+        <footer
+          data-identity={identityHolds ? "pass" : "fail"}
+          className={cn(
+            "flex items-center gap-1.5 border-t border-border px-4 py-2 text-[12px] font-medium",
+            identityHolds ? "bg-income/10 text-income" : "bg-warn/10 text-warn",
+          )}
+        >
+          {identityHolds ? (
+            <Check aria-hidden className="h-3.5 w-3.5" />
+          ) : (
+            <TriangleAlert aria-hidden className="h-3.5 w-3.5" />
+          )}
+          Identity check{identityHolds ? "" : " failed"} — {identity.label}
+        </footer>
+      ) : null}
+    </section>
+  );
+};
 
 export default StatementView;

--- a/web/src/components/ui/StatementView.tsx
+++ b/web/src/components/ui/StatementView.tsx
@@ -46,7 +46,8 @@ const IDENTITY_CHECKS: Record<
     ],
   },
   income_statement: {
-    label: "Net income = Operating profit + Interest income − Interest expense − Tax",
+    label:
+      "Net income = Operating profit + Interest income − Interest expense − Tax",
     left: "net_income",
     right: [
       ["operating_profit", 1],

--- a/web/src/components/ui/TxnTableRow.tsx
+++ b/web/src/components/ui/TxnTableRow.tsx
@@ -52,6 +52,8 @@ export interface TxnTableRowProps {
   onSplit?: () => void;
   onExclude?: () => void;
   onOpen?: () => void;
+  /** Inline AnomalyBadge click → anomaly-explain inspector (B2b). */
+  onExplainAnomaly?: () => void;
 }
 
 export const TxnTableRow: React.FC<TxnTableRowProps> = ({
@@ -67,6 +69,7 @@ export const TxnTableRow: React.FC<TxnTableRowProps> = ({
   onSplit,
   onExclude,
   onOpen,
+  onExplainAnomaly,
 }) => {
   const { Icon: SourceIcon, label: sourceLabel } = SOURCE_ICON[txn.source];
   const anomaly = txn.anomalies[0];
@@ -179,10 +182,13 @@ export const TxnTableRow: React.FC<TxnTableRowProps> = ({
         </td>
       ) : anomaly ? (
         <td className="flex shrink-0 items-center">
+          {/* Clickable: opens the anomaly-explain inspector (B2b) — the
+              panel is reachable from the row, not deep-link-only. */}
           <AnomalyBadge
             type={anomaly.rule_id}
             severity={anomaly.severity}
             variant="inline"
+            onClick={onExplainAnomaly}
           />
         </td>
       ) : null}

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -34,9 +34,7 @@ describe("formatMoneyCompact (chart y ticks — Figma Chart/Line master)", () =>
       "₦3.61M",
     );
     // Trailing zeros are trimmed — never ₦2.50M.
-    expect(formatMoneyCompact(2_500_000, "NGN", { decimals: 2 })).toBe(
-      "₦2.5M",
-    );
+    expect(formatMoneyCompact(2_500_000, "NGN", { decimals: 2 })).toBe("₦2.5M");
   });
 
   it("preserves the sign on negative ticks (dipping cash-flow domains)", () => {

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -29,6 +29,16 @@ describe("formatMoneyCompact (chart y ticks — Figma Chart/Line master)", () =>
     expect(formatMoneyCompact(2_040_000)).toBe("₦2M");
   });
 
+  it("supports two decimals for the donut center total (₦3.61M)", () => {
+    expect(formatMoneyCompact(3_614_800, "NGN", { decimals: 2 })).toBe(
+      "₦3.61M",
+    );
+    // Trailing zeros are trimmed — never ₦2.50M.
+    expect(formatMoneyCompact(2_500_000, "NGN", { decimals: 2 })).toBe(
+      "₦2.5M",
+    );
+  });
+
   it("preserves the sign on negative ticks (dipping cash-flow domains)", () => {
     expect(formatMoneyCompact(-2_000_000)).toBe("−₦2M");
     expect(formatMoneyCompact(-2_500_000)).toBe("−₦2.5M");

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -40,7 +40,11 @@ export const formatMoney = (
 export const formatMoneyCompact = (
   amount: number,
   currency = "NGN",
+  options: { decimals?: number } = {},
 ): string => {
+  // Default 1 decimal (axis ticks); the donut center total passes 2 per
+  // the Figma ChartDonut master ("₦3.61M").
+  const maxDecimals = options.decimals ?? 1;
   const sign = amount < 0 ? "−" : "";
   const abs = Math.abs(amount);
   const [suffix, divisor] =
@@ -51,8 +55,9 @@ export const formatMoneyCompact = (
         : abs >= 1e3
           ? ["K", 1e3]
           : ["", 1];
-  const value = Math.round((abs / divisor) * 10) / 10;
-  const text = Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1);
+  const factor = 10 ** maxDecimals;
+  const value = Math.round((abs / divisor) * factor) / factor;
+  const text = parseFloat(value.toFixed(maxDecimals)).toString();
   return `${sign}${currencySymbol(currency)}${text}${suffix}`;
 };
 

--- a/web/src/mock/ratio-engine.test.ts
+++ b/web/src/mock/ratio-engine.test.ts
@@ -87,6 +87,30 @@ describe("ratio engine (FY2025 seed — line-items.md §5 registry)", () => {
     expect(metric2024("interest_coverage").status).toBe("critical");
   });
 
+  it("plumbs period_delta vs the prior same-kind period (gauge delta line)", () => {
+    // FY2025 gauges carry current − FY2024 deltas (RatioGauge "vs FY2024").
+    const fy2025 = computeRatioReport(ORG_CUESOFT, "FY2025");
+    const fy2024 = computeRatioReport(ORG_CUESOFT, "FY2024");
+    const value = (report: typeof fy2025, key: string) =>
+      report.ratios.find((ratio) => ratio.key === key)!;
+    const current = value(fy2025, "current_ratio");
+    const prior = value(fy2024, "current_ratio");
+    expect(current.period_delta).not.toBeNull();
+    expect(current.period_delta).toBeCloseTo(
+      (current.value as number) - (prior.value as number),
+      6,
+    );
+    // The turnaround story reads positive: liquidity improved FY2024→FY2025.
+    expect(current.period_delta as number).toBeGreaterThan(0);
+    // Growth metrics ARE period comparisons — no delta-on-a-delta.
+    expect(value(fy2025, "revenue_growth").period_delta).toBeNull();
+    // FY2024 has no FY2023 statements → deltas stay null.
+    expect(prior.period_delta).toBeNull();
+    // Metrics n/a in the prior period attach no delta (CFO ratios: no
+    // FY2024 cash-flow statement).
+    expect(value(fy2025, "operating_cash_flow_ratio").period_delta).toBeNull();
+  });
+
   it("persists formula + resolved line-item inputs (the MI-8 trace)", () => {
     const current = metric("current_ratio");
     expect(current.formula).toBe("current_assets / current_liabilities");

--- a/web/src/mock/ratio-engine.ts
+++ b/web/src/mock/ratio-engine.ts
@@ -10,6 +10,7 @@ import type { CanonicalKey } from "@/models/registry/line-items";
 import {
   annualizationFactor,
   periodDayCount,
+  previousPeriod,
 } from "@/models/registry/line-items";
 import { classify, RATIO_REGISTRY } from "@/models/registry/ratios";
 import { mockNow } from "./clock";
@@ -59,23 +60,9 @@ const collectValues = (
   return { values, kinds };
 };
 
-/** Previous same-kind period (growth rules: never mixed granularity). */
-export const previousPeriod = (period: string): string | null => {
-  const q = period.match(/^(\d{4})-Q([1-4])$/);
-  if (q) {
-    const year = Number(q[1]);
-    const quarter = Number(q[2]);
-    return quarter === 1 ? `${year - 1}-Q4` : `${year}-Q${quarter - 1}`;
-  }
-  const h = period.match(/^(\d{4})-H([12])$/);
-  if (h) {
-    const year = Number(h[1]);
-    return h[2] === "1" ? `${year - 1}-H2` : `${year}-H1`;
-  }
-  const fy = period.match(/^FY(\d{4})$/);
-  if (fy) return `FY${Number(fy[1]) - 1}`;
-  return null;
-};
+// Period-grammar helper moved to the models registry (period logic is
+// contract, not mock) — re-exported for existing engine consumers/tests.
+export { previousPeriod };
 
 const KIND_OF_KEY: Record<
   string,
@@ -128,10 +115,8 @@ const ledgerBurn = (
   return { burn: -avgNet, months: nets.length, positive: false };
 };
 
-export const computeRatioReport = (
-  orgId: string,
-  period: string,
-): RatioReport => {
+/** One period's metric results (no cross-period deltas at this level). */
+const computeResults = (orgId: string, period: string): RatioResult[] => {
   const db = getDb();
   const { values, kinds } = collectValues(db, orgId, period);
   const prevValues = (() => {
@@ -580,6 +565,33 @@ export const computeRatioReport = (
       }
       default:
         break;
+    }
+  }
+
+  return results;
+};
+
+export const computeRatioReport = (
+  orgId: string,
+  period: string,
+): RatioReport => {
+  const results = computeResults(orgId, period);
+
+  // period_delta: current − prior same-kind period, per metric (RatioGauge
+  // "+0.21 vs FY2024" delta line — Figma B6b). Growth metrics already ARE
+  // period comparisons; deltas attach only where both periods computed.
+  const prev = previousPeriod(period);
+  if (prev) {
+    const prevByKey = new Map(
+      computeResults(orgId, prev).map((result) => [result.key, result]),
+    );
+    for (const result of results) {
+      if (result.value === null) continue;
+      if (result.group === "growth") continue;
+      const prior = prevByKey.get(result.key);
+      if (prior && prior.value !== null) {
+        result.period_delta = result.value - prior.value;
+      }
     }
   }
 

--- a/web/src/mock/seed.ts
+++ b/web/src/mock/seed.ts
@@ -278,6 +278,20 @@ const categories: Category[] = [
     vat_treatment: "exempt",
     vat_basis: "inclusive",
   },
+  // AI-proposed category awaiting confirmation (B8 frame row state):
+  // courier/dispatch vendors clustered out of Ops & logistics.
+  {
+    id: "cat-ai-logistics",
+    org_id: ORG_CUESOFT,
+    name: "Logistics",
+    type: "expense",
+    color: "#6E6E76",
+    tax_treatment: "ignore",
+    vat_treatment: "exempt",
+    vat_basis: "inclusive",
+    ai_proposed: true,
+    ai_note: "AI proposed from 3 vendors",
+  },
   // Personal org — the freelancer dataset
   {
     id: "cat-personal-income",

--- a/web/src/models/category.ts
+++ b/web/src/models/category.ts
@@ -26,4 +26,13 @@ export interface Category {
   tax_treatment: TaxTreatment;
   vat_treatment: VatTreatment;
   vat_basis: VatBasis;
+  /** AI-proposed, awaiting human confirmation (B8 frame row state). */
+  ai_proposed?: boolean;
+  /** Proposal provenance, e.g. "AI proposed from 3 vendors". */
+  ai_note?: string | null;
+  /**
+   * Usage this calendar year — derived, list-response enrichment only
+   * (B8 merge-safety context: "N transactions this year").
+   */
+  txn_count_ytd?: number;
 }

--- a/web/src/models/registry/line-items.ts
+++ b/web/src/models/registry/line-items.ts
@@ -231,6 +231,24 @@ export const SUGGESTION_CONFIDENCE_FLOOR = 0.6;
 /** Period grammar (line-items.md §6) — closed; YYYY-MM reserved, rejected. */
 export const PERIOD_PATTERN = /^(\d{4}-Q[1-4]|\d{4}-H[12]|FY\d{4})$/;
 
+/** Previous same-kind period (growth rules: never mixed granularity). */
+export const previousPeriod = (period: string): string | null => {
+  const q = period.match(/^(\d{4})-Q([1-4])$/);
+  if (q) {
+    const year = Number(q[1]);
+    const quarter = Number(q[2]);
+    return quarter === 1 ? `${year - 1}-Q4` : `${year}-Q${quarter - 1}`;
+  }
+  const h = period.match(/^(\d{4})-H([12])$/);
+  if (h) {
+    const year = Number(h[1]);
+    return h[2] === "1" ? `${year - 1}-H2` : `${year}-H1`;
+  }
+  const fy = period.match(/^FY(\d{4})$/);
+  if (fy) return `FY${Number(fy[1]) - 1}`;
+  return null;
+};
+
 /** Annualization factor by period token kind (line-items.md §5). */
 export const annualizationFactor = (period: string): number => {
   if (/^\d{4}-Q[1-4]$/.test(period)) return 4;

--- a/web/src/models/repositories/transactions.ts
+++ b/web/src/models/repositories/transactions.ts
@@ -20,6 +20,9 @@ export type TxnUpdate = Partial<
     | "category_id"
     | "txn_date"
     | "excluded_from_reports"
+    // "Mark expected" (B2b): the only accepted anomaly write is [] —
+    // clearing the flags; the server rejects anything else.
+    | "anomalies"
   >
 >;
 

--- a/web/src/models/transaction.ts
+++ b/web/src/models/transaction.ts
@@ -22,6 +22,10 @@ export interface Anomaly {
   severity: AnomalySeverity;
   /** Inspector explanation (AnomalyBadge click → anomaly-explain). */
   note: string;
+  /** ISO date the rule fired — falls back to the entry's created_at. */
+  detected_at?: string;
+  /** Rule build the flag came from (provenance line), e.g. "v2". */
+  rule_version?: string;
 }
 
 export interface TxnEntry {


### PR DESCRIPTION
Code-side fixes from the adjudicated Figma ↔ code divergence ledger (audit of `P2lGfKFLJPS9k9kTKlii1n` vs the TEST_MODE build). Design-side items ride a separate lane; nothing here touches Figma.

## High

1. **B1 overview mid-band grid** — `lg:grid-cols-[2fr,1fr]` is invalid CSS (the comma emits `grid-template-columns:2fr,1fr`, dropped by browsers, collapsing the band to one column at every width). Fixed to `[2fr_1fr]` in all three states; e2e asserts two computed tracks at lg. Plus the donut center per the master: caption above, compact 2-decimal value below.
2. **StatementView reads human (98:743)** — vocabulary labels over raw canonical keys (raw key kept as row `title`), bold derived rows with a "ƒ derived" chip (formula tooltip), per-row + header unmapped tags, and a per-kind identity-check footer (green "Assets = Liabilities + Equity" within the ±1% tolerance).
3. **Purge model converged (MI-15)** — one construction: typed confirm is the **org name** (not "DELETE EVERYTHING"), the 5s danger-armed CTA stays, and the B9b "Export first" secondary joins the modal (kicks off the USR-001 export). Grace states as built. e2e covers locked → typed → armed, exits via Cancel.

## Medium

4. **B6b trends** — multi-series construction stays (adjudicated); the frame's **Data table** toggle added (mirrors B1: Period / Revenue / Gross profit / Net income). The merged #229 y-axis is asserted in the same e2e block.
5. **Gauge deltas go real** — the ratio engine computes the prior same-kind period and attaches `period_delta` (skipped for growth metrics / prior-n/a); captions name the prior period ("vs FY2024"). `previousPeriod` moved to the models registry. Invariant suite extended and green.
6. **Imports copy deck** — blue "Ready for review" tag; failed rows read human sentences with the raw taxonomy code demoted to a details disclosure; "Import history" heading; absolute dates stay (adjudicated finance-date idiom).
7. **B3b CTAs** — split per the frame: secondary "Discard N duplicates" (flags every duplicate for discard; the commit performs it per flows/import.md §2) + primary "Import N" (double-verb label dropped); whole-job abort demoted to a quiet "Discard import" page-header action; the 30-day recoverability footer restored.
8. **B8 categories (190:2836)** — usage meta "N transactions this year" (`txn_count_ytd` list enrichment), AI-proposed row state (seeded "Logistics" ✨ + provenance; a human edit confirms), delete confirms before firing (the `category_in_use` merge pivot unchanged), double-Sparkles bug fixed.
9. **B2b anomaly explain (208:3967)** — reachable from inline row badges; human-cased severity; provenance line (detected date + rule version); category-named comparables + median footer; actions **Cancel / Mark expected** (PUT `{anomalies: []}` — the only anomaly write the mock accepts).

## Low sweep

Amber "Re-authenticate" link-expired banner · nav icons per the AppNav master (Reports file-text, Statements file-spreadsheet) · marketing-nav wordmark accent dot · CodeSnippet copy-button backdrop · "Artifact history" heading + 30-day expiry caption · pluralized "1 anomaly" · humanized FYE select ("31 December", MM-DD wire format) · theme control order Light | Dark | System · donut "Other" dot verified present on main.

## Also

- **/docs/api**: Scalar dev toolbar off via configuration — `showDeveloperTools: "never"` (`showToolbar` is its deprecated alias in the installed `@scalar/types`); e2e asserts absence (the default is "localhost", exactly where the suite runs).
- **Docs**: web-implementation.md as-built block for this lane; pages.md B2b/B3/B4/B5/B6/B6b/B8/B9 rows updated; **B6 Archive tab recorded as [Proposed — deferred]** (built IA stays two nav pages per the adjudicated parity).

## Not built (recorded)

B6 Archive tab (deferred, docs note) · IA stays nav-pages (adjudicated) · signin card/copy restoration beyond the nav wordmark dot (design-lane coordination).

## Gates

- lint (prettier + eslint + check:boundaries) ✓
- typecheck ✓
- unit 406/406 ✓ (incl. the seed-invariant suites — 92 mock tests)
- TEST_MODE production build exit 0 ✓
- Playwright e2e 51/51 ✓ (+ the new grid / purge / anomaly-explain / toolbar assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
