### PR TITLE
fix(web): B1 cash-flow line renders dashed under fill mode — drop the pathLength dash draw-in on non-scaling strokes

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -418,7 +418,11 @@ rail (±2px e2e on personal and company orgs) through `ChartLine`'s
 floored at `lg:min-h-[176px]` so short rails never squash it
 (absolutely-filled SVG, `preserveAspectRatio="none"`, non-scaling
 strokes; the %-positioned tick ladder tracks any height); below lg the
-stacked aspect construction is unchanged.
+stacked aspect construction is unchanged. Fill-mode series fade in
+rather than dash-draw-in: `non-scaling-stroke` computes dash metrics in
+screen space, so the `pathLength`-normalized dash no longer spans the
+stretched path and the line renders as literal dashes with gaps (unit +
+e2e pin the fill-mode polyline dash-free).
 
 **Self-host tabbed snippet as-built (2026-07-20, PR #239).** The A8a
 compose one-liner is now the user-approved Docker Compose | Helm tab pair

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -423,6 +423,15 @@ test("overview mid-band bottoms align at lg — the chart card stretches to the 
       .getByTestId("chart-plot")
       .boundingBox();
     expect(plotBox!.height).toBeGreaterThanOrEqual(176);
+    // Regression (user report): non-scaling-stroke dashes in screen
+    // space, so a pathLength-normalized dash draw-in renders the
+    // stretched series as literal dashes with gaps — the fill-mode
+    // polyline must carry no dash pattern.
+    const netLine = page
+      .getByTestId("overview-mid-band")
+      .getByTestId("chart-line-net");
+    await expect(netLine).not.toHaveAttribute("stroke-dasharray", /.+/);
+    await expect(netLine).not.toHaveAttribute("pathLength", /.+/);
   };
 
   await page.setViewportSize({ width: 1440, height: 900 });

--- a/web/src/components/ui/ChartLine.test.tsx
+++ b/web/src/components/ui/ChartLine.test.tsx
@@ -42,6 +42,15 @@ describe("Chart/Line (design.md §8.2b, MI-12)", () => {
     );
   });
 
+  it("fill mode drops the dash draw-in — non-scaling-stroke dashes in screen space, so pathLength dashing gaps the stretched line (user report)", () => {
+    render(<ChartLine fill series={series} />);
+    const line = screen.getByTestId("chart-line-income");
+    expect(line).not.toHaveAttribute("stroke-dasharray");
+    expect(line).not.toHaveAttribute("pathLength");
+    expect(line).toHaveClass("animate-fade-in");
+    expect(line).not.toHaveClass("animate-draw-in");
+  });
+
   it("pointMarkers renders one circle per datum (B6b discrete FY reading)", () => {
     const { container } = render(
       <ChartLine

--- a/web/src/components/ui/ChartLine.tsx
+++ b/web/src/components/ui/ChartLine.tsx
@@ -264,11 +264,17 @@ export const ChartLine: React.FC<ChartLineProps> = ({
               fill="none"
               strokeWidth="1.5"
               vectorEffect={fill ? "non-scaling-stroke" : undefined}
-              pathLength={1}
-              strokeDasharray="1"
+              // non-scaling-stroke computes dash metrics in screen space,
+              // so the pathLength-normalized dash no longer spans the
+              // stretched path — the series renders as literal dashes with
+              // gaps. Fill mode fades in instead of the dash draw-in.
+              pathLength={fill ? undefined : 1}
+              strokeDasharray={fill ? undefined : "1"}
               className={cn(
                 COLOR_STROKE[entry.color],
-                "animate-draw-in motion-reduce:animate-none motion-reduce:[stroke-dashoffset:0]",
+                fill
+                  ? "animate-fade-in motion-reduce:animate-none"
+                  : "animate-draw-in motion-reduce:animate-none motion-reduce:[stroke-dashoffset:0]",
               )}
             />
           ))}


### PR DESCRIPTION
Regression from #241's chart fill mode (user report, screenshots in both themes): the 12-month cash-flow line broke into segments with month-wide gaps.

**Root cause:** `vector-effect: non-scaling-stroke` computes dash metrics in screen space, while `pathLength={1}` + `strokeDasharray="1"` (the draw-in trick) normalizes in user space. Under the fill mode's non-uniform stretch the single dash no longer spans the path — the browser renders the series as literal dashes. The 'gap' months (Mar–May) had real data the whole time.

**Fix:** fill-mode polylines drop `pathLength`/`strokeDasharray` and fade in (200ms); aspect-mode instances keep the 400ms dash draw-in. Verified visually at 1440 in both themes — line continuous Aug→Jul.

**Locks:** unit (fill mode dash-free + fade-in) and the mid-band e2e now asserts the fill polyline carries no dash pattern.

**Cross-check (findings-are-classes):** upstat's only `non-scaling-stroke` (QueryValue sparkline) has no dash pattern; apparule's dasharray uses are uniform-scale rings/spinners — hazard was expendit-only.

Docs: web-implementation.md fill-mode passage updated in-pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)