### PR TITLE
fix(web): salvage — B9/B9b settings uniques, Wordmark parity + small adjudicated audit items

### DIFF
--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -422,6 +422,32 @@ test("purge modal — org-name typed confirm + Export first escape hatch (MI-15)
   await expect(modal).not.toBeVisible();
 });
 
+test("settings — editable address (B9) + determinate export strip (B9b)", async ({
+  page,
+}) => {
+  await signIn(page);
+  await switchToCompanyOrg(page);
+  await openNav(page, "Settings").click();
+  await page.waitForURL("**/dashboard/settings");
+
+  // Registered address is editable per the B9 frame (street/city/state).
+  await expect(page.getByLabel("Address line")).toBeVisible();
+  await expect(page.getByLabel("City")).toBeVisible();
+  await expect(page.getByLabel("State")).toBeVisible();
+
+  // Export strip: determinate % + record count + rate-limit microcopy,
+  // resolving to the archive download.
+  await page.getByRole("button", { name: "Request export" }).click();
+  await expect(
+    page.getByText(/Preparing export — [\d,]+ records/),
+  ).toBeVisible();
+  await expect(page.getByText(/ZIP · \d+%/)).toBeVisible();
+  await expect(page.getByText(/export up to twice a day/)).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Download archive" }),
+  ).toBeVisible({ timeout: 15_000 });
+});
+
 test("anomaly explain opens from the ledger row (B2b frame anatomy)", async ({
   page,
 }) => {

--- a/web/src/app/api/mock/account/export/[jobId]/route.ts
+++ b/web/src/app/api/mock/account/export/[jobId]/route.ts
@@ -13,11 +13,18 @@ export async function GET(request: Request, context: Context) {
   if (!job) return notFound();
 
   if (job.status === "running") {
-    const expires = mockNow();
-    expires.setDate(expires.getDate() + 7); // 7-day download TTL
-    job.status = "completed";
-    job.signed_url = `/api/mock/account/export/${jobId}/archive.zip`;
-    job.expires_at = expires.toISOString();
+    // Determinate lifecycle (Figma B9b "ZIP · 48%"): the archive builds
+    // across polls — ~48% a poll, completing on the second.
+    const progress = Math.min(100, (job.progress ?? 0) + 48);
+    job.progress = progress;
+    if (progress >= 96) {
+      const expires = mockNow();
+      expires.setDate(expires.getDate() + 7); // 7-day download TTL
+      job.status = "completed";
+      job.progress = 100;
+      job.signed_url = `/api/mock/account/export/${jobId}/archive.zip`;
+      job.expires_at = expires.toISOString();
+    }
   }
   return ok(job);
 }

--- a/web/src/app/api/mock/account/export/route.ts
+++ b/web/src/app/api/mock/account/export/route.ts
@@ -6,11 +6,24 @@ import { ok } from "@/mock/http";
 export async function POST() {
   const db = getDb();
   // Export during purge grace is allowed (flows/rights.md §1).
+  // Record count = every row the archive will carry (honest numbers
+  // from the store — the B9b strip reads "Preparing export — N records").
+  const recordCount =
+    db.transactions.length +
+    db.importJobs.length +
+    db.statements.length +
+    db.lineItems.length +
+    db.taxFilings.length +
+    db.artifacts.length +
+    db.categories.length +
+    db.bankLinks.length;
   const job = {
     job_id: nextId("export"),
     status: "running" as const,
     signed_url: null,
     expires_at: null,
+    record_count: recordCount,
+    progress: 0,
   };
   db.exportJobs.push(job);
   return ok({ job_id: job.job_id }, 202);

--- a/web/src/app/dashboard/imports/[jobId]/JobDetailView.tsx
+++ b/web/src/app/dashboard/imports/[jobId]/JobDetailView.tsx
@@ -305,7 +305,7 @@ export const JobDetailView: React.FC = () => {
             sticky
             columns={[
               { id: "date", label: "Date", widthClass: "w-14" },
-              { id: "source", label: "", widthClass: "w-4" },
+              { id: "source", label: "Src", widthClass: "w-8" },
               { id: "description", label: "Description" },
               { id: "category", label: "Category", widthClass: "w-40" },
               {

--- a/web/src/app/dashboard/settings/SettingsView.tsx
+++ b/web/src/app/dashboard/settings/SettingsView.tsx
@@ -80,6 +80,11 @@ export const SettingsView: React.FC = () => {
   const isCompany = activeOrg?.kind === "company";
   const [orgName, setOrgName] = useState<string | null>(null);
   const [fiscalYearEnd, setFiscalYearEnd] = useState<string | null>(null);
+  const [address, setAddress] = useState<{
+    line1: string;
+    city: string;
+    state: string;
+  } | null>(null);
   const [savingOrg, setSavingOrg] = useState(false);
 
   const [inviteEmail, setInviteEmail] = useState("");
@@ -127,10 +132,19 @@ export const SettingsView: React.FC = () => {
       await settings.updateOrg({
         ...(orgName !== null ? { name: orgName } : {}),
         ...(fiscalYearEnd !== null ? { fiscal_year_end: fiscalYearEnd } : {}),
+        ...(address !== null && activeOrg?.registered_address
+          ? {
+              registered_address: {
+                ...activeOrg.registered_address,
+                ...address,
+              },
+            }
+          : {}),
       });
       setToast("Organization updated");
       setOrgName(null);
       setFiscalYearEnd(null);
+      setAddress(null);
     } catch (err) {
       setToast(err instanceof Error ? err.message : "Update failed");
     } finally {
@@ -253,13 +267,83 @@ export const SettingsView: React.FC = () => {
             </FormRow>
             {isCompany ? (
               <>
-                <FormRow label="Registered address">
-                  {() => (
-                    <p className="text-[13px] text-text">
-                      {activeOrg?.registered_address
-                        ? `${activeOrg.registered_address.line1}, ${activeOrg.registered_address.city} (${activeOrg.registered_address.state})`
-                        : "—"}
-                    </p>
+                {/* Editable registered address (Figma B9 190:4223) —
+                    resolves the CIT/VAT remittance authority. */}
+                <FormRow
+                  label="Registered address"
+                  helper="Street, city and state — the state resolves your remittance authority."
+                >
+                  {(id) => (
+                    <div className="space-y-2">
+                      <Input
+                        id={id}
+                        aria-label="Address line"
+                        value={
+                          address?.line1 ??
+                          activeOrg?.registered_address?.line1 ??
+                          ""
+                        }
+                        onChange={(event) =>
+                          setAddress((prev) => ({
+                            line1: event.target.value,
+                            city:
+                              prev?.city ??
+                              activeOrg?.registered_address?.city ??
+                              "",
+                            state:
+                              prev?.state ??
+                              activeOrg?.registered_address?.state ??
+                              "",
+                          }))
+                        }
+                      />
+                      <div className="flex gap-2">
+                        <Input
+                          aria-label="City"
+                          placeholder="City"
+                          value={
+                            address?.city ??
+                            activeOrg?.registered_address?.city ??
+                            ""
+                          }
+                          onChange={(event) =>
+                            setAddress((prev) => ({
+                              line1:
+                                prev?.line1 ??
+                                activeOrg?.registered_address?.line1 ??
+                                "",
+                              city: event.target.value,
+                              state:
+                                prev?.state ??
+                                activeOrg?.registered_address?.state ??
+                                "",
+                            }))
+                          }
+                        />
+                        <Input
+                          aria-label="State"
+                          placeholder="NG-LA"
+                          value={
+                            address?.state ??
+                            activeOrg?.registered_address?.state ??
+                            ""
+                          }
+                          onChange={(event) =>
+                            setAddress((prev) => ({
+                              line1:
+                                prev?.line1 ??
+                                activeOrg?.registered_address?.line1 ??
+                                "",
+                              city:
+                                prev?.city ??
+                                activeOrg?.registered_address?.city ??
+                                "",
+                              state: event.target.value,
+                            }))
+                          }
+                        />
+                      </div>
+                    </div>
                   )}
                 </FormRow>
                 <FormRow
@@ -292,7 +376,9 @@ export const SettingsView: React.FC = () => {
             <Button
               size="sm"
               loading={savingOrg}
-              disabled={orgName === null && fiscalYearEnd === null}
+              disabled={
+                orgName === null && fiscalYearEnd === null && address === null
+              }
               onClick={() => void saveOrg()}
             >
               Save changes

--- a/web/src/app/dashboard/settings/SettingsView.tsx
+++ b/web/src/app/dashboard/settings/SettingsView.tsx
@@ -474,7 +474,26 @@ export const SettingsView: React.FC = () => {
               </p>
               <div className="mt-2">
                 {exportJob?.status === "running" ? (
-                  <ProgressBar label="Preparing your archive…" />
+                  // Determinate export strip (Figma B9b): record count +
+                  // "ZIP · N%" + the email/rate-limit reassurance.
+                  <div className="space-y-1.5">
+                    <div className="flex items-center justify-between gap-2 text-[13px]">
+                      <span className="text-text">
+                        Preparing export
+                        {exportJob.record_count
+                          ? ` — ${exportJob.record_count.toLocaleString("en-NG")} records`
+                          : "…"}
+                      </span>
+                      <span className="tabular-nums text-text-2">
+                        ZIP · {exportJob.progress ?? 0}%
+                      </span>
+                    </div>
+                    <ProgressBar size="sm" value={exportJob.progress ?? 0} />
+                    <p className="text-[12px] leading-4 text-text-2">
+                      We&apos;ll email you when it&apos;s ready. You can export
+                      up to twice a day.
+                    </p>
+                  </div>
                 ) : exportJob?.status === "completed" &&
                   exportJob.signed_url ? (
                   <Button

--- a/web/src/app/dashboard/transactions/TransactionsView.tsx
+++ b/web/src/app/dashboard/transactions/TransactionsView.tsx
@@ -119,6 +119,7 @@ export const TransactionsView: React.FC = () => {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkCategory, setBulkCategory] = useState<string | null>(null);
   const [bulkOpen, setBulkOpen] = useState(false);
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [saveViewOpen, setSaveViewOpen] = useState(false);
   const [viewName, setViewName] = useState("");
   const [draft, setDraft] = useState<TxnDraft>(draftFrom());
@@ -320,6 +321,15 @@ export const TransactionsView: React.FC = () => {
     setBulkCategory(null);
     setSelected(new Set());
     setToast(`${ids.length} transactions re-categorized`);
+  };
+
+  // Bulk delete (Figma master 123:1126) — always behind the confirm.
+  const bulkDelete = async () => {
+    const ids = [...selected];
+    setBulkDeleteOpen(false);
+    await Promise.all(ids.map((id) => txns.remove(id)));
+    setSelected(new Set());
+    setToast(`${ids.length} transaction${ids.length === 1 ? "" : "s"} deleted`);
   };
 
   const activeTxn =
@@ -644,7 +654,7 @@ export const TransactionsView: React.FC = () => {
                   sortable: true,
                   widthClass: "w-14",
                 },
-                { id: "source", label: "", widthClass: "w-4" },
+                { id: "source", label: "Src", widthClass: "w-8" },
                 {
                   id: "description",
                   label: "Description",
@@ -761,10 +771,23 @@ export const TransactionsView: React.FC = () => {
               setBulkOpen(true);
             }}
             onExport={exportSelection}
+            onDelete={() => setBulkDeleteOpen(true)}
             onClear={() => setSelected(new Set())}
           />
         </div>
       ) : null}
+
+      {/* Bulk delete — danger confirm (master 123:1126). */}
+      <Modal
+        open={bulkDeleteOpen}
+        onOpenChange={setBulkDeleteOpen}
+        variant="danger"
+        title={`Delete ${selected.size} transaction${selected.size === 1 ? "" : "s"}?`}
+        description="Deleted entries leave the ledger and every report immediately."
+        size="sm"
+        confirmLabel="Delete"
+        onConfirm={() => void bulkDelete()}
+      />
 
       {/* Bulk re-categorize (MI-4 at scale) */}
       <Modal

--- a/web/src/app/onboarding/OnboardingView.tsx
+++ b/web/src/app/onboarding/OnboardingView.tsx
@@ -18,6 +18,7 @@ import Input from "@/components/ui/Input";
 import Modal from "@/components/ui/Modal";
 import Radio from "@/components/ui/Radio";
 import Select from "@/components/ui/Select";
+import Wordmark from "@/components/ui/Wordmark";
 
 const NG_STATES = [
   { value: "NG-LA", label: "Lagos" },
@@ -45,9 +46,7 @@ export const OnboardingView: React.FC = () => {
   return (
     <main className="flex min-h-screen items-start justify-center bg-bg px-6 py-16">
       <div className="w-full max-w-lg">
-        <span className="font-display text-2xl font-bold tracking-tight text-text">
-          expendit
-        </span>
+        <Wordmark className="font-display text-2xl font-bold text-text" />
         <h1 className="mt-8 font-display text-xl font-semibold tracking-tight text-text">
           Set up your workspace
         </h1>

--- a/web/src/app/signin/SigninView.tsx
+++ b/web/src/app/signin/SigninView.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import Link from "next/link";
 import { useAuthController } from "@/controllers/use-auth";
 import GoogleAuthButton from "@/components/ui/GoogleAuthButton";
+import Wordmark from "@/components/ui/Wordmark";
 
 const SigninView: React.FC = () => {
   const { signInWithGoogle, loading, error } = useAuthController();
@@ -18,9 +19,7 @@ const SigninView: React.FC = () => {
     <main className="flex min-h-screen items-center justify-center bg-bg px-6">
       <div className="w-full max-w-sm">
         <Link href="/" className="mb-12 block text-center">
-          <span className="font-display text-2xl font-bold tracking-tight text-text">
-            expendit
-          </span>
+          <Wordmark className="font-display text-2xl font-bold text-text" />
         </Link>
 
         <h1 className="text-center font-display text-2xl font-semibold tracking-tight text-text">

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -12,6 +12,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import MarketingNav from "@/components/ui/MarketingNav";
 import MarketingFooter from "@/components/ui/MarketingFooter";
+import Wordmark from "@/components/ui/Wordmark";
 import {
   useAnalyticsController,
   usePageView,
@@ -217,8 +218,8 @@ export const HomeView: React.FC = () => {
         }
         brand={
           <div>
-            <div className="text-lg font-semibold tracking-tight text-text">
-              expendit<span className="text-accent">.</span>
+            <div className="text-lg font-semibold text-text">
+              <Wordmark />
             </div>
             <p className="mt-2 text-[13px] text-text-2">
               Financial intelligence for modern growth.

--- a/web/src/components/ui/BulkActionBar.test.tsx
+++ b/web/src/components/ui/BulkActionBar.test.tsx
@@ -38,4 +38,17 @@ describe("BulkActionBar (design.md §8.2b)", () => {
     expect(onExport).toHaveBeenCalled();
     expect(onClear).toHaveBeenCalled();
   });
+
+  it("bulk delete (Figma 123:1126) renders only when wired and fires", async () => {
+    const onDelete = vi.fn();
+    const { rerender } = render(<BulkActionBar selectedCount={3} />);
+    expect(
+      screen.queryByRole("button", { name: "Delete selection" }),
+    ).toBeNull();
+    rerender(<BulkActionBar selectedCount={3} onDelete={onDelete} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete selection" }),
+    );
+    expect(onDelete).toHaveBeenCalled();
+  });
 });

--- a/web/src/components/ui/BulkActionBar.tsx
+++ b/web/src/components/ui/BulkActionBar.tsx
@@ -1,18 +1,21 @@
 "use client";
 
 /**
- * BulkActionBar — design.md §8.2b: hidden / visible ("n selected" +
- * re-categorize / export / clear) · slide-in.
+ * BulkActionBar — design.md §8.2b (Figma 123:1126): hidden / visible
+ * ("n selected" + re-categorize / export / delete / clear) · slide-in.
+ * Delete is the quiet trash icon — the confirm modal carries the weight.
  */
 
 import React from "react";
-import { Download, Tag as TagIcon, X } from "lucide-react";
+import { Download, Tag as TagIcon, Trash2, X } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 export interface BulkActionBarProps {
   selectedCount: number;
   onRecategorize?: () => void;
   onExport?: () => void;
+  /** Bulk delete (with consumer-side confirm) — Figma 123:1126 trash. */
+  onDelete?: () => void;
   onClear?: () => void;
   className?: string;
 }
@@ -21,6 +24,7 @@ export const BulkActionBar: React.FC<BulkActionBarProps> = ({
   selectedCount,
   onRecategorize,
   onExport,
+  onDelete,
   onClear,
   className,
 }) => {
@@ -55,6 +59,16 @@ export const BulkActionBar: React.FC<BulkActionBarProps> = ({
         <Download aria-hidden className="h-3.5 w-3.5" />
         Export
       </button>
+      {onDelete ? (
+        <button
+          type="button"
+          aria-label="Delete selection"
+          onClick={onDelete}
+          className="rounded p-1 text-expense transition-colors duration-fast ease-standard hover:bg-expense/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      ) : null}
       <button
         type="button"
         aria-label="Clear selection"

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -20,6 +20,7 @@ import React, { useEffect, useId, useState } from "react";
 import Link from "next/link";
 import { Menu, X } from "lucide-react";
 import { cn } from "@/lib/cn";
+import Wordmark from "./Wordmark";
 
 export interface MarketingNavLink {
   label: string;
@@ -175,9 +176,9 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
           href="/"
           className="mr-4 rounded text-sm font-semibold tracking-tight text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
-          {/* Brand mark with the accent dot — matches the footer
-              wordmark (frames carry it on nav + footer). */}
-          expendit<span className="text-accent">.</span>
+          {/* Brand mark with the accent dot — the shared Wordmark
+              (frames carry it on nav + footer). */}
+          <Wordmark />
         </Link>
 
         {links.map((link) =>

--- a/web/src/components/ui/PeriodPicker.tsx
+++ b/web/src/components/ui/PeriodPicker.tsx
@@ -39,6 +39,18 @@ const MODE_PLACEHOLDER: Record<PeriodMode, string> = {
   year: "FYYYYY",
 };
 
+/**
+ * Humanized unset TRIGGER copy (Figma 182:455) — the raw grammar mask
+ * stays on the panel input where it teaches the format.
+ */
+const MODE_TRIGGER_PLACEHOLDER: Record<PeriodMode, string> = {
+  day: "Pick a date",
+  range: "All dates",
+  month: "Pick a month",
+  quarter: "Pick a quarter",
+  year: "Pick a year",
+};
+
 const MODE_PATTERN: Record<PeriodMode, RegExp> = {
   day: /^\d{4}-\d{2}-\d{2}$/,
   range: /^\d{4}-\d{2}-\d{2}\.\.\d{4}-\d{2}-\d{2}$/,
@@ -165,7 +177,7 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
               value ? "text-text" : "text-text-2",
             )}
           >
-            {value ? formatPeriod(mode, value) : MODE_PLACEHOLDER[mode]}
+            {value ? formatPeriod(mode, value) : MODE_TRIGGER_PLACEHOLDER[mode]}
           </span>
         </span>
         <ChevronDown aria-hidden className="h-4 w-4 shrink-0 text-text-2" />

--- a/web/src/components/ui/RemitToCard.test.tsx
+++ b/web/src/components/ui/RemitToCard.test.tsx
@@ -18,10 +18,14 @@ describe("RemitToCard (design.md §8.2)", () => {
         dueDate="2027-03-31"
       />,
     );
-    expect(
-      screen.getByText(/Remit to Lagos State Internal Revenue Service/),
-    ).toBeInTheDocument();
-    expect(screen.getByText("(LIRS)")).toBeInTheDocument();
+    // Short authority name in the subtitle (Figma 96:658); the full
+    // name rides the tooltip instead of truncating.
+    const subtitle = screen.getByText(/Remit to/);
+    expect(subtitle).toHaveTextContent("Remit to LIRS");
+    expect(subtitle).toHaveAttribute(
+      "title",
+      "Lagos State Internal Revenue Service",
+    );
     expect(screen.getByText("₦342,500.75")).toHaveClass("tabular-nums");
     // Figma: "Amount due" label + "Due 31 Mar 2027" + one "Pay via" chip.
     expect(screen.getByText("Amount due")).toBeInTheDocument();

--- a/web/src/components/ui/RemitToCard.tsx
+++ b/web/src/components/ui/RemitToCard.tsx
@@ -55,9 +55,13 @@ export const RemitToCard: React.FC<RemitToCardProps> = ({
           <div className="text-sm font-medium leading-5 text-text">
             {TAX_LABEL[kind]}
           </div>
-          <div className="truncate text-[13px] leading-4 text-text-2">
-            Remit to {authority.name}{" "}
-            <span className="font-mono">({authority.code})</span>
+          <div
+            className="truncate text-[13px] leading-4 text-text-2"
+            // Short authority name in the subtitle (Figma 96:658) — the
+            // full name rides the tooltip instead of truncating.
+            title={authority.name}
+          >
+            Remit to <span className="font-mono">{authority.code}</span>
           </div>
         </div>
       </div>

--- a/web/src/components/ui/Wordmark.test.tsx
+++ b/web/src/components/ui/Wordmark.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Wordmark from "./Wordmark";
+
+describe("Wordmark (brand mark, Figma 178:19)", () => {
+  it("renders the name with the accent dot", () => {
+    const { container } = render(<Wordmark />);
+    expect(container.firstElementChild).toHaveTextContent(/^expendit\.$/);
+    expect(screen.getByText(".")).toHaveClass("text-accent");
+  });
+
+  it("takes the caller's typography classes", () => {
+    const { container } = render(<Wordmark className="text-2xl font-bold" />);
+    expect(container.firstElementChild).toHaveClass("text-2xl", "font-bold");
+  });
+});

--- a/web/src/components/ui/Wordmark.tsx
+++ b/web/src/components/ui/Wordmark.tsx
@@ -1,0 +1,24 @@
+/**
+ * Wordmark — the brand mark with the accent dot ("expendit·"), ONE
+ * component reused across nav / signin / footer / onboarding (Figma
+ * 178:19 — the dot is part of the mark everywhere). Size/weight come
+ * from the caller; the dot always binds to the accent token.
+ */
+
+import React from "react";
+import { cn } from "@/lib/cn";
+
+export interface WordmarkProps {
+  className?: string;
+}
+
+export const Wordmark: React.FC<WordmarkProps> = ({ className }) => (
+  <span className={cn("tracking-tight", className)}>
+    expendit
+    <span aria-hidden className="text-accent">
+      .
+    </span>
+  </span>
+);
+
+export default Wordmark;

--- a/web/src/mock/routes-reports-members-rights.test.ts
+++ b/web/src/mock/routes-reports-members-rights.test.ts
@@ -200,19 +200,31 @@ describe("mock data rights (flows/rights.md)", () => {
     expect(await json(afterCancel)).toBeNull();
   });
 
-  it("export-all: 202 job → completed with a 7-day signed URL", async () => {
+  it("export-all: 202 job → determinate progress → completed with a 7-day signed URL", async () => {
     const { job_id } = await json<{ job_id: string }>(await requestExport());
-    const status = await json<{
-      status: string;
-      signed_url: string | null;
-      expires_at: string | null;
-    }>(
-      await exportStatus(
-        mockRequest(`/api/mock/account/export/${job_id}`),
-        params({ jobId: job_id }),
-      ),
-    );
+    const poll = async () =>
+      json<{
+        status: string;
+        signed_url: string | null;
+        expires_at: string | null;
+        record_count?: number | null;
+        progress?: number;
+      }>(
+        await exportStatus(
+          mockRequest(`/api/mock/account/export/${job_id}`),
+          params({ jobId: job_id }),
+        ),
+      );
+    // First poll: determinate mid-flight ("ZIP · 48%") with the archive's
+    // record count (Figma B9b).
+    const midway = await poll();
+    expect(midway.status).toBe("running");
+    expect(midway.progress).toBe(48);
+    expect(midway.record_count).toBeGreaterThan(100);
+    // Second poll completes with the signed URL.
+    const status = await poll();
     expect(status.status).toBe("completed");
+    expect(status.progress).toBe(100);
     expect(status.signed_url).toBeTruthy();
     expect(status.expires_at).toBeTruthy();
   });

--- a/web/src/models/rights.ts
+++ b/web/src/models/rights.ts
@@ -21,6 +21,10 @@ export interface ExportJob {
   signed_url: string | null;
   /** 7-day download TTL (flows/rights.md §1). */
   expires_at: string | null;
+  /** Rows in the archive ("Preparing export — 34,208 records"). */
+  record_count?: number | null;
+  /** 0–100 determinate progress ("ZIP · 48%"). */
+  progress?: number;
 }
 
 export type PurgeStatus = "pending" | "cancelled" | "executed";


### PR DESCRIPTION
Salvage pass over the orphaned pre-restart `fix/audit-code-items` branch (15 commits + an interrupted integration-merge chain). Each commit was classified against current `main` (post-#225–#230) and the audit ledger; unique value is ported as fresh, slice-scoped commits, everything else is explicitly discarded below. The orphaned branch + worktree are removed with this PR.

## Adopted (6 commits, all slice-extracted)

| item | source | notes |
| --- | --- | --- |
| B9 registered address is editable (street/city/state) | 93de372 slice | Frame renders editable fields; the built card was read-only. `PATCH /orgs/{id}` already validated + persisted `registered_address` — only the UI lagged. |
| USR-001 export strip goes determinate (record count · "ZIP · N%" · rate-limit copy) | 93de372 slice | B9b frame; mock export job gains `record_count`/`progress`, completes on the second poll. Routes test + e2e cover the lifecycle. |
| ONE `Wordmark` component (accent-dot brand mark) | a2e91b4 slice | Ledger row: dot on nav/signin/footer in ALL frames, one component reused everywhere. Replaces #230's inline nav markup + the plain-text marks on /signin, onboarding, footer. **Explicitly excluded:** the signin card + copy-deck rework from the same commit — signin cosmetics were adjudicated out of scope, and the diff was a whole-screen construction change, not trivial. Only the brand mark lands on /signin. |
| B2 bulk delete behind a danger confirm + "Src" header + humanized PeriodPicker trigger | e81aa42 minus superseded/unadjudicated parts | Bulk-delete trash per master 123:1126, armed confirm per the MI-15 ladder (#230's pattern); "Src" column label per the TableHeader frame; picker trigger reads "All dates"/"Pick a month" (grammar mask stays on the panel input). |
| RemitToCard subtitle uses the short authority name | edc45c9 slice | Ledger fix-code direction; kills the "Federal Inland Revenue Service (FIR…" truncation — full name rides the title tooltip. |
| Anomaly-explain comparables read the FULL ledger + Select wires `aria-label` | e5b39ce slice | Both defects verified live on main: the deep-linked explain panel over `?anomalies=1` hid every clean comparable; Select silently dropped `aria-label` (hyphenated JSX props bypass TS excess-property checks) leaving toolbar selects nameless. |

## Superseded by #230 (and the #228/#229 chart lane) — verified per item

- 50ca55b B1 mid-band grid underscore fix — identical fix in #230.
- 3bef095 ChartDonut center flip + compact value — #230.
- 96e4308 StatementView human labels / ƒ chips / identity footer — #230.
- 9047c4e B6b Data-table toggle — #230; the B1 single-series-legend drop is superseded by the chart lane (main renders `legend="none"` + a screen-level valued legend).
- 48608a9 anomaly explain (provenance, median, Mark expected) — #230.
- 70d84f9 B8 categories (usage meta, AI-proposed row, delete confirm, double-sparkle) — #230.
- 93de372 (rest): humanized FYE, theme order Light|Dark|System, purge convergence (org-name confirm + "Export first") — all in #230.
- e81aa42 (part): Reports/Statements nav icons — #230 low sweep.
- 5f58201 docs — #230 shipped its own as-built + pages.md rows incl. the B6 Archive-deferred IA decision.

## Discarded (with reasons)

- **e9dbd06 B3/B3b imports** — copy deck + CTA semantics landed differently in #230; this commit's RELATIVE history ages **contradict** #230's adjudicated absolute finance-date idiom. The post-parse summary card + header Upload button remain an open "decide with design" ledger row.
- **7ad3996 B4/B4b bank-link** — stepper construction, modal copy deck, footer alignment, determinate sync %, stamped-done are all unadjudicated reconcile rows; #230 adopted only the banner-tint item from this lane.
- **f6096ce B5 reports** — heading + expiry caption superseded by #230; toolbar-vs-card, generating strip, and artifact meta-line anatomy are unadjudicated pick-one rows.
- **edc45c9 (rest)** — filing-wizard re-anatomy (rail sub-captions, step-2 anatomy, VAT line renames, green completed check) are unadjudicated reconcile rows.
- **a2e91b4 (rest)** — signin card + copy deck: adjudicated out of scope (see above); onboarding CTA "Create organization" is an unadjudicated reconcile row.
- **e81aa42 (part)** — "All accounts" filter label: adjudicate-both-ways row (frame says accounts, api.md says sources); left for adjudication.
- **Modal danger-icon title variant (93de372)** — not part of #230's adjudicated purge construction.
- **e5b39ce (rest)** — mock bank-sync pacing (~3.5s) serviced the discarded B4b determinate-sync lane; e2e selector churn serviced branch-only specs.
- **The 8 dirty files** — inspected: an interrupted `git merge origin/main` (#230) into the orphaned branch, mid conflict-resolution. Mechanical integration only; no novel uncommitted item. The local branch ref had additionally advanced to a completed merge + "post-merge reconciliation" commit (1b02499) — same integration lane, no new intent; superseded by this slice-scoped salvage.

## Gates

lint (prettier + eslint + boundaries) ✓ · typecheck ✓ · unit 409/409 ✓ · prod build ✓ · Playwright e2e 52/52 ✓ (incl. a new B9 address + B9b export-strip journey)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
