### PR TITLE
feat(web): self-host snippet goes tabbed — Docker Compose | Helm (Figma 474:2)

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -374,6 +374,26 @@ plus typed sync and the in-viewport boundingBox at both widths;
 `floating-layers.spec.ts` unchanged). Presets stay the as-built chips
 row (the master's range preset rail is a design-lane follow-up).
 
+**Self-host tabbed snippet as-built (2026-07-20, PR #239).** The A8a
+compose one-liner is now the user-approved Docker Compose | Helm tab pair
+(A8c, Figma proposal 474:2): `CodeSnippet` gained a tabbed mode (the
+single-block mode is unchanged) — Radix Tabs supply roving focus + ARIA
+per the kit reuse policy, the active tab carries the 2px accent underline
+(labels stay font-medium in both states, so switching never reflows
+them), and copy targets the ACTIVE tab's full two-line block: `git clone
+https://github.com/cuesoftinc/expendit` shared; `cd expendit && docker
+compose up --build -d` (the repo's `make up`) vs `cd expendit && helm
+install expendit deploy/helm` (the real chart path). The rendered `$ `
+prompts are decorative (select-none) and stay out of the payload. The
+shared muted caption renders once under the block — "Compose ships
+MongoDB + Redis — the Helm chart expects reachable instances
+(MONGODB_URL, REDIS_URL)." — visible in both tab states, so switching
+never shifts layout. The section eyebrow drops "· docker" (now
+method-neutral "self-host"). Unit: `CodeSnippet.test.tsx` tabbed cases
+(tab state, per-tab copy payload, Radix roving focus, copied-morph
+reset); e2e: `home.spec.ts` pins helm-tab copy → the clipboard payload,
+caption persistence and the 1440/390 container fit.
+
 ## 3. Token mapping — design.md §2 → `web/src/design/tokens.css`
 
 One custom property per Figma variable in the `expendit/tokens` collection

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -278,4 +278,57 @@ test.describe("public home `/` (Part A)", () => {
     );
     expect(overflow).toBeLessThanOrEqual(1);
   });
+
+  // A8c tabbed snippet (Figma 474:2): tab switch is instant with no layout
+  // shift, the shared MongoDB/Redis caption persists in both tab states,
+  // copy targets the ACTIVE tab's full two-line block, and the block fits
+  // the 1440/390 container canons.
+  test("A8a self-host tabs — helm copy + caption persists", async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/");
+    const block = page.getByTestId("selfhost-snippet");
+    await block.scrollIntoViewIfNeeded();
+    const caption = block.getByText(
+      "Compose ships MongoDB + Redis — the Helm chart expects reachable instances (MONGODB_URL, REDIS_URL).",
+    );
+    await expect(caption).toBeVisible();
+    const tablist = block.getByRole("tablist", { name: "Install method" });
+
+    const before = await block.boundingBox();
+    await tablist.getByRole("tab", { name: "Helm" }).click();
+    await expect(
+      block.getByText("cd expendit && helm install expendit deploy/helm"),
+    ).toBeVisible();
+    await expect(caption).toBeVisible();
+    // no layout shift — mirrored two-line block + always-rendered caption
+    const after = await block.boundingBox();
+    expect(after!.height).toBe(before!.height);
+    expect(after!.width).toBe(before!.width);
+
+    await block.getByRole("button", { name: "Copy code" }).click();
+    await expect(block.getByTestId("copy-check")).toBeVisible();
+    const clip = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clip).toBe(
+      "git clone https://github.com/cuesoftinc/expendit\ncd expendit && helm install expendit deploy/helm",
+    );
+
+    // 390 canon: block inside the viewport, no document overflow
+    await page.setViewportSize({ width: 390, height: 844 });
+    await block.scrollIntoViewIfNeeded();
+    await expect(caption).toBeVisible();
+    const mobile = await block.boundingBox();
+    expect(mobile!.width).toBeLessThanOrEqual(390);
+    const mobileOverflow = await page.evaluate(
+      () =>
+        Math.max(
+          document.documentElement.scrollWidth,
+          document.body.scrollWidth,
+        ) - document.documentElement.clientWidth,
+    );
+    expect(mobileOverflow).toBeLessThanOrEqual(1);
+  });
 });

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -1602,6 +1602,22 @@ export const ComponentGallery: React.FC = () => {
               />
             </div>
           </Variant>
+          <Variant label="code — tabbed (A8c: Docker Compose | Helm, copy per active tab)">
+            <div className="w-full max-w-md">
+              <CodeSnippet
+                tabs={[
+                  {
+                    label: "Docker Compose",
+                    code: "git clone https://github.com/cuesoftinc/expendit\ncd expendit && docker compose up --build -d",
+                  },
+                  {
+                    label: "Helm",
+                    code: "git clone https://github.com/cuesoftinc/expendit\ncd expendit && helm install expendit deploy/helm",
+                  },
+                ]}
+              />
+            </div>
+          </Variant>
           <Variant label="editorial: pillar / community (hover for lift + underline)">
             <div className="grid w-full grid-cols-1 gap-3 md:grid-cols-2">
               <EditorialCard

--- a/web/src/components/home/SelfHostCommunity.tsx
+++ b/web/src/components/home/SelfHostCommunity.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 /**
- * A8a — Self-host (dark editorial): data-ownership pitch, docker compose
- * one-liner (CodeSnippet copy ✓ morph), what ships, docs links.
+ * A8a — Self-host (dark editorial): data-ownership pitch, the tabbed
+ * Docker Compose | Helm snippet (A8c, Figma 474:2 — CodeSnippet tabs mode,
+ * copy ✓ morph on the active tab) with the shared MongoDB/Redis caption,
+ * what ships, docs links.
  * A9 — Community: Discord card + roadmap link.
  */
 
@@ -20,6 +22,22 @@ import {
   SELF_HOST_DOCS_URL,
 } from "./links";
 
+/** Mirrored two-line snippets — line 2 is `make up` (compose) or the real
+ *  chart at deploy/helm. */
+const SELF_HOST_TABS = [
+  {
+    label: "Docker Compose",
+    code: "git clone https://github.com/cuesoftinc/expendit\ncd expendit && docker compose up --build -d",
+  },
+  {
+    label: "Helm",
+    code: "git clone https://github.com/cuesoftinc/expendit\ncd expendit && helm install expendit deploy/helm",
+  },
+];
+
+const SELF_HOST_CAPTION =
+  "Compose ships MongoDB + Redis — the Helm chart expects reachable instances (MONGODB_URL, REDIS_URL).";
+
 export const SelfHostSection: React.FC = () => {
   const { track } = useAnalyticsController();
   return (
@@ -28,14 +46,21 @@ export const SelfHostSection: React.FC = () => {
         <SectionHeading>
           Self-host: your books never leave your building
         </SectionHeading>
-        <div className="mx-auto mt-8 max-w-[460px] text-left">
-          <p className="mb-2 font-mono text-[13px] text-text-2">
-            self-host · docker
-          </p>
+        <div
+          className="mx-auto mt-8 max-w-[460px] text-left"
+          data-testid="selfhost-snippet"
+        >
+          <p className="mb-2 font-mono text-[13px] text-text-2">self-host</p>
           <CodeSnippet
-            code="$ docker compose up -d   # api · web · mongo · redis"
-            label="Self-host command"
+            tabs={SELF_HOST_TABS}
+            tabsLabel="Install method"
+            label="Self-host commands"
           />
+          {/* shared caption — rendered once, outside the tab panels, so
+              both tab states keep it and switching never shifts layout */}
+          <p className="mt-2 text-xs leading-normal text-text-2">
+            {SELF_HOST_CAPTION}
+          </p>
         </div>
         <p className="mx-auto mt-8 max-w-3xl text-sm leading-relaxed text-text-2">
           Built for firms and accountants who can’t ship financial data to

--- a/web/src/components/ui/CodeSnippet.test.tsx
+++ b/web/src/components/ui/CodeSnippet.test.tsx
@@ -2,6 +2,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import CodeSnippet from "./CodeSnippet";
 
+const TABS = [
+  {
+    label: "Docker Compose",
+    code: "git clone https://github.com/cuesoftinc/expendit\ncd expendit && docker compose up --build -d",
+  },
+  {
+    label: "Helm",
+    code: "git clone https://github.com/cuesoftinc/expendit\ncd expendit && helm install expendit deploy/helm",
+  },
+];
+
 describe("CodeSnippet (design.md §8.2b)", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -13,6 +24,63 @@ describe("CodeSnippet (design.md §8.2b)", () => {
     expect(block).toHaveClass("font-mono", "text-[13px]");
     expect(block.closest('[data-theme="dark"]')).not.toBeNull();
     expect(screen.getByText("docker compose up -d")).toBeInTheDocument();
+  });
+
+  it("tabbed mode (A8c): mirrored tabs, active-tab copy payload, prompt decor", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(
+      <CodeSnippet
+        tabs={TABS}
+        tabsLabel="Install method"
+        label="Self-host commands"
+      />,
+    );
+
+    // tablist semantics — docker active by default, helm panel unmounted
+    const tablist = screen.getByRole("tablist", { name: "Install method" });
+    expect(tablist).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Docker Compose" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(
+      screen.getByText(/docker compose up --build -d/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/helm install expendit/)).not.toBeInTheDocument();
+
+    // switch to Helm — the mirrored two-line block swaps in
+    fireEvent.click(screen.getByRole("tab", { name: "Helm" }));
+    expect(screen.getByRole("tab", { name: "Helm" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(
+      screen.getByText(/helm install expendit deploy\/helm/),
+    ).toBeInTheDocument();
+
+    // copy targets the ACTIVE tab's full block — `$ ` prompts stay out
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+    await act(async () => {
+      // flush the clipboard promise
+    });
+    expect(writeText).toHaveBeenCalledWith(TABS[1].code);
+
+    // switching tabs resets the copied morph
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: "Docker Compose" }));
+    expect(
+      screen.getByRole("button", { name: "Copy code" }),
+    ).toBeInTheDocument();
+  });
+
+  it("tabbed mode: arrow keys rove focus across the tablist (Radix)", () => {
+    render(<CodeSnippet tabs={TABS} />);
+    const docker = screen.getByRole("tab", { name: "Docker Compose" });
+    const helm = screen.getByRole("tab", { name: "Helm" });
+    docker.focus();
+    fireEvent.keyDown(docker, { key: "ArrowRight" });
+    expect(helm).toHaveFocus();
   });
 
   it("copy morphs idle → copied ✓ and resets", async () => {

--- a/web/src/components/ui/CodeSnippet.test.tsx
+++ b/web/src/components/ui/CodeSnippet.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import CodeSnippet from "./CodeSnippet";
 
 const TABS = [
@@ -50,7 +51,7 @@ describe("CodeSnippet (design.md §8.2b)", () => {
     expect(screen.queryByText(/helm install expendit/)).not.toBeInTheDocument();
 
     // switch to Helm — the mirrored two-line block swaps in
-    fireEvent.click(screen.getByRole("tab", { name: "Helm" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Helm" }));
     expect(screen.getByRole("tab", { name: "Helm" })).toHaveAttribute(
       "aria-selected",
       "true",
@@ -60,27 +61,25 @@ describe("CodeSnippet (design.md §8.2b)", () => {
     ).toBeInTheDocument();
 
     // copy targets the ACTIVE tab's full block — `$ ` prompts stay out
-    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
-    await act(async () => {
-      // flush the clipboard promise
-    });
+    await userEvent.click(screen.getByRole("button", { name: "Copy code" }));
     expect(writeText).toHaveBeenCalledWith(TABS[1].code);
 
     // switching tabs resets the copied morph
     expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("tab", { name: "Docker Compose" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Docker Compose" }));
     expect(
       screen.getByRole("button", { name: "Copy code" }),
     ).toBeInTheDocument();
   });
 
-  it("tabbed mode: arrow keys rove focus across the tablist (Radix)", () => {
+  it("tabbed mode: arrow keys rove focus across the tablist (Radix)", async () => {
     render(<CodeSnippet tabs={TABS} />);
     const docker = screen.getByRole("tab", { name: "Docker Compose" });
     const helm = screen.getByRole("tab", { name: "Helm" });
     docker.focus();
-    fireEvent.keyDown(docker, { key: "ArrowRight" });
+    await userEvent.keyboard("{ArrowRight}");
     expect(helm).toHaveFocus();
+    expect(helm).toHaveAttribute("aria-selected", "true");
   });
 
   it("copy morphs idle → copied ✓ and resets", async () => {

--- a/web/src/components/ui/CodeSnippet.tsx
+++ b/web/src/components/ui/CodeSnippet.tsx
@@ -80,7 +80,10 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({
           }}
         >
           <div className="flex items-start gap-4 px-4 pt-3">
-            <RadixTabs.List aria-label={tabsLabel} className="flex flex-1 gap-4">
+            <RadixTabs.List
+              aria-label={tabsLabel}
+              className="flex flex-1 gap-4"
+            >
               {tabs.map((tab) => (
                 <RadixTabs.Trigger
                   key={tab.label}

--- a/web/src/components/ui/CodeSnippet.tsx
+++ b/web/src/components/ui/CodeSnippet.tsx
@@ -4,14 +4,31 @@
  * CodeSnippet — design.md §8.2b: Mono/13 block on dark · copy idle /
  * copied (✓ morph). Dark surface scopes `data-theme="dark"` (tokens
  * only); used on the home page self-host section.
+ *
+ * Tabbed mode (A8c, Figma 474:2): pass `tabs` for the mirrored
+ * Docker Compose | Helm pair — Radix Tabs supplies roving focus + ARIA
+ * (kit reuse policy), the active tab carries the 2px accent underline,
+ * and copy targets the ACTIVE tab's full block. The rendered `$ `
+ * prompts are decorative (select-none) and stay out of the payload.
  */
 
 import React, { useEffect, useState } from "react";
+import * as RadixTabs from "@radix-ui/react-tabs";
 import { Check, Copy } from "lucide-react";
 import { cn } from "@/lib/cn";
 
-export interface CodeSnippetProps {
+export interface CodeSnippetTab {
+  label: string;
   code: string;
+}
+
+export interface CodeSnippetProps {
+  /** Single-block mode. */
+  code?: string;
+  /** Tabbed mode — mirrored snippets; takes precedence over `code`. */
+  tabs?: CodeSnippetTab[];
+  /** Accessible name for the tablist (tabbed mode). */
+  tabsLabel?: string;
   /** Accessible label for the block. */
   label?: string;
   className?: string;
@@ -19,10 +36,13 @@ export interface CodeSnippetProps {
 
 export const CodeSnippet: React.FC<CodeSnippetProps> = ({
   code,
+  tabs,
+  tabsLabel = "Install method",
   label = "Code snippet",
   className,
 }) => {
   const [copied, setCopied] = useState(false);
+  const [activeLabel, setActiveLabel] = useState(tabs?.[0]?.label ?? "");
 
   useEffect(() => {
     if (!copied) return;
@@ -30,14 +50,101 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({
     return () => clearTimeout(timer);
   }, [copied]);
 
+  const activeCode = tabs?.length
+    ? (tabs.find((tab) => tab.label === activeLabel) ?? tabs[0]).code
+    : (code ?? "");
+
   const onCopy = async () => {
     try {
-      await navigator.clipboard.writeText(code);
+      await navigator.clipboard.writeText(activeCode);
       setCopied(true);
     } catch {
       // Clipboard unavailable (permissions/insecure context) — stay idle.
     }
   };
+
+  if (tabs?.length) {
+    return (
+      <div
+        data-theme="dark"
+        className={cn(
+          "rounded border border-border bg-bg-editorial",
+          className,
+        )}
+      >
+        <RadixTabs.Root
+          value={activeLabel}
+          onValueChange={(value) => {
+            setActiveLabel(value);
+            setCopied(false);
+          }}
+        >
+          <div className="flex items-start gap-4 px-4 pt-3">
+            <RadixTabs.List aria-label={tabsLabel} className="flex flex-1 gap-4">
+              {tabs.map((tab) => (
+                <RadixTabs.Trigger
+                  key={tab.label}
+                  value={tab.label}
+                  className={cn(
+                    "group flex flex-col gap-1 text-[13px] font-medium",
+                    "text-text-2 transition-colors duration-fast ease-standard",
+                    "hover:text-text data-[state=active]:text-text",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+                  )}
+                >
+                  {tab.label}
+                  <span
+                    aria-hidden="true"
+                    className="h-0.5 w-full bg-transparent group-data-[state=active]:bg-accent"
+                  />
+                </RadixTabs.Trigger>
+              ))}
+            </RadixTabs.List>
+            <button
+              type="button"
+              aria-label={copied ? "Copied" : "Copy code"}
+              data-state={copied ? "copied" : "idle"}
+              onClick={onCopy}
+              className={cn(
+                "shrink-0 p-1 transition-colors duration-fast ease-standard",
+                copied ? "text-income" : "text-text-2 hover:text-text",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+              )}
+            >
+              {copied ? (
+                <Check className="h-3.5 w-3.5" data-testid="copy-check" />
+              ) : (
+                <Copy className="h-3.5 w-3.5" />
+              )}
+            </button>
+          </div>
+          {tabs.map((tab) => (
+            <RadixTabs.Content
+              key={tab.label}
+              value={tab.label}
+              className="focus:outline-none"
+            >
+              <pre
+                aria-label={label}
+                className="overflow-x-auto px-4 pb-3.5 pt-2 font-mono text-[13px] leading-relaxed text-text"
+              >
+                <code>
+                  {tab.code.split("\n").map((line) => (
+                    <span key={line} className="block whitespace-nowrap">
+                      <span aria-hidden="true" className="select-none">
+                        {"$ "}
+                      </span>
+                      {line}
+                    </span>
+                  ))}
+                </code>
+              </pre>
+            </RadixTabs.Content>
+          ))}
+        </RadixTabs.Root>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -51,7 +158,7 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({
         aria-label={label}
         className="overflow-x-auto p-4 pr-12 font-mono text-[13px] leading-relaxed text-text"
       >
-        <code>{code}</code>
+        <code>{activeCode}</code>
       </pre>
       <button
         type="button"


### PR DESCRIPTION
## Summary
- A8a self-host snippet is now the user-approved tabbed block (A8c, Figma proposal 474:2): **Docker Compose | Helm**, mirrored two-line commands — `git clone https://github.com/cuesoftinc/expendit` shared; `cd expendit && docker compose up --build -d` (the repo's `make up`) vs `cd expendit && helm install expendit deploy/helm` (the real chart at `deploy/helm`).
- `CodeSnippet` gained a tabbed mode (single-block mode unchanged) — Radix Tabs supply roving focus + ARIA per the kit reuse policy; active tab carries the 2px accent underline (labels stay font-medium in both states, so switching never reflows them).
- Copy targets the ACTIVE tab's full block — rendered `$ ` prompts are decorative (select-none) and stay out of the payload; ✓ morph resets on tab switch.
- Shared muted caption renders once under the block, visible in both tab states (no layout shift): “Compose ships MongoDB + Redis — the Helm chart expects reachable instances (MONGODB_URL, REDIS_URL).” The section eyebrow drops “· docker” (now method-neutral).
- Dev gallery variant + web-implementation.md as-built note.

## Tests
- Unit (`CodeSnippet.test.tsx`): tabbed cases — tab state, per-tab copy payload, Radix roving focus, copied-morph reset; single-block cases unchanged.
- e2e (`home.spec.ts`): switch to Helm → copy → clipboard equals the full two-line helm block; caption persists across both states; block box stable; in-viewport at 1440/390.

## Gates
prettier ✓ eslint ✓ boundaries ✓ typecheck ✓ vitest ✓ next build ✓ playwright (full suite) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)