### PR TITLE
docs(design): reconcile rows to the built constructions — ThemeToggle icon button, nav breakpoint variants, star badge, micro-label idiom, mobile parity

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -143,7 +143,7 @@ ecosystem change, PR'd to all three design.md files together.
 | --- | --- | --- |
 | Home (public) | pages.md Part A Brex-editorial home, built on this system (W2) | shipped |
 | Dashboard | pages.md Part B suite, built on this system (W3) | shipped |
-| Mobile | — | later phase; ledger + receipt-capture first (pages.md Part C sketch) — ecosystem parity **[Directive]** |
+| Mobile | responsive web shipped — below `md` the marketing nav collapses to the hamburger disclosure (Try Cloud stays in the bar) and the dashboard rides the 64px icon rail with an overlay drawer + scrim; the Figma Mobile page carries the @390 exemplars | native app later phase; ledger + receipt-capture first (pages.md Part C sketch) — ecosystem parity **[Directive]** |
 
 ## 7. Figma Style Guide (source of truth for tokens)
 
@@ -293,7 +293,7 @@ never on screens.
 | Component | Variants × states |
 | --- | --- |
 | AppNav / NavItem | **blocking** · item: default / hover / active / with-badge-count (MI-5) · group label · expanded 240px / collapsed 64px icon rail · org-switcher slot top · theme ×2 · ThemeToggle instance in the chrome (expanded footer + collapsed rail) [Directive 2026-07-19] |
-| ThemeToggle | **blocking** · theme: light / dark / system — three-cell segmented control (sun / moon / lucide monitor; the active cell tracks the applied state) · cycle order light → dark → system; system follows live `prefers-color-scheme` · persisted at localStorage `expendit.theme` · token-bound (`bg-elev`/`border`/`bg`, icon strokes → `text`) so one master renders in both modes · instances pinned in MarketingNav and AppNav chrome per the cross-product canon **[Revised 2026-07-20]** |
+| ThemeToggle | **blocking** · theme: light / dark / system — a single 28px icon button; the icon (sun / moon / lucide monitor) announces the applied state and each click advances the cycle light → dark → system; system follows live `prefers-color-scheme` · persisted at localStorage `expendit.theme` · token-bound (`bg-elev`/`border`/`bg`, icon strokes → `text`) so one master renders in both modes · instances pinned in MarketingNav and AppNav chrome per the cross-product canon · the three-way Light \| Dark \| System control in Settings → Appearance is a SegmentedControl instance, not this component **[Reconciled 2026-07-20]** |
 | OrgSwitcher | **blocking** · closed / open (menu) · org kind: personal / company · current + list rows · theme ×2 (as built: `open` is modeled on kind=company only — 3 of 4 combos; the open menu is the company exemplar) |
 | MobileTabBar + MobileHeader | **nice-to-have** (Part C, later phase) · 5 tabs Home/Transactions/Capture/Reports/Settings · active/inactive · Capture accent · header: title + back |
 
@@ -323,7 +323,7 @@ never on screens.
 
 | Component | Variants × states |
 | --- | --- |
-| TableHeader | **blocking** · density ×2 · sort: none / asc / desc (sort axis in build, 2026-07-17) · column alignment text / numeric-right set per instance (override, not a variant axis) · select-all checkbox slot · sticky |
+| TableHeader | **blocking** · density ×2 · sort: none / asc / desc (sort axis in build, 2026-07-17) · column labels render the ecosystem micro-label idiom — 11px uppercase, wide tracking, `text-2` · column alignment text / numeric-right set per instance (override, not a variant axis) · select-all checkbox slot · sticky **[Reconciled 2026-07-20]** |
 | BulkActionBar | **blocking** · hidden / visible ("n selected" + re-categorize / export / clear) · slide-in |
 | StagedReviewHeader | **blocking** · counts ("Import 209 / discard 5 duplicates") · state: reviewing / committing (MI-3 cascade) · warnings-banner slot |
 
@@ -350,8 +350,8 @@ never on screens.
 
 | Component | Variants × states |
 | --- | --- |
