### PR TITLE
fix(web): landing type matches the Figma styles — Hero/88, Display/32 metrics, Title/20 pillar titles

### DIFF
--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -382,3 +382,87 @@ test.describe("public home `/` (Part A)", () => {
     expect(mobileOverflow).toBeLessThanOrEqual(1);
   });
 });
+
+// Type contract — the landing's key roles render the Figma Home frame's
+// (193:14) bound type styles, computed: Hero/88 Bold (88/92, −2.5% =
+// −2.2px), Display/32 Bold section headings (32/38, −1% = −0.32px — the
+// same metrics StatCard pins), Title/20 Semi Bold pillar titles (20/26,
+// −0.05px) and Body/14 Regular captions (14/20). Regression lock from the
+// fleet font-weight audit (2026-07-20).
+test.describe("type contract — Figma Home frame roles", () => {
+  test("per-role computed weight/size/line-height/tracking match the styles", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 1200 });
+    await page.goto("/");
+
+    const roles = [
+      {
+        role: "hero H1 (Hero/88 Bold)",
+        locator: page.getByRole("heading", {
+          name: "See every naira. File every tax.",
+        }),
+        weight: "700",
+        size: "88px",
+        lineHeight: "92px",
+        letterSpacing: "-2.2px",
+      },
+      {
+        role: "pillars heading (Display/32 Bold)",
+        locator: page.getByRole("heading", {
+          name: "One ledger. Three superpowers.",
+        }),
+        weight: "700",
+        size: "32px",
+        lineHeight: "38px",
+        letterSpacing: "-0.32px",
+      },
+      {
+        role: "how-it-works heading (Display/32 Bold)",
+        locator: page.getByRole("heading", { name: "How it works" }),
+        weight: "700",
+        size: "32px",
+        lineHeight: "38px",
+        letterSpacing: "-0.32px",
+      },
+      {
+        role: "pillar title (Title/20 Semi Bold)",
+        locator: page.getByRole("heading", {
+          name: "Statements → intelligence",
+        }),
+        weight: "600",
+        size: "20px",
+        lineHeight: "26px",
+        letterSpacing: "-0.05px",
+      },
+      {
+        role: "pillar caption (Body/14 Regular)",
+        locator: page.getByText("Upload or link. AI categorizes every"),
+        weight: "400",
+        size: "14px",
+        lineHeight: "20px",
+        letterSpacing: "normal",
+      },
+    ] as const;
+
+    for (const r of roles) {
+      const cs = await r.locator.evaluate((el) => {
+        const s = getComputedStyle(el);
+        return {
+          fontFamily: s.fontFamily,
+          fontWeight: s.fontWeight,
+          fontSize: s.fontSize,
+          lineHeight: s.lineHeight,
+          letterSpacing: s.letterSpacing,
+        };
+      });
+      expect.soft(cs.fontFamily, `${r.role} family`).toMatch(/^Inter\b/);
+      expect.soft(cs.fontWeight, `${r.role} weight`).toBe(r.weight);
+      expect.soft(cs.fontSize, `${r.role} size`).toBe(r.size);
+      expect.soft(cs.lineHeight, `${r.role} line-height`).toBe(r.lineHeight);
+      expect
+        .soft(cs.letterSpacing, `${r.role} letter-spacing`)
+        .toBe(r.letterSpacing);
+    }
+  });
+});

