### PR TITLE
fix(web): fill-mode plot slid under the y-axis labels — restate the axis offset on the absolute SVG

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -422,7 +422,7 @@ stacked aspect construction is unchanged. Fill-mode series fade in
 rather than dash-draw-in: `non-scaling-stroke` computes dash metrics in
 screen space, so the `pathLength`-normalized dash no longer spans the
 stretched path and the line renders as literal dashes with gaps (unit +
-e2e pin the fill-mode polyline dash-free).
+e2e pin the fill-mode polyline dash-free). The absolutely-positioned fill SVG pins to the padding box, so it restates the 52px axis offset as a left inset — the plot never slides under the y-axis label column (e2e pins the label→plot gap ≥ 4px).
 
 **Self-host tabbed snippet as-built (2026-07-20, PR #239).** The A8a
 compose one-liner is now the user-approved Docker Compose | Helm tab pair

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -432,6 +432,20 @@ test("overview mid-band bottoms align at lg — the chart card stretches to the 
       .getByTestId("chart-line-net");
     await expect(netLine).not.toHaveAttribute("stroke-dasharray", /.+/);
     await expect(netLine).not.toHaveAttribute("pathLength", /.+/);
+    // Regression (user report): the fill-mode SVG is absolutely
+    // positioned, which pins to the padding box — it must restate the
+    // axis offset, never slide under the y-axis label column (master:
+    // 44px labels + 8px gap before the plot).
+    const axisBox = await page
+      .getByTestId("overview-mid-band")
+      .getByTestId("chart-y-axis")
+      .boundingBox();
+    const svgBox = await page
+      .getByTestId("overview-mid-band")
+      .locator("svg")
+      .first()
+      .boundingBox();
+    expect(svgBox!.x - (axisBox!.x + axisBox!.width)).toBeGreaterThanOrEqual(4);
   };
 
   await page.setViewportSize({ width: 1440, height: 900 });

--- a/web/src/components/ui/ChartLine.tsx
+++ b/web/src/components/ui/ChartLine.tsx
@@ -220,10 +220,14 @@ export const ChartLine: React.FC<ChartLineProps> = ({
             // Absolute positioning pins to the PADDING box, so inset-0
             // would slide the plot under the y-axis label column — the
             // left inset restates the 52px axis offset (user report:
-            // gridlines struck through the tick labels).
+            // gridlines struck through the tick labels). Width must be
+            // explicit: an absolutely-positioned SVG is a REPLACED
+            // element, so left+right insets with w-auto resolve width
+            // from the viewBox aspect (huge at tall plots) instead of
+            // stretching between the insets.
             fill &&
               (yAxis
-                ? "lg:absolute lg:inset-y-0 lg:right-0 lg:left-[52px] lg:h-full lg:w-auto"
+                ? "lg:absolute lg:inset-y-0 lg:left-[52px] lg:h-full lg:w-[calc(100%-52px)]"
                 : "lg:absolute lg:inset-0 lg:h-full"),
           )}
         >

--- a/web/src/components/ui/ChartLine.tsx
+++ b/web/src/components/ui/ChartLine.tsx
@@ -215,7 +215,17 @@ export const ChartLine: React.FC<ChartLineProps> = ({
           preserveAspectRatio={fill ? "none" : undefined}
           role="img"
           aria-label={`Line chart: ${series.map((entry) => entry.label).join(", ")}`}
-          className={cn("w-full", fill && "lg:absolute lg:inset-0 lg:h-full")}
+          className={cn(
+            "w-full",
+            // Absolute positioning pins to the PADDING box, so inset-0
+            // would slide the plot under the y-axis label column — the
+            // left inset restates the 52px axis offset (user report:
+            // gridlines struck through the tick labels).
+            fill &&
+              (yAxis
+                ? "lg:absolute lg:inset-y-0 lg:right-0 lg:left-[52px] lg:h-full lg:w-auto"
+                : "lg:absolute lg:inset-0 lg:h-full"),
+          )}
         >
           {scale ? (
             // Gridline per tick (--border); the lowest is the baseline.


### PR DESCRIPTION
Second fill-mode regression from #241 (user report): the y-axis tick labels had no gap before the plot — gridlines struck through them. Absolute positioning resolves against the **padding box**, so the fill SVG's `inset-0` ignored the 52px axis padding. The SVG now restates the offset (`left-[52px]`) when the axis renders; aspect mode unchanged.

Locks: mid-band e2e asserts the label-column→plot gap ≥ 4px (plus the existing dash-free and bottom-alignment pins). Verified visually at 1440 — 44px label column, 8px gap, plot clear of it.

Docs: web-implementation.md fill passage updated in-pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)