### PR TITLE
feat(web): real date pickers — DatePicker/MonthPicker grids, PeriodPicker goes pick-or-type

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -341,6 +341,39 @@ assemblies (TxnTable full, staged-review table, ratio grid, filing wizard
 steps) stay screen-level compositions in code too — feature components under
 their W3 screens, not `components/ui/` modules.
 
+**DatePicker as-built (2026-07-20 — every dashboard date field is
+pick-or-type).** `components/ui/DatePicker.tsx` is the period-grammar
+grid family, bespoke per the reuse policy (date-fns math, tokens only):
+`DatePicker` — the calendar month grid (Sunday-first single-letter
+weekday header S M T W T F S per the Figma DatePicker master, month
+chevron nav, selected = filled accent cell, today = accent-outlined
+cell, outside days muted, optional min/max disabling, in-range tint for
+range picking, roving arrow-key focus that flips the month at a grid
+edge; `calendarDays` is the exported pure grid math) — and `MonthPicker`
+(year chevron nav + 12-month grid), with `QuarterPicker` (year nav +
+Q1–Q4) and `YearPicker` (year list, newest first, FY#### labels via
+`formatLabel`) extending the same anatomy to the rest of the closed
+period grammar. PeriodPicker embeds the mode's grid in its existing
+popover panel above the grammar input, so every call site — Overview
+month switch, transactions range filter + inspector txn date, reports
+month/FY statement periods, company statements quarter, ratios FY,
+filing wizard VAT month / CIT FY — got the picker with no call-site
+changes. **Typing stays live** (the a11y path): a grammar-valid draft
+drives the grid's selection and visible month/year before Apply;
+invalid drafts keep the existing inline validation. Grid picks commit
+immediately (range mode: two clicks, start held in the input as
+`from..`, endpoints normalized); the footer is the master's
+Cancel/Apply pair; Escape/Cancel/commit return focus to the trigger
+(the input's Enter commit `preventDefault`s — the browser's Enter
+activation otherwise clicks the re-focused trigger and reopens the
+popover). The taller panel extends the collision canon to both axes:
+`useViewportShiftXY` (use-viewport-clamp) reuses the 1-D clamp on Y, so
+the panel never clips at 1440/390 (`e2e/date-picker.spec.ts` pins the
+Overview pick-a-month flow — value applied + category query refires —
+plus typed sync and the in-viewport boundingBox at both widths;
+`floating-layers.spec.ts` unchanged). Presets stay the as-built chips
+row (the master's range preset rail is a design-lane follow-up).
+
 ## 3. Token mapping — design.md §2 → `web/src/design/tokens.css`
 
 One custom property per Figma variable in the `expendit/tokens` collection

--- a/web/e2e/date-picker.spec.ts
+++ b/web/e2e/date-picker.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+/**
+ * Pick-or-type period fields (design.md §8.2b as built): the PeriodPicker
+ * panel embeds the mode's grid — Overview month mode gets the 12-month
+ * grid — and picking applies the value and refires the query (the donut
+ * card re-titles to the picked month). The open panel obeys the
+ * floating-layer collision canon at desktop (1440) and mobile (390).
+ */
+
+const signIn = async (page: Page): Promise<void> => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: "Continue with Google" }).click();
+  await page.waitForURL("**/dashboard", { timeout: 15_000 });
+};
+
+const expectFullyInViewport = async (locator: Locator): Promise<void> => {
+  const box = await locator.boundingBox();
+  const viewport = locator.page().viewportSize();
+  expect(box).not.toBeNull();
+  expect(viewport).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height);
+};
+
+for (const viewport of [
+  { width: 1440, height: 900 },
+  { width: 390, height: 844 },
+]) {
+  test.describe(`date picker at ${viewport.width}×${viewport.height}`, () => {
+    test.use({ viewport });
+
+    test("overview month switch: pick June in the grid → value applied and the query refires", async ({
+      page,
+    }) => {
+      await signIn(page);
+      // Seeded ledger runs through July 2026 — the donut starts there.
+      await expect(
+        page.getByText(/Expenses by category — Jul 2026/),
+      ).toBeVisible({ timeout: 15_000 });
+
+      const trigger = page.locator('button[aria-haspopup="dialog"]').first();
+      await trigger.click();
+      const popover = page.getByRole("dialog", { name: "Pick month" });
+      await expect(popover).toBeVisible();
+
+      // Collision canon: the panel (now carrying the 12-month grid and
+      // the grammar input) sits fully inside the viewport.
+      await expect(
+        popover.getByRole("button", { name: "July 2026" }),
+      ).toBeVisible();
+      await expect(
+        popover.getByRole("button", { name: "Apply" }),
+      ).toBeVisible();
+      await expectFullyInViewport(popover);
+
+      // Pick June 2026 in the grid: the popover closes, the trigger
+      // takes the humanized value, and the category query refires.
+      await popover.getByRole("button", { name: "June 2026" }).click();
+      await expect(popover).not.toBeVisible();
+      await expect(trigger).toContainText("Jun 2026");
+      await expect(
+        page.getByText(/Expenses by category — Jun 2026/),
+      ).toBeVisible({ timeout: 15_000 });
+    });
+
+    test("typing stays live alongside the grid (pick-or-type)", async ({
+      page,
+    }) => {
+      await signIn(page);
+      await page.locator('button[aria-haspopup="dialog"]').first().click();
+      const popover = page.getByRole("dialog", { name: "Pick month" });
+      const input = popover.getByPlaceholder("YYYY-MM");
+      await input.fill("2026-05");
+      // A valid typed draft drives the grid selection before Apply.
+      await expect(
+        popover.getByRole("button", { name: "May 2026" }),
+      ).toHaveAttribute("aria-pressed", "true");
+      await input.press("Enter");
+      await expect(popover).not.toBeVisible();
+      await expect(
+        page.getByText(/Expenses by category — May 2026/),
+      ).toBeVisible({ timeout: 15_000 });
+    });
+  });
+}

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -1105,6 +1105,14 @@ export const ComponentGallery: React.FC = () => {
               <PeriodPicker mode="month" value={null} error="Pick a period" />
             </div>
           </Variant>
+          <Variant label="day (calendar) · range (two-click)">
+            <div className="w-48">
+              <PeriodPicker mode="day" value="2026-06-15" />
+            </div>
+            <div className="w-56">
+              <PeriodPicker mode="range" value="2026-06-01..2026-06-30" />
+            </div>
+          </Variant>
         </Section>
 
         <Section title="Modal / Dialog">

--- a/web/src/components/ui/DatePicker.test.tsx
+++ b/web/src/components/ui/DatePicker.test.tsx
@@ -15,10 +15,10 @@ describe("calendarDays (grid math)", () => {
     const days = calendarDays(new Date(2024, 1, 1));
     const isos = days.map((day) => format(day, "yyyy-MM-dd"));
     expect(isos).toContain("2024-02-29");
-    // Feb 2024 starts Thursday → the grid opens Monday Jan 29 and
-    // closes Sunday Mar 3: exactly five ISO weeks.
-    expect(isos[0]).toBe("2024-01-29");
-    expect(isos.at(-1)).toBe("2024-03-03");
+    // Feb 2024 starts Thursday → the Sunday-first grid opens Jan 28 and
+    // closes Saturday Mar 2: exactly five full weeks.
+    expect(isos[0]).toBe("2024-01-28");
+    expect(isos.at(-1)).toBe("2024-03-02");
     expect(days).toHaveLength(35);
   });
 
@@ -30,13 +30,13 @@ describe("calendarDays (grid math)", () => {
     expect(isos).toContain("2026-02-28");
   });
 
-  it("aligns every month to full Monday-first weeks", () => {
+  it("aligns every month to full Sunday-first weeks (master grid geometry)", () => {
     for (let offset = 0; offset < 24; offset += 1) {
       const month = addMonths(new Date(2025, 0, 1), offset);
       const days = calendarDays(month);
       expect(days.length % 7).toBe(0);
-      expect(days[0].getDay()).toBe(1); // Monday
-      expect(days.at(-1)?.getDay()).toBe(0); // Sunday
+      expect(days[0].getDay()).toBe(0); // Sunday
+      expect(days.at(-1)?.getDay()).toBe(6); // Saturday
       // The 1st is always inside the grid (month is its own 1st here).
       const isos = days.map((day) => format(day, "yyyy-MM-dd"));
       expect(isos).toContain(format(month, "yyyy-MM-dd"));

--- a/web/src/components/ui/DatePicker.test.tsx
+++ b/web/src/components/ui/DatePicker.test.tsx
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { addMonths, format } from "date-fns";
+import {
+  calendarDays,
+  DatePicker,
+  MonthPicker,
+  QuarterPicker,
+  YearPicker,
+} from "./DatePicker";
+
+describe("calendarDays (grid math)", () => {
+  it("covers a leap-year February including the 29th", () => {
+    const days = calendarDays(new Date(2024, 1, 1));
+    const isos = days.map((day) => format(day, "yyyy-MM-dd"));
+    expect(isos).toContain("2024-02-29");
+    // Feb 2024 starts Thursday → the grid opens Monday Jan 29 and
+    // closes Sunday Mar 3: exactly five ISO weeks.
+    expect(isos[0]).toBe("2024-01-29");
+    expect(isos.at(-1)).toBe("2024-03-03");
+    expect(days).toHaveLength(35);
+  });
+
+  it("never shows Feb 29 in a non-leap year", () => {
+    const isos = calendarDays(new Date(2026, 1, 1)).map((day) =>
+      format(day, "yyyy-MM-dd"),
+    );
+    expect(isos).not.toContain("2026-02-29");
+    expect(isos).toContain("2026-02-28");
+  });
+
+  it("aligns every month to full Monday-first weeks", () => {
+    for (let offset = 0; offset < 24; offset += 1) {
+      const month = addMonths(new Date(2025, 0, 1), offset);
+      const days = calendarDays(month);
+      expect(days.length % 7).toBe(0);
+      expect(days[0].getDay()).toBe(1); // Monday
+      expect(days.at(-1)?.getDay()).toBe(0); // Sunday
+      // The 1st is always inside the grid (month is its own 1st here).
+      const isos = days.map((day) => format(day, "yyyy-MM-dd"));
+      expect(isos).toContain(format(month, "yyyy-MM-dd"));
+    }
+  });
+});
+
+describe("DatePicker (design.md §8.2b calendar grid)", () => {
+  it("renders the value's month with the selected day pressed", () => {
+    render(<DatePicker value={new Date(2026, 5, 15)} onSelect={vi.fn()} />);
+    expect(screen.getByRole("grid", { name: "June 2026" })).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "15 June 2026" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("selects the clicked day", async () => {
+    const onSelect = vi.fn();
+    render(<DatePicker value={new Date(2026, 5, 15)} onSelect={onSelect} />);
+    await userEvent.click(screen.getByRole("button", { name: "18 June 2026" }));
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(format(onSelect.mock.calls[0][0], "yyyy-MM-dd")).toBe("2026-06-18");
+  });
+
+  it("marks today with aria-current", () => {
+    render(<DatePicker value={null} onSelect={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: format(new Date(), "d MMMM yyyy") }),
+    ).toHaveAttribute("aria-current", "date");
+  });
+
+  it("disables days outside min/max and swallows their clicks", async () => {
+    const onSelect = vi.fn();
+    render(
+      <DatePicker
+        value={new Date(2026, 5, 15)}
+        onSelect={onSelect}
+        minDate={new Date(2026, 5, 10)}
+        maxDate={new Date(2026, 5, 20)}
+      />,
+    );
+    const before = screen.getByRole("button", { name: "5 June 2026" });
+    const after = screen.getByRole("button", { name: "25 June 2026" });
+    expect(before).toBeDisabled();
+    expect(after).toBeDisabled();
+    expect(screen.getByRole("button", { name: "10 June 2026" })).toBeEnabled();
+    await userEvent.click(before);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("navigates months with the chevrons", async () => {
+    render(<DatePicker value={new Date(2026, 5, 15)} onSelect={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Next month" }));
+    expect(screen.getByRole("grid", { name: "July 2026" })).toBeVisible();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Previous month" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Previous month" }),
+    );
+    expect(screen.getByRole("grid", { name: "May 2026" })).toBeVisible();
+  });
+
+  it("snaps the visible month when the controlled value moves (typed sync)", () => {
+    const { rerender } = render(
+      <DatePicker value={new Date(2026, 5, 15)} onSelect={vi.fn()} />,
+    );
+    rerender(<DatePicker value={new Date(2027, 2, 3)} onSelect={vi.fn()} />);
+    expect(screen.getByRole("grid", { name: "March 2027" })).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "3 March 2027" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("roves focus with arrow keys and flips the month at the edge", async () => {
+    render(<DatePicker value={new Date(2026, 5, 30)} onSelect={vi.fn()} />);
+    screen.getByRole("button", { name: "30 June 2026" }).focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(screen.getByRole("grid", { name: "July 2026" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "1 July 2026" })).toHaveFocus();
+    await userEvent.keyboard("{ArrowDown}");
+    expect(screen.getByRole("button", { name: "8 July 2026" })).toHaveFocus();
+  });
+
+  it("presses both endpoints of a range", () => {
+    render(
+      <DatePicker
+        value={new Date(2026, 5, 10)}
+        rangeEnd={new Date(2026, 5, 12)}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "10 June 2026" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", { name: "12 June 2026" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+});
+
+describe("MonthPicker (year nav + 12-month grid)", () => {
+  it("renders 12 months with the selected one pressed", () => {
+    render(<MonthPicker value={new Date(2026, 5, 1)} onSelect={vi.fn()} />);
+    expect(screen.getByText("2026")).toBeVisible();
+    expect(screen.getByRole("button", { name: "June 2026" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getAllByRole("button", { name: /\w+ 2026$/ })).toHaveLength(
+      12,
+    );
+  });
+
+  it("navigates years and selects a month start", async () => {
+    const onSelect = vi.fn();
+    render(<MonthPicker value={new Date(2026, 5, 1)} onSelect={onSelect} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Previous year" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "March 2025" }));
+    expect(format(onSelect.mock.calls[0][0], "yyyy-MM")).toBe("2025-03");
+  });
+
+  it("marks the current month with aria-current", () => {
+    render(<MonthPicker value={null} onSelect={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: format(new Date(), "MMMM yyyy") }),
+    ).toHaveAttribute("aria-current", "date");
+  });
+});
+
+describe("QuarterPicker (year nav + Q1–Q4)", () => {
+  it("selects a quarter in the navigated year", async () => {
+    const onSelect = vi.fn();
+    render(
+      <QuarterPicker value={{ year: 2026, quarter: 2 }} onSelect={onSelect} />,
+    );
+    expect(screen.getByRole("button", { name: "Q2 2026" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Previous year" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Q4 2025" }));
+    expect(onSelect).toHaveBeenCalledWith({ year: 2025, quarter: 4 });
+  });
+});
+
+describe("YearPicker (list, newest first)", () => {
+  it("lists years through the label mapping and selects one", async () => {
+    const onSelect = vi.fn();
+    render(
+      <YearPicker
+        value={2025}
+        from={2026}
+        count={4}
+        formatLabel={(year) => `FY${year}`}
+        onSelect={onSelect}
+      />,
+    );
+    const labels = screen
+      .getAllByRole("button")
+      .map((button) => button.textContent);
+    expect(labels).toEqual(["FY2026", "FY2025", "FY2024", "FY2023"]);
+    expect(screen.getByRole("button", { name: "FY2025" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "FY2024" }));
+    expect(onSelect).toHaveBeenCalledWith(2024);
+  });
+
+  it("joins a selected year outside the window into the list", () => {
+    render(
+      <YearPicker value={2018} from={2026} count={4} onSelect={vi.fn()} />,
+    );
+    expect(screen.getByRole("button", { name: "2018" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+});

--- a/web/src/components/ui/DatePicker.tsx
+++ b/web/src/components/ui/DatePicker.tsx
@@ -31,14 +31,16 @@ import {
 } from "date-fns";
 import { cn } from "@/lib/cn";
 
-/** ISO weeks — Monday first, matching the org calendar construction. */
-const WEEK_STARTS_ON = 1;
+/** Sunday-first weeks — the Figma DatePicker master's grid geometry. */
+const WEEK_STARTS_ON = 0;
 
-const WEEKDAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
+/** Single-letter weekday header per the master (S M T W T F S). */
+const WEEKDAYS = ["S", "M", "T", "W", "T", "F", "S"];
 
 /**
- * Pure grid math: every day the month grid shows — full ISO weeks from
- * the Monday on/before the 1st through the Sunday on/after month end.
+ * Pure grid math: every day the month grid shows — full Sunday-first
+ * weeks from the Sunday on/before the 1st through the Saturday
+ * on/after month end.
  */
 export const calendarDays = (month: Date): Date[] =>
   eachDayOfInterval({
@@ -191,9 +193,9 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         onKeyDown={onGridKeyDown}
         className="grid grid-cols-7 text-center"
       >
-        {WEEKDAYS.map((weekday) => (
+        {WEEKDAYS.map((weekday, index) => (
           <span
-            key={weekday}
+            key={index}
             aria-hidden
             className="py-1 text-[11px] font-medium text-text-2"
           >
@@ -226,7 +228,8 @@ export const DatePicker: React.FC<DatePickerProps> = ({
                   : inRange(day)
                     ? "bg-accent/15 text-text"
                     : isToday(day)
-                      ? "font-semibold text-accent hover:bg-bg-elev"
+                      ? // Master's today state: outlined cell, plain text.
+                        "text-text ring-1 ring-inset ring-accent hover:bg-bg-elev"
                       : "text-text hover:bg-bg-elev",
                 outside && !selected && "text-text-2/50",
                 disabled &&
@@ -292,7 +295,7 @@ export const MonthPicker: React.FC<MonthPickerProps> = ({
                 selected
                   ? "bg-accent font-medium text-on-accent"
                   : current
-                    ? "font-semibold text-accent hover:bg-bg-elev"
+                    ? "text-text ring-1 ring-inset ring-accent hover:bg-bg-elev"
                     : "text-text hover:bg-bg-elev",
               )}
             >
@@ -366,7 +369,7 @@ export const QuarterPicker: React.FC<QuarterPickerProps> = ({
                 selected
                   ? "bg-accent font-medium text-on-accent"
                   : current
-                    ? "font-semibold text-accent hover:bg-bg-elev"
+                    ? "text-text ring-1 ring-inset ring-accent hover:bg-bg-elev"
                     : "text-text hover:bg-bg-elev",
               )}
             >
@@ -425,7 +428,7 @@ export const YearPicker: React.FC<YearPickerProps> = ({
               year === value
                 ? "bg-accent font-medium text-on-accent"
                 : year === currentYear
-                  ? "font-semibold text-accent hover:bg-bg-elev"
+                  ? "text-text ring-1 ring-inset ring-accent hover:bg-bg-elev"
                   : "text-text hover:bg-bg-elev",
             )}
           >

--- a/web/src/components/ui/DatePicker.tsx
+++ b/web/src/components/ui/DatePicker.tsx
@@ -1,0 +1,438 @@
+"use client";
+
+/**
+ * DatePicker / MonthPicker — design.md §8.2b: the period-grammar grids
+ * the PeriodPicker popover embeds so every dashboard date field is
+ * pick-or-type (typing stays the a11y path; the popover chrome —
+ * outside-click, Escape, viewport clamp — lives on PeriodPicker).
+ * Bespoke per the reuse policy (headless behavior only — no styled
+ * kits); date-fns for the math; construction parity with apparule's
+ * DateInput calendar. QuarterPicker/YearPicker extend the same
+ * anatomy to the closed period grammar's other modes (line-items.md §6).
+ */
+
+import React, { useLayoutEffect, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  addDays,
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isAfter,
+  isBefore,
+  isSameDay,
+  isSameMonth,
+  isToday,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+import { cn } from "@/lib/cn";
+
+/** ISO weeks — Monday first, matching the org calendar construction. */
+const WEEK_STARTS_ON = 1;
+
+const WEEKDAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
+
+/**
+ * Pure grid math: every day the month grid shows — full ISO weeks from
+ * the Monday on/before the 1st through the Sunday on/after month end.
+ */
+export const calendarDays = (month: Date): Date[] =>
+  eachDayOfInterval({
+    start: startOfWeek(startOfMonth(month), { weekStartsOn: WEEK_STARTS_ON }),
+    end: endOfWeek(endOfMonth(month), { weekStartsOn: WEEK_STARTS_ON }),
+  });
+
+/** Shared header chrome: chevron nav around a tabular label. */
+const GridHeader: React.FC<{
+  label: string;
+  prevLabel: string;
+  nextLabel: string;
+  onPrev: () => void;
+  onNext: () => void;
+}> = ({ label, prevLabel, nextLabel, onPrev, onNext }) => (
+  <div className="mb-1.5 flex items-center justify-between">
+    <button
+      type="button"
+      aria-label={prevLabel}
+      onClick={onPrev}
+      className={cn(
+        "grid size-7 place-items-center rounded text-text-2",
+        "transition-colors duration-fast ease-standard hover:bg-bg-elev hover:text-text",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+      )}
+    >
+      <ChevronLeft aria-hidden className="h-4 w-4" />
+    </button>
+    <span
+      aria-live="polite"
+      className="text-[13px] font-medium tabular-nums text-text"
+    >
+      {label}
+    </span>
+    <button
+      type="button"
+      aria-label={nextLabel}
+      onClick={onNext}
+      className={cn(
+        "grid size-7 place-items-center rounded text-text-2",
+        "transition-colors duration-fast ease-standard hover:bg-bg-elev hover:text-text",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+      )}
+    >
+      <ChevronRight aria-hidden className="h-4 w-4" />
+    </button>
+  </div>
+);
+
+export interface DatePickerProps {
+  /** Selected day (the range start when rangeEnd is set). */
+  value: Date | null;
+  /** Range end — days between value and rangeEnd render in-range. */
+  rangeEnd?: Date | null;
+  onSelect: (day: Date) => void;
+  /** Earliest selectable day (inclusive). */
+  minDate?: Date;
+  /** Latest selectable day (inclusive). */
+  maxDate?: Date;
+  className?: string;
+}
+
+/**
+ * Month-grid calendar: weekday header, month chevron nav, today +
+ * selected states, roving arrow-key focus (crossing a month edge flips
+ * the grid).
+ */
+export const DatePicker: React.FC<DatePickerProps> = ({
+  value,
+  rangeEnd = null,
+  onSelect,
+  minDate,
+  maxDate,
+  className,
+}) => {
+  const [month, setMonth] = useState(() => startOfMonth(value ?? new Date()));
+  const [focusDay, setFocusDay] = useState<Date | null>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  // Typed-input sync: when the controlled value moves to another month
+  // (a valid date was typed), snap the visible grid to it —
+  // adjust-state-during-render, no effect.
+  const [prevValue, setPrevValue] = useState(value);
+  if (prevValue?.getTime() !== value?.getTime()) {
+    setPrevValue(value);
+    if (value && !isSameMonth(value, month)) setMonth(startOfMonth(value));
+  }
+
+  // Roving focus follows arrow-key moves after the grid re-renders.
+  useLayoutEffect(() => {
+    if (!focusDay) return;
+    gridRef.current
+      ?.querySelector<HTMLButtonElement>(
+        `[data-day="${format(focusDay, "yyyy-MM-dd")}"]`,
+      )
+      ?.focus();
+  }, [focusDay, month]);
+
+  const days = calendarDays(month);
+  const min = minDate ? startOfDay(minDate) : undefined;
+  const max = maxDate ? startOfDay(maxDate) : undefined;
+  const isDisabled = (day: Date) =>
+    (min !== undefined && isBefore(day, min)) ||
+    (max !== undefined && isAfter(day, max));
+  const from = value;
+  const to = rangeEnd;
+  const inRange = (day: Date) =>
+    from !== null &&
+    to !== null &&
+    isAfter(day, startOfDay(from)) &&
+    isBefore(day, startOfDay(to));
+  // One tab stop: the focused/selected day (today, else the 1st).
+  const tabStop =
+    focusDay ??
+    (value && isSameMonth(value, month) ? value : null) ??
+    (isSameMonth(new Date(), month) ? startOfDay(new Date()) : month);
+
+  const onGridKeyDown = (event: React.KeyboardEvent) => {
+    const deltas: Record<string, number> = {
+      ArrowLeft: -1,
+      ArrowRight: 1,
+      ArrowUp: -7,
+      ArrowDown: 7,
+    };
+    const delta = deltas[event.key];
+    if (delta === undefined) return;
+    event.preventDefault();
+    const current =
+      (event.target instanceof HTMLElement && event.target.dataset.day
+        ? new Date(`${event.target.dataset.day}T00:00:00`)
+        : null) ?? tabStop;
+    const next = addDays(current, delta);
+    if (!isSameMonth(next, month)) setMonth(startOfMonth(next));
+    setFocusDay(next);
+  };
+
+  return (
+    <div className={cn("select-none", className)} data-testid="date-picker">
+      <GridHeader
+        label={format(month, "MMMM yyyy")}
+        prevLabel="Previous month"
+        nextLabel="Next month"
+        onPrev={() => setMonth((current) => addMonths(current, -1))}
+        onNext={() => setMonth((current) => addMonths(current, 1))}
+      />
+      <div
+        ref={gridRef}
+        role="grid"
+        aria-label={format(month, "MMMM yyyy")}
+        onKeyDown={onGridKeyDown}
+        className="grid grid-cols-7 text-center"
+      >
+        {WEEKDAYS.map((weekday) => (
+          <span
+            key={weekday}
+            aria-hidden
+            className="py-1 text-[11px] font-medium text-text-2"
+          >
+            {weekday}
+          </span>
+        ))}
+        {days.map((day) => {
+          const outside = !isSameMonth(day, month);
+          const disabled = isDisabled(day);
+          const selected =
+            (value !== null && isSameDay(day, value)) ||
+            (rangeEnd !== null && isSameDay(day, rangeEnd));
+          return (
+            <button
+              key={day.toISOString()}
+              type="button"
+              data-day={format(day, "yyyy-MM-dd")}
+              disabled={disabled}
+              tabIndex={isSameDay(day, tabStop) ? 0 : -1}
+              onClick={() => onSelect(day)}
+              aria-label={format(day, "d MMMM yyyy")}
+              aria-pressed={selected || undefined}
+              aria-current={isToday(day) ? "date" : undefined}
+              className={cn(
+                "mx-auto grid size-8 place-items-center rounded text-[13px] tabular-nums",
+                "transition-colors duration-fast ease-standard",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+                selected
+                  ? "bg-accent font-medium text-on-accent"
+                  : inRange(day)
+                    ? "bg-accent/15 text-text"
+                    : isToday(day)
+                      ? "font-semibold text-accent hover:bg-bg-elev"
+                      : "text-text hover:bg-bg-elev",
+                outside && !selected && "text-text-2/50",
+                disabled &&
+                  "cursor-not-allowed text-text-2/30 hover:bg-transparent",
+              )}
+            >
+              {format(day, "d")}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export interface MonthPickerProps {
+  /** Any day inside the selected month. */
+  value: Date | null;
+  onSelect: (monthStart: Date) => void;
+  className?: string;
+}
+
+/** MonthPicker variant: year chevron nav over a 12-month grid. */
+export const MonthPicker: React.FC<MonthPickerProps> = ({
+  value,
+  onSelect,
+  className,
+}) => {
+  const [year, setYear] = useState(() => (value ?? new Date()).getFullYear());
+
+  // Typed-input sync — adjust-state-during-render, no effect.
+  const [prevValue, setPrevValue] = useState(value);
+  if (prevValue?.getTime() !== value?.getTime()) {
+    setPrevValue(value);
+    if (value) setYear(value.getFullYear());
+  }
+
+  return (
+    <div className={cn("select-none", className)} data-testid="month-picker">
+      <GridHeader
+        label={String(year)}
+        prevLabel="Previous year"
+        nextLabel="Next year"
+        onPrev={() => setYear((current) => current - 1)}
+        onNext={() => setYear((current) => current + 1)}
+      />
+      <div className="grid grid-cols-3 gap-1">
+        {Array.from({ length: 12 }, (_, index) => {
+          const monthStart = new Date(year, index, 1);
+          const selected = value !== null && isSameMonth(monthStart, value);
+          const current = isSameMonth(monthStart, new Date());
+          return (
+            <button
+              key={index}
+              type="button"
+              onClick={() => onSelect(monthStart)}
+              aria-label={format(monthStart, "MMMM yyyy")}
+              aria-pressed={selected || undefined}
+              aria-current={current ? "date" : undefined}
+              className={cn(
+                "h-8 rounded text-[13px] transition-colors duration-fast ease-standard",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+                selected
+                  ? "bg-accent font-medium text-on-accent"
+                  : current
+                    ? "font-semibold text-accent hover:bg-bg-elev"
+                    : "text-text hover:bg-bg-elev",
+              )}
+            >
+              {format(monthStart, "MMM")}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export interface QuarterPickerProps {
+  value: { year: number; quarter: number } | null;
+  onSelect: (next: { year: number; quarter: number }) => void;
+  className?: string;
+}
+
+/** Quarter variant of the MonthPicker anatomy: year nav + Q1–Q4. */
+export const QuarterPicker: React.FC<QuarterPickerProps> = ({
+  value,
+  onSelect,
+  className,
+}) => {
+  const [year, setYear] = useState(
+    () => value?.year ?? new Date().getFullYear(),
+  );
+
+  // Typed-input sync — adjust-state-during-render, no effect.
+  const [prevValue, setPrevValue] = useState(value);
+  if (
+    prevValue?.year !== value?.year ||
+    prevValue?.quarter !== value?.quarter
+  ) {
+    setPrevValue(value);
+    if (value) setYear(value.year);
+  }
+
+  const now = new Date();
+  const currentQuarter = {
+    year: now.getFullYear(),
+    quarter: Math.floor(now.getMonth() / 3) + 1,
+  };
+
+  return (
+    <div className={cn("select-none", className)} data-testid="quarter-picker">
+      <GridHeader
+        label={String(year)}
+        prevLabel="Previous year"
+        nextLabel="Next year"
+        onPrev={() => setYear((current) => current - 1)}
+        onNext={() => setYear((current) => current + 1)}
+      />
+      <div className="grid grid-cols-4 gap-1">
+        {[1, 2, 3, 4].map((quarter) => {
+          const selected =
+            value !== null && value.year === year && value.quarter === quarter;
+          const current =
+            currentQuarter.year === year && currentQuarter.quarter === quarter;
+          return (
+            <button
+              key={quarter}
+              type="button"
+              onClick={() => onSelect({ year, quarter })}
+              aria-label={`Q${quarter} ${year}`}
+              aria-pressed={selected || undefined}
+              aria-current={current ? "date" : undefined}
+              className={cn(
+                "h-8 rounded text-[13px] tabular-nums transition-colors duration-fast ease-standard",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+                selected
+                  ? "bg-accent font-medium text-on-accent"
+                  : current
+                    ? "font-semibold text-accent hover:bg-bg-elev"
+                    : "text-text hover:bg-bg-elev",
+              )}
+            >
+              Q{quarter}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export interface YearPickerProps {
+  value: number | null;
+  onSelect: (year: number) => void;
+  /** Label mapping — the FY#### statement grammar on PeriodPicker. */
+  formatLabel?: (year: number) => string;
+  /** Newest year listed (default: current year). */
+  from?: number;
+  /** How many years the list walks back (default 10). */
+  count?: number;
+  className?: string;
+}
+
+/** Year list, newest first — a selected value outside the window joins it. */
+export const YearPicker: React.FC<YearPickerProps> = ({
+  value,
+  onSelect,
+  formatLabel = String,
+  from = new Date().getFullYear(),
+  count = 10,
+  className,
+}) => {
+  const years = Array.from({ length: count }, (_, index) => from - index);
+  if (value !== null && !years.includes(value)) {
+    years.push(value);
+    years.sort((a, b) => b - a);
+  }
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <ul
+      data-testid="year-picker"
+      className={cn("max-h-44 select-none overflow-auto", className)}
+    >
+      {years.map((year) => (
+        <li key={year}>
+          <button
+            type="button"
+            onClick={() => onSelect(year)}
+            aria-pressed={year === value || undefined}
+            aria-current={year === currentYear ? "date" : undefined}
+            className={cn(
+              "w-full rounded px-2 py-1 text-left text-[13px] tabular-nums",
+              "transition-colors duration-fast ease-standard",
+              year === value
+                ? "bg-accent font-medium text-on-accent"
+                : year === currentYear
+                  ? "font-semibold text-accent hover:bg-bg-elev"
+                  : "text-text hover:bg-bg-elev",
+            )}
+          >
+            {formatLabel(year)}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/web/src/components/ui/PeriodPicker.test.tsx
+++ b/web/src/components/ui/PeriodPicker.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import PeriodPicker, { isValidPeriod } from "./PeriodPicker";
 
@@ -28,9 +28,121 @@ describe("PeriodPicker (design.md §8.2b)", () => {
       />,
     );
     await userEvent.click(screen.getByRole("button"));
-    await userEvent.click(screen.getByRole("button", { name: "Q2 2026" }));
+    // The preset chip and the quarter-grid cell can share an accessible
+    // name ("Q2 2026") — both commit the same period; the chip renders
+    // first in DOM order.
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Q2 2026" })[0],
+    );
     expect(onValueChange).toHaveBeenCalledWith("2026-Q2");
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("picks a day from the embedded calendar and commits it", async () => {
+    const onValueChange = vi.fn();
+    render(
+      <PeriodPicker
+        mode="day"
+        value="2026-06-15"
+        onValueChange={onValueChange}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    expect(screen.getByRole("grid", { name: "June 2026" })).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "18 June 2026" }));
+    expect(onValueChange).toHaveBeenCalledWith("2026-06-18");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("picks a range in two clicks, normalizing the order", async () => {
+    const onValueChange = vi.fn();
+    render(
+      <PeriodPicker
+        mode="range"
+        value="2026-06-01..2026-06-30"
+        onValueChange={onValueChange}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    await userEvent.click(screen.getByRole("button", { name: "12 June 2026" }));
+    // First click holds the pending start in the grammar input.
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByPlaceholderText("YYYY-MM-DD..YYYY-MM-DD")).toHaveValue(
+      "2026-06-12..",
+    );
+    // Second click before the start swaps the endpoints.
+    await userEvent.click(screen.getByRole("button", { name: "10 June 2026" }));
+    expect(onValueChange).toHaveBeenCalledWith("2026-06-10..2026-06-12");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("picks a month from the 12-month grid", async () => {
+    const onValueChange = vi.fn();
+    render(
+      <PeriodPicker
+        mode="month"
+        value="2026-06"
+        onValueChange={onValueChange}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    await userEvent.click(screen.getByRole("button", { name: "March 2026" }));
+    expect(onValueChange).toHaveBeenCalledWith("2026-03");
+  });
+
+  it("picks a quarter from the Q1–Q4 grid", async () => {
+    const onValueChange = vi.fn();
+    render(
+      <PeriodPicker
+        mode="quarter"
+        value="2026-Q2"
+        onValueChange={onValueChange}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    await userEvent.click(
+      within(screen.getByTestId("quarter-picker")).getByRole("button", {
+        name: "Q3 2026",
+      }),
+    );
+    expect(onValueChange).toHaveBeenCalledWith("2026-Q3");
+  });
+
+  it("picks a year from the FY list", async () => {
+    const onValueChange = vi.fn();
+    render(
+      <PeriodPicker mode="year" value="FY2024" onValueChange={onValueChange} />,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    await userEvent.click(
+      within(screen.getByTestId("year-picker")).getByRole("button", {
+        name: "FY2025",
+      }),
+    );
+    expect(onValueChange).toHaveBeenCalledWith("FY2025");
+  });
+
+  it("syncs a valid typed draft into the grid before Apply (type ↔ pick)", async () => {
+    render(<PeriodPicker mode="month" value="2026-06" />);
+    await userEvent.click(screen.getByRole("button"));
+    const input = screen.getByPlaceholderText("YYYY-MM");
+    await userEvent.clear(input);
+    await userEvent.type(input, "2027-03");
+    expect(screen.getByText("2027")).toBeVisible();
+    expect(screen.getByRole("button", { name: "March 2027" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("returns focus to the trigger on Escape", async () => {
+    render(<PeriodPicker mode="month" value="2026-06" />);
+    const trigger = screen.getByRole("button");
+    await userEvent.click(trigger);
+    expect(screen.getByRole("dialog")).toBeVisible();
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
   });
 
   it("rejects grammar-invalid manual input with an inline error", async () => {
@@ -73,32 +185,64 @@ describe("PeriodPicker (design.md §8.2b)", () => {
       // Overview header regression: w-36 trigger at the right edge of a
       // 1440 viewport; the min-w-56 panel overflowed by 56px.
       vi.stubGlobal("innerWidth", 1440);
+      vi.stubGlobal("innerHeight", 900);
       vi.spyOn(
         window.HTMLElement.prototype,
         "getBoundingClientRect",
-      ).mockReturnValue({ left: 1272, right: 1496 } as DOMRect);
+      ).mockReturnValue({
+        left: 1272,
+        right: 1496,
+        top: 100,
+        bottom: 420,
+      } as DOMRect);
 
       render(<PeriodPicker mode="month" value="2026-07" />);
       await userEvent.click(screen.getByRole("button"));
 
       expect(screen.getByRole("dialog")).toHaveStyle({
-        transform: "translateX(-64px)",
+        transform: "translate(-64px, 0px)",
+      });
+    });
+
+    it("translates the popover up when the calendar would clip the bottom edge", async () => {
+      // The embedded grids made the panel tall enough to clip below on
+      // low anchors (390 canon viewport) — the same 1-D clamp runs on Y.
+      vi.stubGlobal("innerWidth", 1440);
+      vi.stubGlobal("innerHeight", 900);
+      vi.spyOn(
+        window.HTMLElement.prototype,
+        "getBoundingClientRect",
+      ).mockReturnValue({
+        left: 400,
+        right: 624,
+        top: 700,
+        bottom: 1020,
+      } as DOMRect);
+
+      render(<PeriodPicker mode="month" value="2026-07" />);
+      await userEvent.click(screen.getByRole("button"));
+
+      expect(screen.getByRole("dialog")).toHaveStyle({
+        transform: "translate(0px, -128px)",
       });
     });
 
     it("leaves an in-viewport popover unshifted", async () => {
       vi.stubGlobal("innerWidth", 1440);
+      vi.stubGlobal("innerHeight", 900);
       vi.spyOn(
         window.HTMLElement.prototype,
         "getBoundingClientRect",
-      ).mockReturnValue({ left: 400, right: 624 } as DOMRect);
+      ).mockReturnValue({
+        left: 400,
+        right: 624,
+        top: 100,
+        bottom: 420,
+      } as DOMRect);
 
       render(<PeriodPicker mode="month" value="2026-07" />);
       await userEvent.click(screen.getByRole("button"));
 
-      expect(screen.getByRole("dialog")).not.toHaveStyle({
-        transform: "translateX(-64px)",
-      });
       expect(screen.getByRole("dialog").style.transform).toBe("");
     });
   });

--- a/web/src/components/ui/PeriodPicker.test.tsx
+++ b/web/src/components/ui/PeriodPicker.test.tsx
@@ -135,6 +135,23 @@ describe("PeriodPicker (design.md §8.2b)", () => {
     );
   });
 
+  it("cancels without committing (master's Cancel/Apply footer)", async () => {
+    const onValueChange = vi.fn();
+    render(
+      <PeriodPicker
+        mode="month"
+        value="2026-06"
+        onValueChange={onValueChange}
+      />,
+    );
+    const trigger = screen.getByRole("button");
+    await userEvent.click(trigger);
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
   it("returns focus to the trigger on Escape", async () => {
     render(<PeriodPicker mode="month" value="2026-06" />);
     const trigger = screen.getByRole("button");

--- a/web/src/components/ui/PeriodPicker.tsx
+++ b/web/src/components/ui/PeriodPicker.tsx
@@ -365,7 +365,13 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
               value={draft}
               onChange={(event) => setDraft(event.target.value)}
               onKeyDown={(event) => {
-                if (event.key === "Enter") commit(draft);
+                if (event.key === "Enter") {
+                  // Commit refocuses the trigger — without preventDefault
+                  // the browser's Enter activation then clicks the newly
+                  // focused trigger and instantly reopens the popover.
+                  event.preventDefault();
+                  commit(draft);
+                }
               }}
               placeholder={MODE_PLACEHOLDER[mode]}
               className={cn(
@@ -375,7 +381,17 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
               )}
             />
           </label>
-          <div className="mt-2 flex justify-end">
+          <div className="mt-2 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                triggerRef.current?.focus();
+              }}
+              className="rounded px-2.5 py-1 text-[13px] font-medium text-text-2 transition-colors duration-fast ease-standard hover:bg-bg-elev hover:text-text"
+            >
+              Cancel
+            </button>
             <button
               type="button"
               onClick={() => commit(draft)}

--- a/web/src/components/ui/PeriodPicker.tsx
+++ b/web/src/components/ui/PeriodPicker.tsx
@@ -3,14 +3,25 @@
 /**
  * DatePicker/PeriodPicker — design.md §8.2b: modes day / range / month /
  * quarter / year (the closed period grammar, line-items.md §6) ·
- * open/closed · error · presets.
+ * open/closed · error · presets. Every mode is pick-or-type: the panel
+ * embeds the mode's grid (DatePicker calendar, MonthPicker,
+ * QuarterPicker, FY YearPicker) above the grammar input — the input
+ * stays editable (the a11y path) and a valid typed draft drives the
+ * grid's selection and visible month/year.
  */
 
 import React, { useEffect, useRef, useState } from "react";
 import { Calendar, ChevronDown } from "lucide-react";
+import { format, isBefore, isValid, parseISO } from "date-fns";
 import { formatIso } from "@/lib/dates";
 import { cn } from "@/lib/cn";
-import { useViewportShiftX } from "@/lib/use-viewport-clamp";
+import { useViewportShiftXY } from "@/lib/use-viewport-clamp";
+import {
+  DatePicker,
+  MonthPicker,
+  QuarterPicker,
+  YearPicker,
+} from "./DatePicker";
 
 export type PeriodMode = "day" | "range" | "month" | "quarter" | "year";
 
@@ -63,6 +74,67 @@ const MODE_PATTERN: Record<PeriodMode, RegExp> = {
 export const isValidPeriod = (mode: PeriodMode, value: string): boolean =>
   MODE_PATTERN[mode].test(value);
 
+/** yyyy-MM-dd → Date (null when grammar- or calendar-invalid). */
+const parseDay = (value: string): Date | null => {
+  if (!MODE_PATTERN.day.test(value)) return null;
+  const day = parseISO(value);
+  return isValid(day) ? day : null;
+};
+
+/** Grid selection the current draft (or committed value) describes. */
+const parseDraft = (
+  mode: PeriodMode,
+  draft: string,
+): {
+  day: Date | null;
+  from: Date | null;
+  to: Date | null;
+  month: Date | null;
+  quarter: { year: number; quarter: number } | null;
+  year: number | null;
+} => {
+  const none = {
+    day: null,
+    from: null,
+    to: null,
+    month: null,
+    quarter: null,
+    year: null,
+  };
+  switch (mode) {
+    case "day":
+      return { ...none, day: parseDay(draft) };
+    case "range": {
+      // A lone start ("2026-06-01..") keeps the calendar anchored while
+      // the second click is pending.
+      const [from, to] = draft.split("..");
+      return {
+        ...none,
+        from: from ? parseDay(from) : null,
+        to: to ? parseDay(to) : null,
+      };
+    }
+    case "month":
+      return {
+        ...none,
+        month: MODE_PATTERN.month.test(draft) ? parseISO(`${draft}-01`) : null,
+      };
+    case "quarter": {
+      const match = /^(\d{4})-Q([1-4])$/.exec(draft);
+      return match
+        ? {
+            ...none,
+            quarter: { year: Number(match[1]), quarter: Number(match[2]) },
+          }
+        : none;
+    }
+    case "year": {
+      const match = /^FY(\d{4})$/.exec(draft);
+      return match ? { ...none, year: Number(match[1]) } : none;
+    }
+  }
+};
+
 /**
  * Figma trigger copy is humanized ("12 Jan 2026", "1 Apr – 30 Jun 2026",
  * "Jun 2026", "Q2 2026", "FY2025") while the value keeps the period
@@ -101,12 +173,18 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState(value ?? "");
   const [draftError, setDraftError] = useState<string | null>(null);
+  // Range picking is two clicks — the pending start lives here until
+  // the end click commits (or the panel closes).
+  const [rangeStart, setRangeStart] = useState<Date | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
-  // The panel is min-w-56 while the trigger can be narrower (Overview
+  // The panel is min-w-56+ while the trigger can be narrower (Overview
   // header w-36) — left-anchored it overflowed the right viewport edge
-  // (system QA 2026-07-19). Clamp keeps it fully in the viewport.
-  const shiftX = useViewportShiftX(open, panelRef);
+  // (system QA 2026-07-19); the embedded grids are tall enough to clip
+  // the bottom edge on low anchors. The two-axis clamp keeps the panel
+  // fully in the viewport.
+  const shift = useViewportShiftXY(open, panelRef);
 
   // Track the controlled value — adjust-state-during-render, no effect.
   const [prevValue, setPrevValue] = useState(value);
@@ -115,13 +193,25 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
     setDraft(value ?? "");
   }
 
+  // Abandoned half-picked ranges reset when the panel opens or closes.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
+    setRangeStart(null);
+  }
+
   useEffect(() => {
     if (!open) return;
     const onPointerDown = (event: PointerEvent) => {
       if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
     };
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
+      if (event.key === "Escape") {
+        setOpen(false);
+        // Focus management: Escape hands focus back to the trigger
+        // (outside clicks leave focus where the user put it).
+        triggerRef.current?.focus();
+      }
     };
     document.addEventListener("pointerdown", onPointerDown);
     document.addEventListener("keydown", onKeyDown);
@@ -137,8 +227,33 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
       return;
     }
     setDraftError(null);
+    setDraft(next);
     onValueChange?.(next);
     setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  // Grid selection follows the live draft, so a valid typed value moves
+  // the calendar before it is applied (picker ↔ input sync).
+  const parsed = parseDraft(mode, draft);
+
+  /** Calendar day click — commits directly (range: start, then end). */
+  const pickDay = (day: Date) => {
+    const iso = format(day, "yyyy-MM-dd");
+    if (mode === "day") {
+      commit(iso);
+      return;
+    }
+    if (rangeStart === null) {
+      setRangeStart(day);
+      setDraft(`${iso}..`);
+      setDraftError(null);
+      return;
+    }
+    const [from, to] = isBefore(day, rangeStart)
+      ? [day, rangeStart]
+      : [rangeStart, day];
+    commit(`${format(from, "yyyy-MM-dd")}..${format(to, "yyyy-MM-dd")}`);
   };
 
   const shownError = error ?? draftError;
@@ -151,6 +266,7 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
         </span>
       ) : null}
       <button
+        ref={triggerRef}
         type="button"
         aria-expanded={open}
         aria-haspopup="dialog"
@@ -188,8 +304,16 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
           ref={panelRef}
           role="dialog"
           aria-label={`Pick ${mode}`}
-          style={shiftX ? { transform: `translateX(${shiftX}px)` } : undefined}
-          className="absolute left-0 top-full z-dropdown mt-1 w-full min-w-56 rounded border border-border bg-bg p-3 shadow-lg"
+          style={
+            shift.x || shift.y
+              ? { transform: `translate(${shift.x}px, ${shift.y}px)` }
+              : undefined
+          }
+          className={cn(
+            "absolute left-0 top-full z-dropdown mt-1 w-full rounded border border-border bg-bg p-3 shadow-lg",
+            // The 7-column calendar needs the wider floor (7×32px cells).
+            mode === "day" || mode === "range" ? "min-w-64" : "min-w-56",
+          )}
         >
           {presets.length > 0 ? (
             <div className="mb-2 flex flex-wrap gap-1.5">
@@ -209,7 +333,32 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
               ))}
             </div>
           ) : null}
-          <label className="block text-[11px] font-medium uppercase tracking-wide text-text-2">
+          {mode === "day" ? (
+            <DatePicker value={parsed.day} onSelect={pickDay} />
+          ) : mode === "range" ? (
+            <DatePicker
+              value={rangeStart ?? parsed.from}
+              rangeEnd={rangeStart ? null : parsed.to}
+              onSelect={pickDay}
+            />
+          ) : mode === "month" ? (
+            <MonthPicker
+              value={parsed.month}
+              onSelect={(monthStart) => commit(format(monthStart, "yyyy-MM"))}
+            />
+          ) : mode === "quarter" ? (
+            <QuarterPicker
+              value={parsed.quarter}
+              onSelect={(next) => commit(`${next.year}-Q${next.quarter}`)}
+            />
+          ) : (
+            <YearPicker
+              value={parsed.year}
+              formatLabel={(year) => `FY${year}`}
+              onSelect={(year) => commit(`FY${year}`)}
+            />
+          )}
+          <label className="mt-2 block border-t border-border pt-2 text-[11px] font-medium uppercase tracking-wide text-text-2">
             {mode}
             <input
               autoFocus

--- a/web/src/lib/use-viewport-clamp.test.ts
+++ b/web/src/lib/use-viewport-clamp.test.ts
@@ -4,6 +4,7 @@ import {
   VIEWPORT_GUTTER,
   clampShiftX,
   useViewportShiftX,
+  useViewportShiftXY,
 } from "./use-viewport-clamp";
 
 describe("clampShiftX (floating-layer viewport clamp)", () => {
@@ -79,5 +80,45 @@ describe("useViewportShiftX", () => {
       window.dispatchEvent(new Event("resize"));
     });
     expect(result.current).toBe(0);
+  });
+});
+
+describe("useViewportShiftXY (two-axis clamp for the calendar panels)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const panelAt = (rect: Partial<DOMRect>) =>
+    ({
+      getBoundingClientRect: () => rect as DOMRect,
+    }) as HTMLElement;
+
+  it("clamps both axes independently", () => {
+    vi.stubGlobal("innerWidth", 1440);
+    vi.stubGlobal("innerHeight", 900);
+    const ref = {
+      current: panelAt({ left: 1272, right: 1496, top: 700, bottom: 1020 }),
+    };
+    const { result } = renderHook(() => useViewportShiftXY(true, ref));
+    expect(result.current).toEqual({
+      x: 1440 - VIEWPORT_GUTTER - 1496,
+      y: 900 - VIEWPORT_GUTTER - 1020,
+    });
+  });
+
+  it("returns zero shift for an in-viewport panel and resets on close", () => {
+    vi.stubGlobal("innerWidth", 1440);
+    vi.stubGlobal("innerHeight", 900);
+    const ref = {
+      current: panelAt({ left: 400, right: 624, top: 100, bottom: 420 }),
+    };
+    const { result, rerender } = renderHook(
+      ({ open }: { open: boolean }) => useViewportShiftXY(open, ref),
+      { initialProps: { open: true } },
+    );
+    expect(result.current).toEqual({ x: 0, y: 0 });
+    ref.current = panelAt({ left: 1272, right: 1496, top: 700, bottom: 1020 });
+    rerender({ open: false });
+    expect(result.current).toEqual({ x: 0, y: 0 });
   });
 });

--- a/web/src/lib/use-viewport-clamp.ts
+++ b/web/src/lib/use-viewport-clamp.ts
@@ -77,3 +77,63 @@ export const useViewportShiftX = (
 
   return shift;
 };
+
+export interface ViewportShift {
+  x: number;
+  y: number;
+}
+
+const NO_SHIFT: ViewportShift = { x: 0, y: 0 };
+
+/**
+ * Two-axis variant of useViewportShiftX — the calendar grids made the
+ * PeriodPicker panel tall enough to clip the bottom viewport edge on
+ * low anchors (390 canon viewport), so the same 1-D clamp runs on Y
+ * too. clampShiftX is axis-agnostic: pass top/bottom + innerHeight.
+ */
+export const useViewportShiftXY = (
+  open: boolean,
+  panelRef: RefObject<HTMLElement | null>,
+): ViewportShift => {
+  const [shift, setShift] = useState(NO_SHIFT);
+
+  // Reset when the layer closes — adjust-state-during-render, no effect.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
+    if (!open) setShift(NO_SHIFT);
+  }
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    // Mirrors the shift already painted so resize re-measures can
+    // recover the unshifted anchor geometry from the live rect.
+    let applied = NO_SHIFT;
+    const measure = () => {
+      const panel = panelRef.current;
+      if (!panel || typeof window === "undefined") return;
+      const rect = panel.getBoundingClientRect();
+      const next = {
+        x: clampShiftX(
+          rect.left - applied.x,
+          rect.right - applied.x,
+          window.innerWidth,
+        ),
+        y: clampShiftX(
+          rect.top - applied.y,
+          rect.bottom - applied.y,
+          window.innerHeight,
+        ),
+      };
+      applied = next;
+      setShift((current) =>
+        current.x === next.x && current.y === next.y ? current : next,
+      );
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [open, panelRef]);
+
+  return shift;
+};


### PR DESCRIPTION
## Summary

Every dashboard date field is now a **real picker** while staying fully typeable (the a11y path) — user directive.

**New `components/ui/DatePicker.tsx`** (bespoke per the reuse policy — headless behavior only, date-fns math, tokens only):
- **`DatePicker`** — calendar month grid: Sunday-first single-letter weekday header (S M T W T F S, per the Figma DatePicker master), month chevron nav, selected = filled accent cell, today = accent-outlined cell, outside days muted, optional min/max disabling, in-range tint, roving arrow-key focus that flips the month at a grid edge. `calendarDays` is the exported pure grid math.
- **`MonthPicker`** — year chevron nav + 12-month grid; **`QuarterPicker`** (year nav + Q1–Q4) and **`YearPicker`** (year list, newest first, FY#### labels) extend the same anatomy to the rest of the closed period grammar.

**PeriodPicker** embeds the mode's grid in its existing popover above the grammar input, so every call site got the picker with **no call-site changes**: Overview month switch, transactions range filter + inspector txn date, reports month/FY periods, company statements quarter, ratios FY, filing wizard VAT month / CIT FY. Marketing untouched.

- **Typing preserved**: a grammar-valid draft drives the grid's selection and visible month/year before Apply; invalid drafts keep the existing inline validation.
- Grid picks commit immediately; range mode is two clicks (pending start held in the input as `from..`, endpoints normalized).
- Master's **Cancel/Apply** footer; Escape/Cancel/commit return focus to the trigger. The input's Enter commit `preventDefault`s — the browser's Enter activation otherwise clicks the re-focused trigger and reopens the popover (caught by e2e).
- **Collision canon on both axes**: `useViewportShiftXY` (use-viewport-clamp) reuses the 1-D clamp on Y for the taller panel; `useViewportShiftX` untouched for OrgSwitcher.
- Reconciled to the design lane's landing Figma masters (screenshots in its scratchpad; its report/design.md row is the design agent's lane). The master's range preset rail is a noted design-lane follow-up — presets stay the as-built chips.

## Tests

- **Unit (437 ✓)**: `calendarDays` grid math (leap Feb 2024, non-leap, 24-month Sunday-first alignment), min/max disabling, chevron nav, typed-value month snap, arrow-key roving across a month edge, range endpoints; MonthPicker/QuarterPicker/YearPicker; PeriodPicker pick-commits per mode, two-click range with order normalization, typed draft ↔ grid sync, Cancel/Escape focus return, two-axis collision clamp (right overflow, bottom overflow, unshifted).
- **e2e (56 ✓)**: new `e2e/date-picker.spec.ts` at 1440×900 and 390×844 — open picker → pick June in the grid → value applied + the category query refires (donut re-titles), typed sync before Apply, popover boundingBox fully in-viewport per the collision canon. `floating-layers.spec.ts` unchanged and green.

## Gates

- `npm run lint` (prettier + eslint + boundaries) ✓
- `npm run typecheck` ✓
- `npm run test` — 437 ✓
- `npm run test:e2e` — 56 ✓
- `npm run build` ✓

## Docs

`docs/web-implementation.md` DatePicker as-built note. design.md row is owned by the parallel design lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)