### PR TITLE
fix(web): pin A5a how-it-works thumbs to the frame's 384×190 box

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -330,6 +330,14 @@ adjudicated audit ledger):**
   (`showDeveloperTools: "never"` — `showToolbar` is its deprecated
   alias), never a fork.
 
+**A5a thumb clamp as-built (2026-07-20,
+`fix/howitworks-thumb-alignment`):** the three how-it-works step thumbs
+are pinned to the frame's 384×190 box (`aspect-[384/190]` + overflow
+clip — the taller B3b/B1/B7 embeds crop at the bottom exactly as the
+A5a thumbs do), so the numbered captions sit on one aligned row at
+desktop; the home e2e asserts the caption row stays level (±2px) at
+1440 in both themes.
+
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -263,6 +263,56 @@ test.describe("public home `/` (Part A)", () => {
     expect(orphanRows).toBe(0);
   });
 
+  test("A5a: uniform thumbs pin the step captions to one row at 1440 (both themes)", async ({
+    page,
+  }, testInfo) => {
+    // Figma A5a pin: every step thumb is a 384×190 box (taller embeds clip
+    // at the bottom), so the numbered captions share a single row.
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/");
+    for (const theme of ["light", "dark"] as const) {
+      await page.evaluate(
+        (next) => window.localStorage.setItem("expendit.theme", next),
+        theme,
+      );
+      await page.reload();
+      const section = page.locator("#how-it-works");
+      await section.scrollIntoViewIfNeeded();
+
+      const thumbs = section.locator('[data-testid="how-thumb"]');
+      await expect(thumbs).toHaveCount(3);
+      for (let i = 0; i < 3; i += 1) {
+        const box = await thumbs.nth(i).boundingBox();
+        expect
+          .soft(Math.abs((box?.width ?? 0) - 384), `thumb ${i} width ${theme}`)
+          .toBeLessThanOrEqual(1);
+        expect
+          .soft(
+            Math.abs((box?.height ?? 0) - 190),
+            `thumb ${i} height ${theme}`,
+          )
+          .toBeLessThanOrEqual(1);
+      }
+
+      const captions = section.locator('[data-testid="how-step-caption"]');
+      await expect(captions).toHaveCount(3);
+      const tops: number[] = [];
+      for (let i = 0; i < 3; i += 1) {
+        const box = await captions.nth(i).boundingBox();
+        tops.push(box?.y ?? Number.NaN);
+      }
+      expect(
+        Math.max(...tops) - Math.min(...tops),
+        `caption row skew (${theme}): ${tops.join(", ")}`,
+      ).toBeLessThanOrEqual(2);
+
+      await testInfo.attach(`how-it-works-${theme}`, {
+        body: await section.screenshot(),
+        contentType: "image/png",
+      });
+    }
+  });
+
   test("renders at 375w (responsive floor)", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 800 });
     await page.goto("/");

--- a/web/src/components/home/HowItWorksSection.tsx
+++ b/web/src/components/home/HowItWorksSection.tsx
@@ -84,8 +84,14 @@ export const HowItWorksSection: React.FC = () => {
           {STEPS.map((step) => (
             <li key={step.number}>
               {/* Thumb: inert composition + link overlay (no nested
-                  interactive elements — the embed is decorative). */}
-              <div className="relative overflow-hidden rounded border border-border bg-bg transition-transform duration-base ease-standard hover:-translate-y-0.5 motion-reduce:hover:translate-y-0">
+                  interactive elements — the embed is decorative). The box is
+                  pinned to the frame's 384×190 thumb proportions (A5a) —
+                  taller embeds clip at the bottom, so all three captions
+                  sit on one aligned row. */}
+              <div
+                data-testid="how-thumb"
+                className="relative aspect-[384/190] overflow-hidden rounded border border-border bg-bg transition-transform duration-base ease-standard hover:-translate-y-0.5 motion-reduce:hover:translate-y-0"
+              >
                 <div inert className="pointer-events-none select-none">
                   {step.thumb}
                 </div>
@@ -96,7 +102,10 @@ export const HowItWorksSection: React.FC = () => {
                   className="absolute inset-0 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent"
                 />
               </div>
-              <div className="mt-5 flex items-center gap-3">
+              <div
+                data-testid="how-step-caption"
+                className="mt-5 flex items-center gap-3"
+              >
                 <span className="flex h-6 w-6 items-center justify-center rounded-full bg-accent text-[13px] font-semibold text-on-accent">
                   {step.number}
                 </span>


### PR DESCRIPTION
## What

The Figma A5a "How it works" section (Home `193:14` → `279:2`) clips every step thumb to a uniform **384×190** frame — the taller B3b/B1/B7 compositions (197/261/245 at 384 wide) crop at the bottom, so the three numbered captions sit on one row. The live section let each `ScaledEmbed` run at its natural scaled height (design heights 740/980/920 on 1440), so the middle Overview column pushed its caption lower and the captions staggered column by column.

## How

- `HowItWorksSection`: the thumb wrapper now carries `aspect-[384/190]` + `overflow-hidden`, clamping the media region to the frame's proportions at every breakpoint (mobile stacking unchanged — each stacked card just keeps the frame's thumb aspect). Taller embeds clip at the bottom exactly like the Figma thumbs.
- e2e (`home.spec.ts`): new journey at 1440 asserts all three thumbs are 384×190 (±1px) and the caption row is level (±2px) in **both themes**, attaching section screenshots.
- docs: `web-implementation.md` A5a thumb-clamp as-built note.

## Verification

- Caption y at 1440 after fix: `591.67, 591.67, 591.67` (light and dark identical); section screenshots visually match the Figma A5a reference render in both themes.
- Gates: `lint` ✅ · `typecheck` ✅ · unit `437/437` ✅ · Playwright `57/57` ✅ · `next build` ✅

Do not merge — awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)