### PR TITLE
fix(web): DatePicker popover per master 467:11039, modal-safe merge Select, B1 mid-band balance

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -366,13 +366,41 @@ immediately (range mode: two clicks, start held in the input as
 Cancel/Apply pair; Escape/Cancel/commit return focus to the trigger
 (the input's Enter commit `preventDefault`s — the browser's Enter
 activation otherwise clicks the re-focused trigger and reopens the
-popover). The taller panel extends the collision canon to both axes:
-`useViewportShiftXY` (use-viewport-clamp) reuses the 1-D clamp on Y, so
-the panel never clips at 1440/390 (`e2e/date-picker.spec.ts` pins the
-Overview pick-a-month flow — value applied + category query refires —
-plus typed sync and the in-viewport boundingBox at both widths;
-`floating-layers.spec.ts` unchanged). Presets stay the as-built chips
-row (the master's range preset rail is a design-lane follow-up).
+popover). Geometry is the master's (set 467:11039): a 220px popover —
+194px content behind 12/10px padding — day cells 26×22 on 2/4px gaps,
+month cells 62×26 / a Q1–Q4 row / 26px year rows on a 4px gap, 14px nav
+chevrons, Table/13 throughout; the panel hugs the grid rather than
+stretching to the trigger. Collision follows the master's contract via
+`useAnchoredPanelPlacement` (use-viewport-clamp): the popover FLIPS
+above the field when viewport room below runs out (it never covers the
+field), caps with internal scroll when neither side fits — an open
+popover never exceeds the viewport or grows the document scroll
+height — clamps X against `documentElement.clientWidth` (innerWidth
+counts the classic scrollbar the panel used to sit flush under), and
+right-anchored triggers stay right-anchored (the Overview header).
+`e2e/date-picker.spec.ts` pins the Overview pick-a-month flow — value
+applied + category query refires — plus typed sync, the in-viewport
+boundingBox and unchanged document scrollHeight at 1440×900, 1440×700
+and 390; `floating-layers.spec.ts` unchanged. Presets stay the as-built
+chips row (the master's range preset rail is a design-lane follow-up).
+
+**Floating layers in modals + B1 band balance as-built (2026-07-20,
+`fix/datepicker-polish`).** (a) `Select portalMenu` is modal-safe: the
+portaled menu marks itself `data-floating-layer` + `pointer-events-auto`
+(Radix's modal body lock disables pointer events under `<body>`),
+`Modal` ignores outside interactions originating inside floating layers,
+and Escape with an open menu closes the menu only (second Escape reaches
+the dialog). The B8 merge modal opts in — its "Merge into" menu used to
+render inside the modal body's `overflow-auto` as a clipped inner
+scrollbox (`e2e/categories-merge.spec.ts` walks the merge end-to-end and
+pins the unclipped, height-capped construction). (b) The B1 mid-band
+drops `items-start`: the chart card stretches to the donut/anomalies
+rail (±2px e2e on personal and company orgs) through `ChartLine`'s
+`fill` mode — at lg+ the plot grows to the card's remaining height,
+floored at `lg:min-h-[176px]` so short rails never squash it
+(absolutely-filled SVG, `preserveAspectRatio="none"`, non-scaling
+strokes; the %-positioned tick ladder tracks any height); below lg the
+stacked aspect construction is unchanged.
 
 ## 3. Token mapping — design.md §2 → `web/src/design/tokens.css`
 

--- a/web/e2e/categories-merge.spec.ts
+++ b/web/e2e/categories-merge.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+/**
+ * B8 merge tool (user report): the "Merge into" Select rendered its
+ * absolute menu inside the modal body's overflow — a raw inner
+ * scrollbox with clipped rows. The menu now portals to <body>
+ * (data-floating-layer), stays modal-safe (picking an option must not
+ * dismiss the dialog), keeps the Select master's padded rows, caps its
+ * height with internal scroll, and the merge completes end-to-end.
+ */
+
+const signIn = async (page: Page): Promise<void> => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: "Continue with Google" }).click();
+  await page.waitForURL("**/dashboard", { timeout: 15_000 });
+};
+
+const expectFullyInViewport = async (locator: Locator): Promise<void> => {
+  const box = await locator.boundingBox();
+  const viewport = locator.page().viewportSize();
+  expect(box).not.toBeNull();
+  expect(viewport).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height);
+};
+
+test("merge modal: portaled dropdown is unclipped, height-capped, and the merge completes", async ({
+  page,
+}) => {
+  await signIn(page);
+  await page.goto("/dashboard/categories");
+  await page.getByRole("button", { name: "Merge" }).first().click();
+
+  const dialog = page.getByRole("dialog", { name: /^Merge/ });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("combobox").click();
+
+  // The menu escaped the modal body: full panel in-viewport, first row
+  // fully inside the panel (no half-clipped rows), height capped by the
+  // Select master's max-h-56 listbox (+ panel chrome).
+  const panel = page.locator("[data-floating-layer]");
+  await expect(panel).toBeVisible();
+  await expectFullyInViewport(panel);
+  const panelBox = await panel.boundingBox();
+  const firstOption = panel.getByRole("option").first();
+  await expect(firstOption).toBeVisible();
+  const optionBox = await firstOption.boundingBox();
+  expect(optionBox!.y).toBeGreaterThanOrEqual(panelBox!.y);
+  expect(optionBox!.y + optionBox!.height).toBeLessThanOrEqual(
+    panelBox!.y + panelBox!.height + 1,
+  );
+  expect(panelBox!.height).toBeLessThanOrEqual(236);
+
+  // Picking inside the portaled menu must not dismiss the dialog
+  // (Modal's outside-interaction guard).
+  await firstOption.click();
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByRole("button", { name: "Merge", exact: true }).click();
+  await expect(page.getByText(/Merged into/)).toBeVisible({
+    timeout: 15_000,
+  });
+});

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -393,6 +393,58 @@ test("overview mid-band forms two columns at lg (Figma 179:12)", async ({
   expect(trackCount).toBe(2);
 });
 
+test("overview mid-band bottoms align at lg — the chart card stretches to the rail (user report)", async ({
+  page,
+}) => {
+  const expectAlignedBand = async () => {
+    const band = page.getByTestId("overview-mid-band");
+    await expect(band).toBeVisible();
+    // ±2px: the chart card's bottom edge tracks the donut/anomalies
+    // rail (grid stretch + ChartLine fill absorbing the difference).
+    await expect
+      .poll(
+        async () => {
+          const chartBox = await band
+            .locator("> section")
+            .first()
+            .boundingBox();
+          const railBox = await band.locator("> div").last().boundingBox();
+          if (!chartBox || !railBox) return Number.NaN;
+          return Math.abs(
+            chartBox.y + chartBox.height - (railBox.y + railBox.height),
+          );
+        },
+        { timeout: 10_000 },
+      )
+      .toBeLessThanOrEqual(2);
+    // The plot absorbed the stretch but never dips below its floor.
+    const plotBox = await page
+      .getByTestId("overview-mid-band")
+      .getByTestId("chart-plot")
+      .boundingBox();
+    expect(plotBox!.height).toBeGreaterThanOrEqual(176);
+  };
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await signIn(page);
+  await expectAlignedBand();
+
+  // Company org: different rail composition, same contract.
+  await switchToCompanyOrg(page);
+  await expectAlignedBand();
+
+  // Stacked at 390 the aspect construction is unchanged — one column,
+  // no fill floor (the plot stays shorter than the lg minimum).
+  await page.setViewportSize({ width: 390, height: 844 });
+  const band = page.getByTestId("overview-mid-band");
+  const tracks = await band.evaluate(
+    (el) => getComputedStyle(el).gridTemplateColumns.trim().split(/\s+/).length,
+  );
+  expect(tracks).toBe(1);
+  const stackedPlot = await band.getByTestId("chart-plot").boundingBox();
+  expect(stackedPlot!.height).toBeLessThan(150);
+});
+
 test("purge modal — org-name typed confirm + Export first escape hatch (MI-15)", async ({
   page,
 }) => {

--- a/web/e2e/date-picker.spec.ts
+++ b/web/e2e/date-picker.spec.ts
@@ -4,8 +4,11 @@ import { expect, test, type Locator, type Page } from "@playwright/test";
  * Pick-or-type period fields (design.md §8.2b as built): the PeriodPicker
  * panel embeds the mode's grid — Overview month mode gets the 12-month
  * grid — and picking applies the value and refires the query (the donut
- * card re-titles to the picked month). The open panel obeys the
- * floating-layer collision canon at desktop (1440) and mobile (390).
+ * card re-titles to the picked month). The open panel obeys the master's
+ * collision contract (467:11039) at desktop (1440×900), a short desktop
+ * (1440×700) and mobile (390): fully in-viewport, and the document
+ * never gains scroll height from an open popover (user report — the
+ * panel "broke the page" past the layout bottom).
  */
 
 const signIn = async (page: Page): Promise<void> => {
@@ -25,8 +28,16 @@ const expectFullyInViewport = async (locator: Locator): Promise<void> => {
   expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height);
 };
 
+const scrollHeights = (page: Page) =>
+  page.evaluate(() => ({
+    doc: document.documentElement.scrollHeight,
+    body: document.body.scrollHeight,
+  }));
+
 for (const viewport of [
   { width: 1440, height: 900 },
+  // Short desktop: the popover must flip/cap rather than push the page.
+  { width: 1440, height: 700 },
   { width: 390, height: 844 },
 ]) {
   test.describe(`date picker at ${viewport.width}×${viewport.height}`, () => {
@@ -41,13 +52,15 @@ for (const viewport of [
         page.getByText(/Expenses by category — Jul 2026/),
       ).toBeVisible({ timeout: 15_000 });
 
+      const closedHeights = await scrollHeights(page);
       const trigger = page.locator('button[aria-haspopup="dialog"]').first();
       await trigger.click();
       const popover = page.getByRole("dialog", { name: "Pick month" });
       await expect(popover).toBeVisible();
 
       // Collision canon: the panel (now carrying the 12-month grid and
-      // the grammar input) sits fully inside the viewport.
+      // the grammar input) sits fully inside the viewport, and the open
+      // popover never grows the document (no scrollbar, no layout push).
       await expect(
         popover.getByRole("button", { name: "July 2026" }),
       ).toBeVisible();
@@ -55,6 +68,7 @@ for (const viewport of [
         popover.getByRole("button", { name: "Apply" }),
       ).toBeVisible();
       await expectFullyInViewport(popover);
+      expect(await scrollHeights(page)).toEqual(closedHeights);
 
       // Pick June 2026 in the grid: the popover closes, the trigger
       // takes the humanized value, and the category query refires.

--- a/web/src/app/dashboard/OverviewView.tsx
+++ b/web/src/app/dashboard/OverviewView.tsx
@@ -11,6 +11,7 @@
 import React, { useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { cn } from "@/lib/cn";
 import { formatIso, daysUntil } from "@/lib/dates";
 import { useOrg, useOverviewController } from "@/controllers";
 import { useCategoriesController } from "@/controllers/use-categories";
@@ -34,14 +35,26 @@ const Card: React.FC<{
   title: string;
   children: React.ReactNode;
   action?: React.ReactNode;
+  /** Body becomes a column flex so a fill-mode chart can stretch. */
+  fill?: boolean;
   className?: string;
-}> = ({ title, children, action, className }) => (
-  <section className={`rounded border border-border bg-bg ${className ?? ""}`}>
+}> = ({ title, children, action, fill, className }) => (
+  <section
+    className={cn(
+      "rounded border border-border bg-bg",
+      fill && "lg:flex lg:flex-col",
+      className,
+    )}
+  >
     <header className="flex items-center justify-between border-b border-border px-4 py-2.5">
       <h2 className="text-[13px] font-medium text-text">{title}</h2>
       {action}
     </header>
-    <div className="p-4">{children}</div>
+    <div
+      className={cn("p-4", fill && "lg:flex lg:min-h-0 lg:flex-1 lg:flex-col")}
+    >
+      {children}
+    </div>
   </section>
 );
 
@@ -345,12 +358,16 @@ export const OverviewView: React.FC = () => {
         )}
       </div>
 
-      {/* Figma 179:12: chart left (2/3), donut + anomalies right (1/3). */}
+      {/* Figma 179:12: chart left (2/3), donut + anomalies right (1/3).
+          Default grid stretch (no items-start): the chart card's bottom
+          tracks the rail's — its fill-mode plot absorbs the difference
+          (user report: the band read bottom-ragged at lg). */}
       <div
         data-testid="overview-mid-band"
-        className="mt-4 grid grid-cols-1 items-start gap-4 lg:grid-cols-[2fr_1fr]"
+        className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[2fr_1fr]"
       >
         <Card
+          fill
           // The monthly series starts at ledger onset (no fabricated
           // pre-onset months) — the title states the span it actually has.
           title={
@@ -416,6 +433,7 @@ export const OverviewView: React.FC = () => {
             </div>
           ) : (
             <ChartLine
+              fill
               state={points.length === 0 ? "empty" : "data"}
               emptyKind="transactions"
               series={[

--- a/web/src/app/dashboard/categories/CategoriesView.tsx
+++ b/web/src/app/dashboard/categories/CategoriesView.tsx
@@ -417,6 +417,10 @@ export const CategoriesView: React.FC = () => {
       >
         <Select
           label="Merge into"
+          // The in-body menu clipped into a raw scrollbox inside the
+          // modal body's overflow (user report) — portal it to <body>;
+          // Modal's outside-interaction guard keeps the dialog open.
+          portalMenu
           options={categories.items
             .filter(
               (cat) =>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -220,4 +220,11 @@
     font-family:
       var(--font-jetbrains-mono), "JetBrains Mono", ui-monospace, monospace;
   }
+
+  /* Fix Naira symbol and other currency symbols overlapping with digits under tabular-nums by disabling contextual alternates */
+  .tabular-nums {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum" 1, "calt" 0;
+  }
 }
+

--- a/web/src/components/ui/ChartLine.test.tsx
+++ b/web/src/components/ui/ChartLine.test.tsx
@@ -170,4 +170,31 @@ describe("Chart/Line (design.md §8.2b, MI-12)", () => {
     render(<ChartLine state="empty" emptyKind="transactions" />);
     expect(screen.getByText("No transactions yet")).toBeInTheDocument();
   });
+
+  it("fill mode stretches the plot at lg with a floor and non-scaling strokes (B1 band alignment)", () => {
+    render(<ChartLine fill series={series} />);
+    const plot = screen.getByTestId("chart-plot");
+    expect(plot).toHaveClass("lg:flex-1");
+    expect(plot).toHaveClass("lg:min-h-[176px]");
+    const svg = screen.getByRole("img");
+    expect(svg).toHaveAttribute("preserveAspectRatio", "none");
+    expect(svg).toHaveClass("lg:h-full");
+    expect(screen.getByTestId("chart-line-income")).toHaveAttribute(
+      "vector-effect",
+      "non-scaling-stroke",
+    );
+    expect(screen.getAllByTestId("chart-gridline")[0]).toHaveAttribute(
+      "vector-effect",
+      "non-scaling-stroke",
+    );
+  });
+
+  it("default construction keeps the aspect-driven box (no fill artifacts)", () => {
+    render(<ChartLine series={series} />);
+    const svg = screen.getByRole("img");
+    expect(svg).not.toHaveAttribute("preserveAspectRatio");
+    expect(screen.getByTestId("chart-line-income")).not.toHaveAttribute(
+      "vector-effect",
+    );
+  });
 });

--- a/web/src/components/ui/ChartLine.tsx
+++ b/web/src/components/ui/ChartLine.tsx
@@ -62,6 +62,15 @@ export interface ChartLineProps {
   emptyKind?: EmptyStateKind;
   onEmptyAction?: () => void;
   height?: number;
+  /**
+   * Fill the parent column at lg+ (B1 mid-band bottom alignment): the
+   * plot grows to the card's remaining height — floored at the default
+   * plot's rendered size so short rails never squash it — instead of
+   * the fixed viewBox aspect. The stretched SVG keeps device-pixel
+   * strokes (non-scaling) and the %-positioned tick ladder tracks any
+   * height. Below lg the stacked layout keeps the aspect construction.
+   */
+  fill?: boolean;
   className?: string;
 }
 
@@ -99,6 +108,7 @@ export const ChartLine: React.FC<ChartLineProps> = ({
   emptyKind = "transactions",
   onEmptyAction,
   height = 160,
+  fill = false,
   className,
 }) => {
   if (state === "loading") {
@@ -148,8 +158,25 @@ export const ChartLine: React.FC<ChartLineProps> = ({
   };
 
   return (
-    <figure data-state="data" className={cn("w-full", className)}>
-      <div className={cn("relative w-full", yAxis && Y_AXIS_OFFSET_CLASS)}>
+    <figure
+      data-state="data"
+      className={cn(
+        "w-full",
+        fill && "lg:flex lg:min-h-0 lg:flex-1 lg:flex-col",
+        className,
+      )}
+    >
+      <div
+        data-testid="chart-plot"
+        className={cn(
+          "relative w-full",
+          // Fill: the plot takes the card's remaining height at lg+,
+          // floored at the default plot's rendered size (~176px at the
+          // 2fr column) so a short rail never squashes it.
+          fill && "lg:min-h-[176px] lg:flex-1",
+          yAxis && Y_AXIS_OFFSET_CLASS,
+        )}
+      >
         {/* Y tick labels — HTML at fixed 13px (Figma Table/13 Regular),
             absolutely spanning the plot so percentage tops track the
             gridline fractions at any rendered width. Presentation only —
@@ -181,9 +208,14 @@ export const ChartLine: React.FC<ChartLineProps> = ({
         ) : null}
         <svg
           viewBox={`0 0 ${WIDTH} ${plotHeight}`}
+          // Fill: the box stretches past the viewBox aspect; geometry
+          // scales with it and the %-based tick ladder stays aligned.
+          // (Sizing is unaffected below lg — the box then matches the
+          // viewBox aspect exactly, so "none" renders identically.)
+          preserveAspectRatio={fill ? "none" : undefined}
           role="img"
           aria-label={`Line chart: ${series.map((entry) => entry.label).join(", ")}`}
-          className="w-full"
+          className={cn("w-full", fill && "lg:absolute lg:inset-0 lg:h-full")}
         >
           {scale ? (
             // Gridline per tick (--border); the lowest is the baseline.
@@ -196,6 +228,9 @@ export const ChartLine: React.FC<ChartLineProps> = ({
                 y1={yAt(tick)}
                 y2={yAt(tick)}
                 strokeWidth="1"
+                // Fill stretches the box non-uniformly — keep hairlines
+                // at device pixels.
+                vectorEffect={fill ? "non-scaling-stroke" : undefined}
                 className="stroke-border"
               />
             ))
@@ -228,6 +263,7 @@ export const ChartLine: React.FC<ChartLineProps> = ({
               points={toPoints(entry.points)}
               fill="none"
               strokeWidth="1.5"
+              vectorEffect={fill ? "non-scaling-stroke" : undefined}
               pathLength={1}
               strokeDasharray="1"
               className={cn(

--- a/web/src/components/ui/DatePicker.tsx
+++ b/web/src/components/ui/DatePicker.tsx
@@ -9,6 +9,12 @@
  * kits); date-fns for the math; construction parity with apparule's
  * DateInput calendar. QuarterPicker/YearPicker extend the same
  * anatomy to the closed period grammar's other modes (line-items.md §6).
+ *
+ * Geometry is the Figma DatePicker master (set 467:11039): 194px grid
+ * content; day cells 26×22 (gap 2px across / 4px between weeks,
+ * weekday header S M T W T F S at 13 Medium text-2); month/quarter
+ * cells 26px tall on a 4px gap; nav rows carry 14px chevrons around a
+ * centered 13 Medium label; 4px row rhythm.
  */
 
 import React, { useLayoutEffect, useRef, useState } from "react";
@@ -56,18 +62,20 @@ const GridHeader: React.FC<{
   onPrev: () => void;
   onNext: () => void;
 }> = ({ label, prevLabel, nextLabel, onPrev, onNext }) => (
-  <div className="mb-1.5 flex items-center justify-between">
+  // Master nav row: 14px chevrons at the row edges, 13 Medium label
+  // centered; 4px gap to the grid below.
+  <div className="mb-1 flex w-full items-center justify-between">
     <button
       type="button"
       aria-label={prevLabel}
       onClick={onPrev}
       className={cn(
-        "grid size-7 place-items-center rounded text-text-2",
+        "grid size-6 place-items-center rounded text-text-2",
         "transition-colors duration-fast ease-standard hover:bg-bg-elev hover:text-text",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
       )}
     >
-      <ChevronLeft aria-hidden className="h-4 w-4" />
+      <ChevronLeft aria-hidden className="h-3.5 w-3.5" />
     </button>
     <span
       aria-live="polite"
@@ -80,12 +88,12 @@ const GridHeader: React.FC<{
       aria-label={nextLabel}
       onClick={onNext}
       className={cn(
-        "grid size-7 place-items-center rounded text-text-2",
+        "grid size-6 place-items-center rounded text-text-2",
         "transition-colors duration-fast ease-standard hover:bg-bg-elev hover:text-text",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
       )}
     >
-      <ChevronRight aria-hidden className="h-4 w-4" />
+      <ChevronRight aria-hidden className="h-3.5 w-3.5" />
     </button>
   </div>
 );
@@ -191,13 +199,15 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         role="grid"
         aria-label={format(month, "MMMM yyyy")}
         onKeyDown={onGridKeyDown}
-        className="grid grid-cols-7 text-center"
+        // Master day grid: 26px columns, 2px column gap, 4px week gap
+        // (7×26 + 6×2 = the 194px content width).
+        className="grid w-[194px] grid-cols-7 gap-x-0.5 gap-y-1 text-center"
       >
         {WEEKDAYS.map((weekday, index) => (
           <span
             key={index}
             aria-hidden
-            className="py-1 text-[11px] font-medium text-text-2"
+            className="flex h-[22px] w-[26px] items-center justify-center text-[13px] font-medium text-text-2"
           >
             {weekday}
           </span>
@@ -220,7 +230,8 @@ export const DatePicker: React.FC<DatePickerProps> = ({
               aria-pressed={selected || undefined}
               aria-current={isToday(day) ? "date" : undefined}
               className={cn(
-                "mx-auto grid size-8 place-items-center rounded text-[13px] tabular-nums",
+                // Master day cell: 26×22, 4px radius, Table/13.
+                "grid h-[22px] w-[26px] place-items-center rounded text-[13px] tabular-nums",
                 "transition-colors duration-fast ease-standard",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
                 selected
@@ -228,12 +239,12 @@ export const DatePicker: React.FC<DatePickerProps> = ({
                   : inRange(day)
                     ? "bg-accent/15 text-text"
                     : isToday(day)
-                      ? // Master's today state: outlined cell, plain text.
-                        "text-text ring-1 ring-inset ring-accent hover:bg-bg-elev"
+                      ? // Master's today state: accent-outlined cell, Medium.
+                        "font-medium text-text ring-1 ring-inset ring-accent hover:bg-bg-elev"
                       : "text-text hover:bg-bg-elev",
-                outside && !selected && "text-text-2/50",
+                outside && !selected && "text-text-2",
                 disabled &&
-                  "cursor-not-allowed text-text-2/30 hover:bg-transparent",
+                  "cursor-not-allowed text-text-2/40 hover:bg-transparent",
               )}
             >
               {format(day, "d")}
@@ -276,7 +287,8 @@ export const MonthPicker: React.FC<MonthPickerProps> = ({
         onPrev={() => setYear((current) => current - 1)}
         onNext={() => setYear((current) => current + 1)}
       />
-      <div className="grid grid-cols-3 gap-1">
+      {/* Master month grid: 62×26 cells on a 4px gap (194px content). */}
+      <div className="grid w-[194px] grid-cols-3 gap-1">
         {Array.from({ length: 12 }, (_, index) => {
           const monthStart = new Date(year, index, 1);
           const selected = value !== null && isSameMonth(monthStart, value);
@@ -290,7 +302,7 @@ export const MonthPicker: React.FC<MonthPickerProps> = ({
               aria-pressed={selected || undefined}
               aria-current={current ? "date" : undefined}
               className={cn(
-                "h-8 rounded text-[13px] transition-colors duration-fast ease-standard",
+                "h-[26px] rounded text-[13px] transition-colors duration-fast ease-standard",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
                 selected
                   ? "bg-accent font-medium text-on-accent"
@@ -349,7 +361,8 @@ export const QuarterPicker: React.FC<QuarterPickerProps> = ({
         onPrev={() => setYear((current) => current - 1)}
         onNext={() => setYear((current) => current + 1)}
       />
-      <div className="grid grid-cols-4 gap-1">
+      {/* Master quarter row: Q1–Q4 as one 26px row on a 4px gap. */}
+      <div className="grid w-[194px] grid-cols-4 gap-1">
         {[1, 2, 3, 4].map((quarter) => {
           const selected =
             value !== null && value.year === year && value.quarter === quarter;
@@ -364,7 +377,7 @@ export const QuarterPicker: React.FC<QuarterPickerProps> = ({
               aria-pressed={selected || undefined}
               aria-current={current ? "date" : undefined}
               className={cn(
-                "h-8 rounded text-[13px] tabular-nums transition-colors duration-fast ease-standard",
+                "h-[26px] rounded text-[13px] tabular-nums transition-colors duration-fast ease-standard",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
                 selected
                   ? "bg-accent font-medium text-on-accent"
@@ -411,9 +424,13 @@ export const YearPicker: React.FC<YearPickerProps> = ({
   const currentYear = new Date().getFullYear();
 
   return (
+    // Master year list: 26px rows, no nav — the list scrolls (~5 rows).
     <ul
       data-testid="year-picker"
-      className={cn("max-h-44 select-none overflow-auto", className)}
+      className={cn(
+        "max-h-[132px] w-[194px] select-none overflow-auto",
+        className,
+      )}
     >
       {years.map((year) => (
         <li key={year}>
@@ -423,7 +440,7 @@ export const YearPicker: React.FC<YearPickerProps> = ({
             aria-pressed={year === value || undefined}
             aria-current={year === currentYear ? "date" : undefined}
             className={cn(
-              "w-full rounded px-2 py-1 text-left text-[13px] tabular-nums",
+              "flex h-[26px] w-full items-center rounded px-2 text-left text-[13px] tabular-nums",
               "transition-colors duration-fast ease-standard",
               year === value
                 ? "bg-accent font-medium text-on-accent"

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -67,6 +67,18 @@ export const Modal: React.FC<ModalProps> = ({
         <Dialog.Overlay className="fixed inset-0 z-overlay bg-bg-editorial/60 animate-fade-in motion-reduce:animate-none" />
         <Dialog.Content
           aria-describedby={undefined}
+          // App floating layers (portaled Select menus) live under
+          // <body>, outside the Radix content subtree — without this
+          // guard a click inside one dismisses the whole dialog
+          // (merge-modal report).
+          onInteractOutside={(event) => {
+            if (
+              event.target instanceof Element &&
+              event.target.closest("[data-floating-layer]")
+            ) {
+              event.preventDefault();
+            }
+          }}
           className={cn(
             // font-sans: portals mount under <body>, which still carries
             // the legacy Poppins font until the legacy pages retire (W3).

--- a/web/src/components/ui/PeriodPicker.test.tsx
+++ b/web/src/components/ui/PeriodPicker.test.tsx
@@ -192,75 +192,113 @@ describe("PeriodPicker (design.md §8.2b)", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("Out of range");
   });
 
-  describe("viewport collision clamp (system QA 2026-07-19)", () => {
+  describe("collision placement (master contract 467:11039)", () => {
     afterEach(() => {
       vi.unstubAllGlobals();
       vi.restoreAllMocks();
+      // The prototype clientHeight spy shadows documentElement too —
+      // drop the instance overrides installed by mockViewport.
+      Reflect.deleteProperty(document.documentElement, "clientWidth");
+      Reflect.deleteProperty(document.documentElement, "clientHeight");
     });
 
-    it("translates the popover back inside the viewport when it would overflow right", async () => {
+    // The hook reads the viewport from documentElement (scrollbar-safe);
+    // pin it per test so the element-prototype spies cannot leak into it.
+    const mockViewport = (width: number, height: number) => {
+      vi.stubGlobal("innerWidth", width);
+      vi.stubGlobal("innerHeight", height);
+      Object.defineProperty(document.documentElement, "clientWidth", {
+        value: width,
+        configurable: true,
+      });
+      Object.defineProperty(document.documentElement, "clientHeight", {
+        value: height,
+        configurable: true,
+      });
+    };
+
+    // The prototype mock feeds the TRIGGER rect (the hook only measures
+    // the anchor); panel size comes from the offset/scroll spies.
+    const mockGeometry = (rect: Partial<DOMRect>) => {
+      vi.spyOn(
+        window.HTMLElement.prototype,
+        "getBoundingClientRect",
+      ).mockReturnValue(rect as DOMRect);
+      vi.spyOn(
+        window.HTMLElement.prototype,
+        "offsetWidth",
+        "get",
+      ).mockReturnValue(220);
+      vi.spyOn(
+        window.HTMLElement.prototype,
+        "offsetHeight",
+        "get",
+      ).mockReturnValue(320);
+      vi.spyOn(
+        window.HTMLElement.prototype,
+        "clientHeight",
+        "get",
+      ).mockReturnValue(320);
+      vi.spyOn(
+        window.HTMLElement.prototype,
+        "scrollHeight",
+        "get",
+      ).mockReturnValue(320);
+    };
+
+    it("right-anchors the panel on a right-edge trigger (Overview header)", async () => {
       // Overview header regression: w-36 trigger at the right edge of a
-      // 1440 viewport; the min-w-56 panel overflowed by 56px.
-      vi.stubGlobal("innerWidth", 1440);
-      vi.stubGlobal("innerHeight", 900);
-      vi.spyOn(
-        window.HTMLElement.prototype,
-        "getBoundingClientRect",
-      ).mockReturnValue({
-        left: 1272,
-        right: 1496,
-        top: 100,
-        bottom: 420,
-      } as DOMRect);
+      // 1440 viewport — the left-anchored 220px panel overflowed and sat
+      // flush against the viewport edge with no gutter.
+      mockViewport(1440, 900);
+      mockGeometry({ left: 1272, right: 1416, top: 52, bottom: 84 });
 
       render(<PeriodPicker mode="month" value="2026-07" />);
       await userEvent.click(screen.getByRole("button"));
 
-      expect(screen.getByRole("dialog")).toHaveStyle({
-        transform: "translate(-64px, 0px)",
-      });
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveClass("right-0");
+      expect(dialog).toHaveClass("top-full");
+      expect(dialog.style.transform).toBe("");
     });
 
-    it("translates the popover up when the calendar would clip the bottom edge", async () => {
-      // The embedded grids made the panel tall enough to clip below on
-      // low anchors (390 canon viewport) — the same 1-D clamp runs on Y.
-      vi.stubGlobal("innerWidth", 1440);
-      vi.stubGlobal("innerHeight", 900);
-      vi.spyOn(
-        window.HTMLElement.prototype,
-        "getBoundingClientRect",
-      ).mockReturnValue({
-        left: 400,
-        right: 624,
-        top: 700,
-        bottom: 1020,
-      } as DOMRect);
+    it("flips the panel above a bottom-anchored trigger (never covers it)", async () => {
+      mockViewport(1440, 900);
+      mockGeometry({ left: 400, right: 544, top: 700, bottom: 732 });
 
       render(<PeriodPicker mode="month" value="2026-07" />);
       await userEvent.click(screen.getByRole("button"));
 
-      expect(screen.getByRole("dialog")).toHaveStyle({
-        transform: "translate(0px, -128px)",
-      });
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveClass("bottom-full");
+      expect(dialog.style.maxHeight).toBe("");
     });
 
-    it("leaves an in-viewport popover unshifted", async () => {
-      vi.stubGlobal("innerWidth", 1440);
-      vi.stubGlobal("innerHeight", 900);
-      vi.spyOn(
-        window.HTMLElement.prototype,
-        "getBoundingClientRect",
-      ).mockReturnValue({
-        left: 400,
-        right: 624,
-        top: 100,
-        bottom: 420,
-      } as DOMRect);
+    it("caps the panel with internal scroll when neither side fits", async () => {
+      mockViewport(1440, 300);
+      mockGeometry({ left: 400, right: 544, top: 40, bottom: 72 });
 
       render(<PeriodPicker mode="month" value="2026-07" />);
       await userEvent.click(screen.getByRole("button"));
 
-      expect(screen.getByRole("dialog").style.transform).toBe("");
+      const dialog = screen.getByRole("dialog");
+      // Below wins (more room): 300 − 8 − 72 − 4 = 216.
+      expect(dialog.style.maxHeight).toBe("216px");
+      expect(dialog.style.overflowY).toBe("auto");
+    });
+
+    it("leaves an in-viewport popover below, left-anchored and unshifted", async () => {
+      mockViewport(1440, 900);
+      mockGeometry({ left: 400, right: 544, top: 52, bottom: 84 });
+
+      render(<PeriodPicker mode="month" value="2026-07" />);
+      await userEvent.click(screen.getByRole("button"));
+
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveClass("top-full");
+      expect(dialog).toHaveClass("left-0");
+      expect(dialog.style.transform).toBe("");
+      expect(dialog.style.maxHeight).toBe("");
     });
   });
 });

--- a/web/src/components/ui/PeriodPicker.tsx
+++ b/web/src/components/ui/PeriodPicker.tsx
@@ -15,7 +15,8 @@ import { Calendar, ChevronDown } from "lucide-react";
 import { format, isBefore, isValid, parseISO } from "date-fns";
 import { formatIso } from "@/lib/dates";
 import { cn } from "@/lib/cn";
-import { useViewportShiftXY } from "@/lib/use-viewport-clamp";
+import { useAnchoredPanelPlacement } from "@/lib/use-viewport-clamp";
+import Button from "./Button";
 import {
   DatePicker,
   MonthPicker,
@@ -179,12 +180,11 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
-  // The panel is min-w-56+ while the trigger can be narrower (Overview
-  // header w-36) — left-anchored it overflowed the right viewport edge
-  // (system QA 2026-07-19); the embedded grids are tall enough to clip
-  // the bottom edge on low anchors. The two-axis clamp keeps the panel
-  // fully in the viewport.
-  const shift = useViewportShiftXY(open, panelRef);
+  // Master collision contract (467:11039): flip above when room below
+  // runs out (never cover the field), cap + scroll when neither side
+  // fits, keep right-anchored triggers right-anchored (the Overview
+  // header trigger sat flush against the viewport edge), clamp X.
+  const placement = useAnchoredPanelPlacement(open, triggerRef, panelRef);
 
   // Track the controlled value — adjust-state-during-render, no effect.
   const [prevValue, setPrevValue] = useState(value);
@@ -304,15 +304,25 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
           ref={panelRef}
           role="dialog"
           aria-label={`Pick ${mode}`}
-          style={
-            shift.x || shift.y
-              ? { transform: `translate(${shift.x}px, ${shift.y}px)` }
-              : undefined
-          }
+          style={{
+            // Cap + internal scroll when neither side fits the panel —
+            // it must never exceed the viewport or grow the document.
+            ...(placement?.maxHeight !== undefined
+              ? { maxHeight: placement.maxHeight, overflowY: "auto" as const }
+              : {}),
+            ...(placement?.shiftX
+              ? { transform: `translateX(${placement.shiftX}px)` }
+              : {}),
+            // Hide the unplaced first frame (measure paints next).
+            ...(placement === null ? { visibility: "hidden" as const } : {}),
+          }}
           className={cn(
-            "absolute left-0 top-full z-dropdown mt-1 w-full rounded border border-border bg-bg p-3 shadow-lg",
-            // The 7-column calendar needs the wider floor (7×32px cells).
-            mode === "day" || mode === "range" ? "min-w-64" : "min-w-56",
+            // Master popover chrome (467:10998): 194px content behind
+            // 12px/10px padding — the panel hugs the grid, it does not
+            // stretch to the trigger.
+            "absolute z-dropdown w-[220px] rounded border border-border bg-bg px-3 py-2.5 shadow-lg",
+            placement?.side === "above" ? "bottom-full mb-1" : "top-full mt-1",
+            placement?.alignRight ? "right-0" : "left-0",
           )}
         >
           {presets.length > 0 ? (
@@ -358,7 +368,9 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
               onSelect={(year) => commit(`FY${year}`)}
             />
           )}
-          <label className="mt-2 block border-t border-border pt-2 text-[11px] font-medium uppercase tracking-wide text-text-2">
+          {/* Grammar input — the typing path keeps clear air around its
+              divider (it sat jammed against the grid; user report). */}
+          <label className="mt-2.5 block border-t border-border pt-2 text-[11px] font-medium uppercase tracking-wide text-text-2">
             {mode}
             <input
               autoFocus
@@ -375,30 +387,28 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
               }}
               placeholder={MODE_PLACEHOLDER[mode]}
               className={cn(
-                "mt-1 h-9 w-full rounded border bg-bg px-2.5 font-mono text-[13px] tabular-nums text-text",
+                "mt-1.5 h-8 w-full rounded border bg-bg px-2.5 font-mono text-[13px] tabular-nums text-text",
                 "placeholder:text-text-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent",
                 draftError ? "border-expense" : "border-border",
               )}
             />
           </label>
-          <div className="mt-2 flex justify-end gap-2">
-            <button
-              type="button"
+          {/* Master confirm row: quiet Cancel + primary Apply, 28px
+              Buttons on an 8px gap (the shared Button sm construction). */}
+          <div className="mt-2.5 flex justify-end gap-2">
+            <Button
+              kind="quiet"
+              size="sm"
               onClick={() => {
                 setOpen(false);
                 triggerRef.current?.focus();
               }}
-              className="rounded px-2.5 py-1 text-[13px] font-medium text-text-2 transition-colors duration-fast ease-standard hover:bg-bg-elev hover:text-text"
             >
               Cancel
-            </button>
-            <button
-              type="button"
-              onClick={() => commit(draft)}
-              className="rounded bg-accent px-2.5 py-1 text-[13px] font-medium text-on-accent transition-colors duration-fast ease-standard hover:opacity-90"
-            >
+            </Button>
+            <Button size="sm" onClick={() => commit(draft)}>
               Apply
-            </button>
+            </Button>
           </div>
         </div>
       ) : null}

--- a/web/src/components/ui/Select.test.tsx
+++ b/web/src/components/ui/Select.test.tsx
@@ -69,4 +69,37 @@ describe("Select/Menu (design.md §8.2b)", () => {
       "true",
     );
   });
+
+  describe("portalMenu inside a modal (merge-modal report)", () => {
+    it("marks the portaled menu as a floating layer with pointer events", async () => {
+      render(<Select options={options} value={null} portalMenu />);
+      await userEvent.click(screen.getByRole("combobox"));
+      const menu = screen.getByRole("listbox").parentElement!;
+      // Modal's outside-interaction guard keys on this marker, and
+      // pointer-events must re-enable under Radix's modal body lock.
+      expect(menu).toHaveAttribute("data-floating-layer");
+      expect(menu).toHaveClass("pointer-events-auto");
+      expect(menu.parentElement).toBe(document.body);
+    });
+
+    it("Escape closes the open menu without reaching the dialog", async () => {
+      const onEscape = vi.fn();
+      render(
+        <div onKeyDown={onEscape}>
+          <Select options={options} value={null} portalMenu />
+        </div>,
+      );
+      const trigger = screen.getByRole("combobox");
+      await userEvent.click(trigger);
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      trigger.focus();
+      await userEvent.keyboard("{Escape}");
+      // The menu closed; the wrapping (dialog-like) handler never saw it.
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      expect(onEscape).not.toHaveBeenCalled();
+      // A second Escape (menu closed) propagates to the dialog layer.
+      await userEvent.keyboard("{Escape}");
+      expect(onEscape).toHaveBeenCalled();
+    });
+  });
 });

--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -128,6 +128,10 @@ export const Select: React.FC<SelectProps> = ({
 
   const onKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === "Escape") {
+      // With the menu open, Escape closes the MENU only — inside a
+      // Radix modal the un-stopped event would close the dialog too
+      // (merge-modal report).
+      if (open) event.stopPropagation();
       setOpen(false);
       return;
     }
@@ -197,6 +201,11 @@ export const Select: React.FC<SelectProps> = ({
         ? wrapMenu(
             <div
               ref={panelRef}
+              // Floating-layer marker: Modal's outside-interaction guard
+              // ignores events inside it, and pointer-events re-enable
+              // under Radix's modal body lock (merge-modal report — the
+              // in-body menu clipped into a raw inner scrollbox).
+              data-floating-layer={portalMenu ? true : undefined}
               style={
                 portalMenu
                   ? (anchoredStyle ?? {
@@ -208,7 +217,7 @@ export const Select: React.FC<SelectProps> = ({
               className={cn(
                 "rounded border border-border bg-bg shadow-lg",
                 portalMenu
-                  ? "z-modal"
+                  ? "z-modal pointer-events-auto"
                   : "absolute left-0 top-full z-dropdown mt-1 w-full",
               )}
             >

--- a/web/src/lib/use-viewport-clamp.test.ts
+++ b/web/src/lib/use-viewport-clamp.test.ts
@@ -3,8 +3,8 @@ import { act, renderHook } from "@testing-library/react";
 import {
   VIEWPORT_GUTTER,
   clampShiftX,
+  useAnchoredPanelPlacement,
   useViewportShiftX,
-  useViewportShiftXY,
 } from "./use-viewport-clamp";
 
 describe("clampShiftX (floating-layer viewport clamp)", () => {
@@ -83,42 +83,103 @@ describe("useViewportShiftX", () => {
   });
 });
 
-describe("useViewportShiftXY (two-axis clamp for the calendar panels)", () => {
+describe("useAnchoredPanelPlacement (master collision contract 467:11039)", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  const panelAt = (rect: Partial<DOMRect>) =>
+  const anchorAt = (rect: Partial<DOMRect>) =>
     ({
       getBoundingClientRect: () => rect as DOMRect,
     }) as HTMLElement;
 
-  it("clamps both axes independently", () => {
+  const panelSized = (width: number, height: number) =>
+    ({
+      offsetWidth: width,
+      offsetHeight: height,
+      clientHeight: height,
+      scrollHeight: height,
+    }) as HTMLElement;
+
+  it("keeps a fitting panel below and left-anchored", () => {
     vi.stubGlobal("innerWidth", 1440);
     vi.stubGlobal("innerHeight", 900);
-    const ref = {
-      current: panelAt({ left: 1272, right: 1496, top: 700, bottom: 1020 }),
+    const anchorRef = {
+      current: anchorAt({ left: 400, right: 544, top: 52, bottom: 84 }),
     };
-    const { result } = renderHook(() => useViewportShiftXY(true, ref));
+    const panelRef = { current: panelSized(220, 300) };
+    const { result } = renderHook(() =>
+      useAnchoredPanelPlacement(true, anchorRef, panelRef),
+    );
     expect(result.current).toEqual({
-      x: 1440 - VIEWPORT_GUTTER - 1496,
-      y: 900 - VIEWPORT_GUTTER - 1020,
+      side: "below",
+      alignRight: false,
+      maxHeight: undefined,
+      shiftX: 0,
     });
   });
 
-  it("returns zero shift for an in-viewport panel and resets on close", () => {
+  it("right-anchors a right-edge trigger (the Overview header case)", () => {
     vi.stubGlobal("innerWidth", 1440);
     vi.stubGlobal("innerHeight", 900);
-    const ref = {
-      current: panelAt({ left: 400, right: 624, top: 100, bottom: 420 }),
+    // w-36 trigger at the header's right edge: left-anchored, the
+    // 220px panel overflowed the right edge and sat flush under it.
+    const anchorRef = {
+      current: anchorAt({ left: 1272, right: 1416, top: 52, bottom: 84 }),
     };
-    const { result, rerender } = renderHook(
-      ({ open }: { open: boolean }) => useViewportShiftXY(open, ref),
-      { initialProps: { open: true } },
+    const panelRef = { current: panelSized(220, 300) };
+    const { result } = renderHook(() =>
+      useAnchoredPanelPlacement(true, anchorRef, panelRef),
     );
-    expect(result.current).toEqual({ x: 0, y: 0 });
-    ref.current = panelAt({ left: 1272, right: 1496, top: 700, bottom: 1020 });
+    expect(result.current).toMatchObject({ alignRight: true, shiftX: 0 });
+  });
+
+  it("flips above a bottom-anchored trigger instead of covering it", () => {
+    vi.stubGlobal("innerWidth", 1440);
+    vi.stubGlobal("innerHeight", 900);
+    const anchorRef = {
+      current: anchorAt({ left: 400, right: 544, top: 700, bottom: 732 }),
+    };
+    const panelRef = { current: panelSized(220, 300) };
+    const { result } = renderHook(() =>
+      useAnchoredPanelPlacement(true, anchorRef, panelRef),
+    );
+    expect(result.current).toMatchObject({
+      side: "above",
+      maxHeight: undefined,
+    });
+  });
+
+  it("caps with internal scroll when neither side fits", () => {
+    vi.stubGlobal("innerWidth", 1440);
+    vi.stubGlobal("innerHeight", 300);
+    const anchorRef = {
+      current: anchorAt({ left: 400, right: 544, top: 40, bottom: 72 }),
+    };
+    const panelRef = { current: panelSized(220, 320) };
+    const { result } = renderHook(() =>
+      useAnchoredPanelPlacement(true, anchorRef, panelRef),
+    );
+    // Below wins (more room): 300 − 8 − 72 − 4 = 216.
+    expect(result.current).toMatchObject({ side: "below", maxHeight: 216 });
+  });
+
+  it("returns null while closed and resets after closing", () => {
+    vi.stubGlobal("innerWidth", 1440);
+    vi.stubGlobal("innerHeight", 900);
+    const anchorRef = {
+      current: anchorAt({ left: 400, right: 544, top: 52, bottom: 84 }),
+    };
+    const panelRef = { current: panelSized(220, 300) };
+    const { result, rerender } = renderHook(
+      ({ open }: { open: boolean }) =>
+        useAnchoredPanelPlacement(open, anchorRef, panelRef),
+      { initialProps: { open: false } },
+    );
+    expect(result.current).toBeNull();
+    rerender({ open: true });
+    expect(result.current).not.toBeNull();
     rerender({ open: false });
-    expect(result.current).toEqual({ x: 0, y: 0 });
+    expect(result.current).toBeNull();
   });
 });

--- a/web/src/lib/use-viewport-clamp.ts
+++ b/web/src/lib/use-viewport-clamp.ts
@@ -78,62 +78,89 @@ export const useViewportShiftX = (
   return shift;
 };
 
-export interface ViewportShift {
-  x: number;
-  y: number;
+export interface PanelPlacement {
+  /** Vertical side relative to the anchor. */
+  side: "below" | "above";
+  /** Right-align the panel to the anchor's right edge. */
+  alignRight: boolean;
+  /** Cap + internal scroll when neither side fits the full panel. */
+  maxHeight?: number;
+  /** Residual horizontal clamp after alignment (px translate). */
+  shiftX: number;
 }
 
-const NO_SHIFT: ViewportShift = { x: 0, y: 0 };
-
 /**
- * Two-axis variant of useViewportShiftX — the calendar grids made the
- * PeriodPicker panel tall enough to clip the bottom viewport edge on
- * low anchors (390 canon viewport), so the same 1-D clamp runs on Y
- * too. clampShiftX is axis-agnostic: pass top/bottom + innerHeight.
+ * Placement for a trigger-anchored absolute panel — the DatePicker
+ * master's collision contract (467:11039): the popover FLIPS above the
+ * field when viewport room below runs out (it never covers the field,
+ * and never translates over the page like a raw Y-shift would), caps
+ * with internal scroll when neither side fits (an open popover never
+ * exceeds the viewport or grows the document scroll height), clamps
+ * horizontally at the viewport edges, and right-anchored triggers stay
+ * right-anchored. Returns null until the first measure paints (the
+ * caller hides the panel for that frame). Replaces the earlier
+ * translate-Y clamp, which slid the panel over its own trigger.
  */
-export const useViewportShiftXY = (
+export const useAnchoredPanelPlacement = (
   open: boolean,
+  anchorRef: RefObject<HTMLElement | null>,
   panelRef: RefObject<HTMLElement | null>,
-): ViewportShift => {
-  const [shift, setShift] = useState(NO_SHIFT);
+  offsetY: number = 4,
+): PanelPlacement | null => {
+  const [placement, setPlacement] = useState<PanelPlacement | null>(null);
 
   // Reset when the layer closes — adjust-state-during-render, no effect.
   const [prevOpen, setPrevOpen] = useState(open);
   if (prevOpen !== open) {
     setPrevOpen(open);
-    if (!open) setShift(NO_SHIFT);
+    if (!open) setPlacement(null);
   }
 
   useLayoutEffect(() => {
     if (!open) return;
-    // Mirrors the shift already painted so resize re-measures can
-    // recover the unshifted anchor geometry from the live rect.
-    let applied = NO_SHIFT;
     const measure = () => {
+      const anchor = anchorRef.current;
       const panel = panelRef.current;
-      if (!panel || typeof window === "undefined") return;
-      const rect = panel.getBoundingClientRect();
-      const next = {
-        x: clampShiftX(
-          rect.left - applied.x,
-          rect.right - applied.x,
-          window.innerWidth,
-        ),
-        y: clampShiftX(
-          rect.top - applied.y,
-          rect.bottom - applied.y,
-          window.innerHeight,
-        ),
-      };
-      applied = next;
-      setShift((current) =>
-        current.x === next.x && current.y === next.y ? current : next,
+      if (!anchor || !panel || typeof window === "undefined") return;
+      // clientWidth/Height exclude a classic scrollbar (innerWidth does
+      // not — the panel used to sit flush under it); jsdom reports 0,
+      // so fall back to the window metrics there.
+      const viewportW =
+        document.documentElement.clientWidth || window.innerWidth;
+      const viewportH =
+        document.documentElement.clientHeight || window.innerHeight;
+      const rect = anchor.getBoundingClientRect();
+      const panelW = panel.offsetWidth;
+      // Natural panel height even when a previous measure capped it.
+      const chromeH = panel.offsetHeight - panel.clientHeight;
+      const panelH = Math.max(panel.offsetHeight, panel.scrollHeight + chromeH);
+      const spaceBelow = viewportH - VIEWPORT_GUTTER - rect.bottom - offsetY;
+      const spaceAbove = rect.top - VIEWPORT_GUTTER - offsetY;
+      const side: PanelPlacement["side"] =
+        panelH <= spaceBelow || spaceBelow >= spaceAbove ? "below" : "above";
+      const space = side === "below" ? spaceBelow : spaceAbove;
+      const maxHeight =
+        panelH > space ? Math.max(Math.floor(space), 0) : undefined;
+      // Master: right-anchored triggers keep their right anchoring.
+      const alignRight =
+        rect.left + panelW > viewportW - VIEWPORT_GUTTER &&
+        rect.right - panelW >= VIEWPORT_GUTTER;
+      const left = alignRight ? rect.right - panelW : rect.left;
+      const shiftX = clampShiftX(left, left + panelW, viewportW);
+      setPlacement((current) =>
+        current !== null &&
+        current.side === side &&
+        current.alignRight === alignRight &&
+        current.maxHeight === maxHeight &&
+        current.shiftX === shiftX
+          ? current
+          : { side, alignRight, maxHeight, shiftX },
       );
     };
     measure();
     window.addEventListener("resize", measure);
     return () => window.removeEventListener("resize", measure);
-  }, [open, panelRef]);
+  }, [open, anchorRef, panelRef, offsetY]);
 
-  return shift;
+  return placement;
 };


### PR DESCRIPTION
## Summary

Three user-reported polish items on the shipped date-picker lane (#235), one commit each:

### 1 — Month-picker popover: master geometry + real collision contract (`696a074`)
- **Padding/geometry now the Figma master's** (DatePicker set 467:11039, month variant 467:10988): 220px popover hugging a 194px content column behind 12/10px padding; day cells 26×22 on 2/4px gaps; month cells 62×26; Q1–Q4 row; 26px year rows; 14px nav chevrons; Table/13 throughout; the grammar-input section gets clear air around its divider; the confirm row reuses the shared `Button` sm (quiet Cancel + primary Apply). The panel no longer stretches `w-full` against its own grid.
- **Y-overflow fixed per the master's pinned contract**: `useAnchoredPanelPlacement` replaces the translate-Y clamp — the popover **flips above** the field when room below runs out (never covers the field), **caps with internal scroll** when neither side fits, clamps X against `documentElement.clientWidth` (the old `innerWidth` math left the panel flush under a classic scrollbar with no gutter), and **right-anchored triggers stay right-anchored** (the Overview header case). An open popover never exceeds the viewport or grows the document scroll height.
- e2e: `date-picker.spec.ts` now also runs **1440×700** and asserts **document scrollHeight unchanged** while open, on top of the pick-flow/typed-sync/boundingBox assertions at 1440×900 and 390.

### 2 — Merge-modal selector: portaled, modal-safe (`fdc0cb6`)
The B8 "Merge into" Select rendered its absolute menu inside the modal body's `overflow-auto` — a raw inner scrollbox with clipped rows. `portalMenu` now marks the portaled panel `data-floating-layer` + `pointer-events-auto` (Radix's modal body lock disables pointer events under `<body>`), `Modal.onInteractOutside` ignores events inside floating layers (picking an option no longer dismisses the dialog), and Escape with an open menu closes the **menu** only. The merge Select opts in — padded rows, `max-h-56` internal scroll per the Select master. New `e2e/categories-merge.spec.ts` walks the merge end-to-end and pins the unclipped, height-capped construction.

### 3 — Overview mid-band bottoms align (`fe7cc99`)
The 2fr chart card ended ~240px above the donut/anomalies rail. The band drops `items-start`; the chart Card + `ChartLine` gain a `fill` mode at lg+ — the plot grows to the card's remaining height, floored at `lg:min-h-[176px]` so short rails never squash it (absolutely-filled SVG, `preserveAspectRatio="none"`, non-scaling strokes; the %-positioned tick ladder recomputes at any height). Below lg the stacked aspect construction is untouched. **Measured diff: 0.0px on personal AND company orgs at 1440**; e2e pins ±2px on both plus the 390 stack.

### Also
- `460660b` — coordinator-directed salvage: a stray uncommitted `globals.css` tabular-nums/`calt` fix found in the shared checkout (not this lane's authorship; separate commit so review can keep or drop it).
- `5fc2f2a` — web-implementation.md as-built rewrite (placement contract, modal-safe floating layers, band fill).

## Gates (worktree, full)
- `npm run lint` (prettier + eslint + boundaries) ✓ · `typecheck` ✓ · `test` **445 ✓** · `test:e2e` **60 ✓** · `build` ✓

## Screenshots
Before/after at 1440 (light+dark) captured against the master render — popover right-anchored under the trigger, master cell density, Cancel/Apply row; band bottoms flush at 807/807 (personal) and 861/861 (company). Available in the lane scratchpad (`expendit-datepicker/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)