--- a/web/src/components/home/HeroSection.tsx
+++ b/web/src/components/home/HeroSection.tsx
@@ -58,7 +58,10 @@ export const HeroSection: React.FC<HeroSectionProps> = ({
   <EditorialDark motif>
     {nav}
     <SectionInner className="pb-24 pt-14 text-center md:pt-24">
-      <h1 className="mx-auto max-w-[1100px] font-display text-[44px] font-bold leading-[1.05] tracking-tight text-text sm:text-[56px] lg:text-[80px]">
+      {/* Hero/88 Bold at the 1440 frame (Figma 193:1631, design.md §2
+          [Decided 2026-07-16]): 88/92; tracking-tight (−0.025em) is the
+          style's −2.5% exactly. Scales down 56/44 at smaller breakpoints. */}
+      <h1 className="mx-auto max-w-[1100px] font-display text-[44px] font-bold leading-[1.05] tracking-tight text-text sm:text-[56px] lg:text-[88px] lg:leading-[92px]">
         See every naira. File every tax.
       </h1>
       <p className="mx-auto mt-6 max-w-3xl text-base leading-relaxed text-text-2">

--- a/web/src/components/home/Section.tsx
+++ b/web/src/components/home/Section.tsx
@@ -45,14 +45,16 @@ export const SectionInner: React.FC<{
   </div>
 );
 
-/** Section heading — Display/32 Bold, centered (Figma A3–A10 pattern). */
+/** Section heading — Display/32 Bold, centered (Figma A3–A10 pattern):
+ * 32/38 with the style's −1% (−0.01em) tracking, 28/34 below md. Same
+ * metrics the StatCard value already pins. */
 export const SectionHeading: React.FC<{
   children: React.ReactNode;
   className?: string;
 }> = ({ children, className }) => (
   <h2
     className={cn(
-      "text-center font-display text-[28px] font-bold leading-tight tracking-tight text-text md:text-[32px]",
+      "text-center font-display text-[28px] font-bold leading-[34px] tracking-[-0.01em] text-text md:text-[32px] md:leading-[38px]",
       className,
     )}
   >

--- a/web/src/components/ui/EditorialCard.tsx
+++ b/web/src/components/ui/EditorialCard.tsx
@@ -65,7 +65,9 @@ export const EditorialCard: React.FC<EditorialCardProps> = ({
           {eyebrow}
         </div>
       ) : null}
-      <h3 className="text-base font-semibold text-text">
+      {/* Title/20 Semi Bold (Figma EditorialCard master 132:1284): 20/26,
+          −0.05px tracking. */}
+      <h3 className="text-[20px] font-semibold leading-[26px] tracking-[-0.05px] text-text">
         {/* Accent underline draws on hover. */}
         <span className="bg-gradient-to-r from-accent to-accent bg-[length:0%_2px] bg-left-bottom bg-no-repeat transition-[background-size] duration-base ease-standard group-hover:bg-[length:100%_2px] motion-reduce:transition-none">
           {title}
@@ -77,9 +79,10 @@ export const EditorialCard: React.FC<EditorialCardProps> = ({
           />
         ) : null}
       </h3>
-      <p className="mt-2 text-sm leading-relaxed text-text-2">{body}</p>
+      {/* Body/14 Regular (14/20); the CTA line is Body/14 Medium. */}
+      <p className="mt-2 text-sm leading-5 text-text-2">{body}</p>
       {cta ? (
-        <span className="mt-4 inline-flex items-center gap-1 text-[13px] font-medium text-accent">
+        <span className="mt-4 inline-flex items-center gap-1 text-sm font-medium leading-5 text-accent">
           {cta}
           <ChevronRight aria-hidden className="h-3.5 w-3.5" />
         </span>


### PR DESCRIPTION
## Why

Fleet-wide follow-up to the apparule font-weight report (screenshot comparison read heavier/looser than Figma). Same method here: per-role `getComputedStyle` vs the Figma Home frame's (193:14) bound type styles at the 1440 frame.

## Per-role deltas

| Role | Figma style | Web before | Web after |
| --- | --- | --- | --- |
| Hero H1 | `Hero/88 Bold` 88/92 · −2.5% (−2.2px) | 700 · **80/84** · −2px | 700 · 88/92 · −2.2px |
| Section headings (A3–A10) | `Display/32 Bold` 32/38 · −1% (−0.32px) | 700 · 32/**40** · **−0.8px** | 700 · 32/38 · −0.32px |
| Pillar title | `Title/20 Semi Bold` 20/26 · −0.05px | 600 · **16/24** · 0 | 600 · 20/26 · −0.05px |
| Pillar caption / card CTA | `Body/14` 14/20 | 14/**22.75** · CTA **13px** | 14/20 · CTA 14/20 |
| Demo stat value | `Display/32 Bold` 32/38 · −0.32px | ✓ already exact | unchanged |
| Demo stat label | `Table/13` 13/16 | ✓ already exact | unchanged |

Family was never the issue here (Inter via `next/font` already loaded; smoothing pair already in globals.css). The deltas were size/leading/tracking drift on the marketing roles — `tracking-tight` on the hero was actually the style's −2.5% exactly, at the wrong font size.

## Adjudications

- Section headings converge on the file's `Display/32 Bold` metrics — the same numbers `StatCard` already pins — rather than the ad-hoc `leading-tight tracking-tight` pair.
- **Kept web-side** (canvas defects, flagged for a Figma pass, not code): the A4/A5a heading nodes and the how-it-works step titles/captions are raw unstyled text on canvas (leading normal · ls 0 · step titles 15px Medium off-ramp · captions hardcoding `#6e6e76`) instead of binding the kit's local styles.
- Compatible with the salvaged `.tabular-nums` `calt` fix on PR #241 (no file overlap, no smoothing interaction).

## Verification

- e2e "type contract" lock: per-role computed family/weight/size/line-height/letter-spacing at 1440.
- Gates: lint/boundaries ✓ · typecheck ✓ · vitest 439 ✓ · e2e 59 ✓ · `next build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)