-| MarketingNav | **blocking** · on-dark (over hero) / dark-on-light (post-hero scroll, sticky) · 4 text links pinned to the cross-product canon: Features · Pricing · Docs (GitBook root) · GitHub — the GitHub item renders as a compact star badge (star glyph + neutral "Star" label; no count on canvas — the live star count is runtime behavior) · ThemeToggle instance · "Sign in" text link (`/signin`) + "Try Cloud" accent primary CTA · no Solutions dropdown [Revised 2026-07-19] · mobile: below md the bar keeps the Try Cloud CTA beside the hamburger; the panel carries the 4 links + ThemeToggle + Sign in [Revised 2026-07-19] |
-| MarketingFooter | **blocking** · brand block (wordmark + tagline) + 4 link columns pinned to the cross-product canon — Product (Features · Pricing · Try Cloud · Self Host) · Docs (Docs · Quickstart · API reference · Self-host guide) · Community (GitHub · Discord · Roadmap · CueLABS™) · Legal (Privacy · Terms · Status) — legal bar verbatim "© Cuesoft Inc. 2026. Expendit. CueLABS™ Division. MIT License." ("Cuesoft Inc." → cuesoft.io, "CueLABS™ Division" → cuelabs.cuesoft.io, "MIT License" → repo LICENSE) · "View Security Policy" CTA (repo SECURITY.md) · English language selector · dark editorial band in both themes [Directive 2026-07-19] |
+| MarketingNav | **blocking** · surface: on-dark (over hero) / dark-on-light (post-hero scroll, sticky) × breakpoint: desktop / mobile / mobile-open · 4 text links pinned to the cross-product canon: Features · Pricing · Docs (GitBook root) · GitHub — the GitHub item renders as a compact star badge (GitHub mark + star glyph + neutral "Star" label; no count on canvas — the live star count is runtime behavior) · ThemeToggle instance · "Sign in" text link (`/signin`) + "Try Cloud" accent primary CTA · no Solutions dropdown · breakpoint=mobile is the 390 bar — Wordmark · Try Cloud · icon/menu hamburger (the conversion CTA never hides behind the menu); breakpoint=mobile-open adds the disclosure panel — Features / Pricing / Docs / star badge, then divider + ThemeToggle + Sign in — and the bar swaps to icon/x (matching @390 exemplars on the Figma Mobile page) **[Reconciled 2026-07-20]** |
+| MarketingFooter | **blocking** · brand block (wordmark + tagline) + 4 link columns pinned to the cross-product canon — Product (Features · Pricing · Try Cloud · Self Host) · Docs (Docs · Quickstart · API reference · Self-host guide) · Community (GitHub · Discord · Roadmap · CueLABS™) · Legal (Privacy · Terms · Status) — column headers render the 11px uppercase micro-label idiom (same treatment as TableHeader labels) — legal bar verbatim "© Cuesoft Inc. 2026. Expendit. CueLABS™ Division. MIT License." ("Cuesoft Inc." → cuesoft.io, "CueLABS™ Division" → cuelabs.cuesoft.io, "MIT License" → repo LICENSE) · "View Security Policy" CTA (repo SECURITY.md) · English language selector · dark editorial band in both themes [Directive 2026-07-19] |
 | EditorialCard | **important** · pillar (A4) / community (A9) · default / hover (2px lift + accent underline draw) · light/dark section |
 | CodeSnippet | **important** · Mono/13 block on dark · copy: idle / copied (✓ morph) |
 | ComparisonTable | **important** · 2 columns (Cloud vs Self-host) · cell: check / x / text · per-column CTA footer row — as built 2026-07-18: the price row reads "Announced at GA" / "Free forever", captioned "Cloud pricing is announced at GA — self-hosting is free forever" |


### PR DESCRIPTION
## Summary

Design-docs half of the Figma convergence pass (2026-07-20). `docs/pages.md` was already fully reconciled by the merged code-lane PRs (purge model, categories usage meta, FYE select, theme control order) — this PR touches only the `docs/design.md` rows still quoting stale constructions:

- **ThemeToggle (§8.2b)** — the master is a single 28px cycling icon button (sun / moon / monitor announces the applied state), not a three-cell segmented control; the three-way Light | Dark | System control in Settings → Appearance is a SegmentedControl instance.
- **MarketingNav (§8.2b)** — the set now carries the surface × breakpoint matrix (desktop / mobile / mobile-open): the 390 bar keeps Wordmark · Try Cloud · hamburger (the conversion CTA never hides behind the menu); the open panel carries Features / Pricing / Docs / star badge + divider + ThemeToggle + Sign in. Star badge construction: GitHub mark + star glyph + neutral "Star" label.
- **TableHeader (§8.2b)** — column labels render the ecosystem micro-label idiom: 11px uppercase, wide tracking, `text-2`.
- **MarketingFooter (§8.2b)** — column headers carry the same micro-label idiom.
- **Platform parity map (§6)** — responsive web mobile is shipped (hamburger disclosure, 64px rail + overlay drawer + scrim below `md`; @390 exemplars on the Figma Mobile page); the native app remains the later-phase Part C target.

Canvas counterpart (same pass, Figma file): MarketingNav breakpoint=mobile / mobile-open master variants, icon/menu master, Mobile-page @390 exemplars (B2 Transactions, B7b Filing wizard, nav drawer open), /docs/api Light + Dark Scalar frames, branded 404 frame, and component descriptions tagged [Reconciled 2026-07-20].

Do not merge — convergence-lane review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)