### PR TITLE
feat(web): categories Archive tab — routed Active|Archive registry tabs (ratified 2026-07-21)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -70,6 +70,13 @@ without `:userID`, error envelope, pagination) plus these new capabilities:
 | `DELETE /api/v1/account/purge` | cancel within grace |
 | `GET /api/v1/consent` · `POST /api/v1/consent` | ToS/privacy/AI-processing acceptance records |
 
+### Category registry archive (pages.md B8) **[Ratified 2026-07-21]**
+
+| Method & path | Purpose |
+| --- | --- |
+| `GET /api/v1/categories?archived=1` | archived registry; the default (no param) list is active-only, so pickers, merge targets, and imports never see archived rows |
+| `POST /api/v1/categories/{id}/archive` · `.../unarchive` | quiet + reversible + idempotent; `archived_at` stamps the archive date (null = active); merge refuses an archived target — `422 merge_target_archived` |
+
 ### Import hardening
 
 | Change | Why |

--- a/docs/design.md
+++ b/docs/design.md
@@ -191,7 +191,7 @@ only. Per the rule above, the page and this doc must never diverge.
 | 1 Atoms | Button, Input, MoneyCell, CategoryChip, AnomalyBadge, Toast/Banner + primitive kit (§8.2b): Checkbox, Radio, Switch, Tag/Badge, Tooltip, Avatar, Kbd, ProgressBar, Skeleton set | molecules |
 | 2 Molecules | StatCard, TxnTableRow, UploadDropzone, LinkAccountCard, RatioGauge, Inspector chrome, CommandPalette, WizardShell chrome, FormRow, ManualStatementRow, RemitToCard, TaxCalendarRow + form/overlay kit (§8.2b): Select/Menu, DatePicker/PeriodPicker, Modal/Dialog chrome, SegmentedControl, Tabs, Accordion, WizardStep, StampedCheck, ColorSwatchPicker · app chrome (AppNav/NavItem, OrgSwitcher) · GoogleAuthButton · product rows (MemberRow, ImportJobRow, ReportArtifactRow, FilingHistoryRow) | tables + flows |
 | 3 Assemblies | TxnTable (full), staged-review table, ratio grid, StatementView, filing wizard steps, EmptyState set + table chrome (TableHeader, BulkActionBar, StagedReviewHeader) · chart kit (Chart/Line, Chart/Donut) | screens |
-| 4 Screen templates | dashboard, transactions, import review, accounts, company statements+ratios, tax center+wizard, settings/rights, signin (the single X-1 auth screen), reports (B5), categories (B8) | dashboard design |
+| 4 Screen templates | dashboard, transactions, import review, accounts, company statements+ratios, tax center+wizard, settings/rights, signin (the single X-1 auth screen), reports (B5), categories (B8 — routed Active/Archive registry tabs) | dashboard design |
 | 5 Home page | A1–A11 Brex-editorial sections + marketing kit (§8.2b): MarketingNav, MarketingFooter, EditorialCard, CodeSnippet, ComparisonTable | landing redesign |
 
 **Stage 0 icon set (extended 2026-07-16).** The parity audit fixes the Lucide

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -152,9 +152,9 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   ±1% tolerance, amber when not), period-selector header (StatementView,
   design.md §8.2); export to report artifact
   (`kind: financial_statement`, api.md §2).
-- Archive tab **[Proposed — deferred]**: the B6 hub frame carries a
-  Statements / Ratios / Trends / Archive tab row; the built IA stays two
-  nav pages (adjudicated parity) and no Archive surface ships yet.
+- Archive **[Ratified 2026-07-21]**: the archive surface lives on the
+  category registry (B8 `/categories`, routed Archive tab); B6 keeps the
+  adjudicated two-page IA — no hub tab row.
 - **Ratios** (`/company/ratios` — screen B6b): RatioGauge grid (MI-8),
   grouped:
   - *Liquidity*: current ratio, quick ratio, cash ratio
@@ -228,6 +228,15 @@ Categories · Settings. ⌘K palette everywhere (MI-1). Org switcher atop nav
   state** (✨ chip + provenance note, e.g. "AI proposed from 3 vendors"; a
   human edit confirms the entry). Per-row Delete confirms before firing
   (danger pattern); `category_in_use` pivots to merge.
+- Registry tabs **[Ratified 2026-07-21]** (routed — RouteTabs idiom,
+  deep-linkable): **Active** (`/categories`) and **Archive**
+  (`/categories/archive`). Archive is a quiet per-row action (reversible,
+  no confirm — the danger ladder reserves danger affordances for
+  destructive acts): an archived category keeps its history but leaves
+  the default list, so pickers, merge targets, and new imports never
+  offer it. Archive rows read "Archived d MMM yyyy · N transactions this
+  year" (absolute dates, finance idiom) with a quiet Unarchive; merging
+  into an archived target is refused (`merge_target_archived`).
 - Settings: org members/roles (company orgs), organization profile — name,
   registered address, fiscal year end (company orgs; data-model.md §5,
   FormRow; FYE is a human month-end select, "31 December", writing the

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -444,6 +444,30 @@ method-neutral "self-host"). Unit: `CodeSnippet.test.tsx` tabbed cases
 reset); e2e: `home.spec.ts` pins helm-tab copy → the clipboard payload,
 caption persistence and the 1440/390 container fit.
 
+**Categories Archive tab as-built (2026-07-21, ratified — resolves the
+deferred Archive proposal).** The archive surface ships on the category
+registry, not the B6 hub (B6 keeps its adjudicated two-page IA; the
+ratified canvas frame is "B8b — Categories (Archive)").
+`/dashboard/categories` carries the routed tab pair **Active | Archive**
+(RouteTabs idiom — every tab a real sub-route, deep-linkable; `RouteTabs`
+resolves the most specific matching href, so the bare Active route no
+longer captures its child). Rows gain a quiet **Archive** action (danger
+ladder: reversible moves are never danger and take no confirm);
+`/dashboard/categories/archive` lists archived rows as chip + "Archived
+d MMM yyyy · N transactions this year" (absolute finance dates) + quiet
+**Unarchive**. Model: `Category.archived_at` (ISO datetime, null/absent
+= active). Mock API: `GET /categories` serves the active registry only —
+pickers, merge targets, and recategorize menus never see archived rows —
+with `?archived=1` for the archive; idempotent `POST
+/categories/{id}/archive` / `.../unarchive`; merge refuses an archived
+target (`422 merge_target_archived`). Seed: "Conferences & travel" +
+"Print & stationery" archived on the Cuesoft org (the B8b narrative).
+Unit: `routes-categories.test.ts`, `use-categories.test.ts`,
+`CategoriesArchiveView.test.tsx`, and a RouteTabs nested-href case; e2e:
+`categories-archive.spec.ts` (archive → Archive tab → unarchive →
+delete-cleanup, plus the deep-link) and the 390 sweep gains the archive
+route.
+
 ## 3. Token mapping — design.md §2 → `web/src/design/tokens.css`
 
 One custom property per Figma variable in the `expendit/tokens` collection
@@ -513,7 +537,7 @@ the ⌘K palette (MI-1) is a global overlay, not a route.
 | B6b | `/dashboard/company/ratios` | Ratio grid (RatioGauge groups, trends; traces open in the Inspector) |
 | B7 | `/dashboard/taxes` | Tax center (profile, calendar, estimates with RemitToCard, filing history) |
 | B7b | `/dashboard/taxes/file` | Filing wizard (MI-10) |
-| B8 | `/dashboard/categories` | Categories (CRUD, color, merge) |
+| B8 | `/dashboard/categories` · `/dashboard/categories/archive` | Categories — routed Active/Archive registry tabs (CRUD, color, merge; quiet archive/unarchive, absolute archive dates) |
 | B9 | `/dashboard/settings` → `/dashboard/settings/organization` | Settings shell — page title + routed tab bar (underline grammar, tablist-of-links with `aria-current`); the bare route redirects to the first tab (live IA, **[User-ratified 2026-07-20]**) |
 | B9 | `/dashboard/settings/organization` | Organization tab — org profile (name, registered address, fiscal year end) + Appearance card tail (theme control) |
 | B9 | `/dashboard/settings/members` | Members tab — members & roles (invite → pending until first sign-in) |

--- a/web/e2e/categories-archive.spec.ts
+++ b/web/e2e/categories-archive.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * B8 categories Archive tab (ratified 2026-07-21): archive is a quiet,
+ * reversible row action — the row moves to the routed Archive tab
+ * (/dashboard/categories/archive, deep-linkable) and comes back on
+ * Unarchive. The spec creates its own category and deletes it at the
+ * end, leaving the shared mock narrative untouched for later specs.
+ */
+
+const signIn = async (page: Page): Promise<void> => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: "Continue with Google" }).click();
+  await page.waitForURL("**/dashboard", { timeout: 15_000 });
+};
+
+/** The archived seed narrative lives on the Cuesoft org (B8b frame). */
+const switchToCompanyOrg = async (page: Page): Promise<void> => {
+  const trigger = page.getByRole("button", { name: /Personal|Cuesoft/ });
+  await trigger.first().click();
+  await page
+    .getByRole("listbox", { name: "Organizations" })
+    .getByRole("option", { name: /Cuesoft Ltd/ })
+    .click();
+};
+
+test("archive journey: archive → Archive tab → unarchive returns it", async ({
+  page,
+}) => {
+  await signIn(page);
+  await switchToCompanyOrg(page);
+  await page.goto("/dashboard/categories");
+
+  // Routed tab bar, Active selected on the bare route.
+  const tablist = page.getByRole("tablist", {
+    name: "Category registry views",
+  });
+  await expect(tablist).toBeVisible();
+  await expect(page.getByRole("tab", { name: "Active" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+
+  // Own fixture: create a category so the seed narrative stays intact.
+  await page.getByRole("button", { name: "New category" }).click();
+  await page.getByLabel("Name").fill("Legacy fleet");
+  await page.getByRole("button", { name: "Create" }).click();
+  const row = page.locator("li", { hasText: "Legacy fleet" });
+  await expect(row).toBeVisible();
+
+  // Quiet archive — no confirm dialog, just the toast.
+  await row.getByRole("button", { name: "Archive", exact: true }).click();
+  await expect(
+    page.getByText('"Legacy fleet" archived — find it under Archive'),
+  ).toBeVisible();
+  await expect(row).toHaveCount(0);
+
+  // The Archive tab is a real link route.
+  await page.getByRole("tab", { name: "Archive" }).click();
+  await page.waitForURL("**/dashboard/categories/archive");
+  await expect(page.getByRole("tab", { name: "Archive" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+
+  // Absolute-date meta (finance idiom) — the mock clock's "today".
+  const archivedRow = page.locator("li", { hasText: "Legacy fleet" });
+  await expect(archivedRow).toContainText("Archived 20 Jul 2026");
+  // Seeded archive narrative renders alongside.
+  await expect(
+    page.locator("li", { hasText: "Conferences & travel" }),
+  ).toContainText("Archived 14 Mar 2026 · 0 transactions this year");
+
+  // Unarchive returns the row to the active registry.
+  await archivedRow.getByRole("button", { name: "Unarchive" }).click();
+  await expect(
+    page.getByText('"Legacy fleet" restored to the active registry'),
+  ).toBeVisible();
+  await expect(archivedRow).toHaveCount(0);
+
+  await page.getByRole("tab", { name: "Active" }).click();
+  await page.waitForURL("**/dashboard/categories");
+  const restored = page.locator("li", { hasText: "Legacy fleet" });
+  await expect(restored).toBeVisible();
+
+  // Cleanup: delete the fixture category (0 txns → immediate delete).
+  await restored.getByRole("button", { name: "Delete" }).click();
+  await page
+    .getByRole("dialog", { name: /^Delete/ })
+    .getByRole("button", { name: "Delete category" })
+    .click();
+  await expect(page.getByText("Category deleted")).toBeVisible();
+  await expect(restored).toHaveCount(0);
+});
+
+test("archive tab deep-links", async ({ page }) => {
+  await signIn(page);
+  await switchToCompanyOrg(page);
+  await page.goto("/dashboard/categories/archive");
+
+  await expect(page.getByRole("tab", { name: "Archive" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await expect(
+    page.getByRole("region", { name: "Archived categories" }),
+  ).toBeVisible();
+  await expect(
+    page.locator("li", { hasText: "Print & stationery" }),
+  ).toContainText("Archived 5 Jan 2026");
+  // The dashboard nav keeps Categories highlighted on the sub-route.
+  await expect(
+    page.getByRole("link", { name: "Categories" }),
+  ).toHaveAttribute("aria-current", "page");
+});

--- a/web/e2e/categories-archive.spec.ts
+++ b/web/e2e/categories-archive.spec.ts
@@ -109,7 +109,8 @@ test("archive tab deep-links", async ({ page }) => {
     page.locator("li", { hasText: "Print & stationery" }),
   ).toContainText("Archived 5 Jan 2026");
   // The dashboard nav keeps Categories highlighted on the sub-route.
-  await expect(
-    page.getByRole("link", { name: "Categories" }),
-  ).toHaveAttribute("aria-current", "page");
+  await expect(page.getByRole("link", { name: "Categories" })).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
 });

--- a/web/e2e/mobile-responsive.spec.ts
+++ b/web/e2e/mobile-responsive.spec.ts
@@ -120,6 +120,8 @@ const PERSONAL_ROUTES = [
   "/dashboard/accounts",
   "/dashboard/reports",
   "/dashboard/categories",
+  // routed registry tabs (2026-07-21): the Archive pane reflows too.
+  "/dashboard/categories/archive",
   // routed settings tabs (2026-07-20): the bar itself must h-scroll in
   // the viewport, and every pane reflows — sweep all four sub-routes.
   "/dashboard/settings/organization",

--- a/web/src/app/api/mock/categories/[id]/archive/route.ts
+++ b/web/src/app/api/mock/categories/[id]/archive/route.ts
@@ -1,0 +1,28 @@
+/**
+ * Mock: category archive (pages.md B8 Archive tab) — quiet, reversible.
+ * Sets `archived_at`; the category leaves the default list (pickers,
+ * merge targets, imports) while every historical reference keeps its
+ * chip. Idempotent: archiving an archived category is a no-op 200.
+ */
+
+import { getDb } from "@/mock/db";
+import { mockNow } from "@/mock/clock";
+import { notFound, ok, resolveOrgId, writeBlocked } from "@/mock/http";
+
+type Context = { params: Promise<{ id: string }> };
+
+export async function POST(request: Request, context: Context) {
+  const blocked = writeBlocked();
+  if (blocked) return blocked;
+  const { id } = await context.params;
+  const orgId = resolveOrgId(request);
+  if (!orgId) return notFound();
+
+  const category = getDb().categories.find(
+    (cat) => cat.id === id && cat.org_id === orgId,
+  );
+  if (!category) return notFound();
+
+  if (!category.archived_at) category.archived_at = mockNow().toISOString();
+  return ok(category);
+}

--- a/web/src/app/api/mock/categories/[id]/merge/route.ts
+++ b/web/src/app/api/mock/categories/[id]/merge/route.ts
@@ -40,6 +40,13 @@ export async function POST(request: Request, context: Context) {
       `Cannot merge ${source.type} into ${target.type} — types must match`,
     );
   }
+  if (target.archived_at) {
+    return fail(
+      422,
+      "merge_target_archived",
+      "Cannot merge into an archived category — restore it first",
+    );
+  }
 
   let moved = 0;
   for (const txn of db.transactions) {

--- a/web/src/app/api/mock/categories/[id]/unarchive/route.ts
+++ b/web/src/app/api/mock/categories/[id]/unarchive/route.ts
@@ -1,0 +1,26 @@
+/**
+ * Mock: category unarchive (pages.md B8 Archive tab) — clears
+ * `archived_at`, returning the category to the active registry.
+ * Idempotent: unarchiving an active category is a no-op 200.
+ */
+
+import { getDb } from "@/mock/db";
+import { notFound, ok, resolveOrgId, writeBlocked } from "@/mock/http";
+
+type Context = { params: Promise<{ id: string }> };
+
+export async function POST(request: Request, context: Context) {
+  const blocked = writeBlocked();
+  if (blocked) return blocked;
+  const { id } = await context.params;
+  const orgId = resolveOrgId(request);
+  if (!orgId) return notFound();
+
+  const category = getDb().categories.find(
+    (cat) => cat.id === id && cat.org_id === orgId,
+  );
+  if (!category) return notFound();
+
+  category.archived_at = null;
+  return ok(category);
+}

--- a/web/src/app/api/mock/categories/route.ts
+++ b/web/src/app/api/mock/categories/route.ts
@@ -9,11 +9,17 @@ export async function GET(request: Request) {
   const orgId = resolveOrgId(request);
   if (!orgId) return fail(404, "not_found", "Unknown org");
   const db = getDb();
+  // Active registry by default; `?archived=1` lists the archive (B8
+  // Archive tab). Pickers, merge targets, and imports read the default
+  // list, so archived categories never surface there.
+  const archived = new URL(request.url).searchParams.get("archived") === "1";
   // Usage enrichment (B8 "N transactions this year" — merge-safety
   // context): calendar-year count per category, derived at read time.
   const year = String(mockNow().getFullYear());
   const items = db.categories
-    .filter((cat) => cat.org_id === orgId)
+    .filter(
+      (cat) => cat.org_id === orgId && Boolean(cat.archived_at) === archived,
+    )
     .map((cat) => ({
       ...cat,
       txn_count_ytd: db.transactions.filter(

--- a/web/src/app/dashboard/DashboardShell.tsx
+++ b/web/src/app/dashboard/DashboardShell.tsx
@@ -84,7 +84,14 @@ const NAV_ROUTES: NavRoute[] = [
     nested: true,
     group: "Taxes",
   },
-  { href: "/dashboard/categories", label: "Categories", icon: TagIcon },
+  // nested: the routed registry tabs (/dashboard/categories/archive)
+  // keep the Categories entry highlighted (ratified 2026-07-21).
+  {
+    href: "/dashboard/categories",
+    label: "Categories",
+    icon: TagIcon,
+    nested: true,
+  },
   // nested: the routed settings tabs (/dashboard/settings/<tab>) keep
   // the Settings entry highlighted (ratified 2026-07-20).
   {

--- a/web/src/app/dashboard/categories/CategoriesView.tsx
+++ b/web/src/app/dashboard/categories/CategoriesView.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 /**
- * B8 `/dashboard/categories` — Categories (pages.md B8): CRUD with
- * color dot (ColorSwatchPicker presets), the merge tool (repoints ledger
- * + staged rows), and the AI-training note. 409 category_in_use on
- * delete pivots to merge. Render-only.
+ * B8 `/dashboard/categories` — Categories, the Active registry tab
+ * (pages.md B8): CRUD with color dot (ColorSwatchPicker presets), the
+ * merge tool (repoints ledger + staged rows), the quiet Archive action
+ * (rows move to the routed Archive tab), and the AI-training note.
+ * 409 category_in_use on delete pivots to merge. Render-only.
  */
 
 import React, { useMemo, useState } from "react";
@@ -19,11 +20,13 @@ import CategoryChip from "@/components/ui/CategoryChip";
 import ColorSwatchPicker from "@/components/ui/ColorSwatchPicker";
 import Input from "@/components/ui/Input";
 import Modal from "@/components/ui/Modal";
+import RouteTabs from "@/components/ui/RouteTabs";
 import SegmentedControl from "@/components/ui/SegmentedControl";
 import Select from "@/components/ui/Select";
 import Skeleton from "@/components/ui/Skeleton";
 import PageHeader from "../PageHeader";
 import ToastLayer from "../ToastLayer";
+import { CATEGORY_TABS } from "./tabs";
 
 // Registry preset palette (data, not styling — B8 ColorSwatchPicker).
 const PRESET_COLORS = [
@@ -49,6 +52,7 @@ interface CategoryListProps {
   items: Category[];
   onEdit: (category: Category) => void;
   onMerge: (category: Category) => void;
+  onArchive: (category: Category) => void;
   onDelete: (category: Category) => void;
 }
 
@@ -64,6 +68,7 @@ const CategoryList: React.FC<CategoryListProps> = ({
   items,
   onEdit,
   onMerge,
+  onArchive,
   onDelete,
 }) => (
   <section aria-label={title} className="rounded border border-border bg-bg">
@@ -102,6 +107,16 @@ const CategoryList: React.FC<CategoryListProps> = ({
               </Button>
               <Button kind="quiet" size="sm" onClick={() => onMerge(category)}>
                 Merge
+              </Button>
+              {/* Archive is quiet, not danger (danger ladder): it is the
+                  reversible soft path — the row moves to the Archive tab
+                  and leaves pickers, history untouched. */}
+              <Button
+                kind="quiet"
+                size="sm"
+                onClick={() => onArchive(category)}
+              >
+                Archive
               </Button>
               <Button
                 kind="destructive"
@@ -184,6 +199,16 @@ export const CategoriesView: React.FC = () => {
     }
   };
 
+  // Quiet + reversible (no confirm): the row moves to the Archive tab.
+  const archiveCategory = async (category: Category) => {
+    try {
+      await categories.archive(category.id);
+      setToast(`"${category.name}" archived — find it under Archive`);
+    } catch (err) {
+      setToast(err instanceof Error ? err.message : "Archive failed");
+    }
+  };
+
   const removeCategory = async (category: Category) => {
     try {
       await categories.remove(category.id);
@@ -233,59 +258,65 @@ export const CategoriesView: React.FC = () => {
         }
       />
 
-      {categories.error ? (
+      {/* Routed registry tabs (ratified 2026-07-21): Active | Archive,
+          every tab a real sub-route (RouteTabs idiom). */}
+      <RouteTabs tabs={[...CATEGORY_TABS]} aria-label="Category registry views">
+        {categories.error ? (
+          <div className="mb-4">
+            <Banner kind="error">{categories.error}</Banner>
+          </div>
+        ) : null}
+
         <div className="mb-4">
-          <Banner kind="error">{categories.error}</Banner>
+          {/* Banner kind="info" supplies its own leading icon — no manual
+              Sparkles (double-icon bug, audit B8). */}
+          <Banner kind="info">
+            Your category corrections train the AI — re-categorized imports
+            improve future suggestions for this workspace.
+          </Banner>
         </div>
-      ) : null}
 
-      <div className="mb-4">
-        {/* Banner kind="info" supplies its own leading icon — no manual
-            Sparkles (double-icon bug, audit B8). */}
-        <Banner kind="info">
-          Your category corrections train the AI — re-categorized imports
-          improve future suggestions for this workspace.
-        </Banner>
-      </div>
-
-      {categories.loading && categories.items.length === 0 ? (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          {[...Array(2)].map((_, i) => (
-            <Skeleton key={i} variant="chart" />
-          ))}
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <CategoryList
-            title="Expense categories"
-            items={expenseCategories}
-            onEdit={(category) =>
-              setDraft({
-                id: category.id,
-                name: category.name,
-                type: category.type,
-                color: category.color,
-              })
-            }
-            onMerge={setMergeSource}
-            onDelete={setConfirmDelete}
-          />
-          <CategoryList
-            title="Income categories"
-            items={incomeCategories}
-            onEdit={(category) =>
-              setDraft({
-                id: category.id,
-                name: category.name,
-                type: category.type,
-                color: category.color,
-              })
-            }
-            onMerge={setMergeSource}
-            onDelete={setConfirmDelete}
-          />
-        </div>
-      )}
+        {categories.loading && categories.items.length === 0 ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {[...Array(2)].map((_, i) => (
+              <Skeleton key={i} variant="chart" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <CategoryList
+              title="Expense categories"
+              items={expenseCategories}
+              onEdit={(category) =>
+                setDraft({
+                  id: category.id,
+                  name: category.name,
+                  type: category.type,
+                  color: category.color,
+                })
+              }
+              onMerge={setMergeSource}
+              onArchive={(category) => void archiveCategory(category)}
+              onDelete={setConfirmDelete}
+            />
+            <CategoryList
+              title="Income categories"
+              items={incomeCategories}
+              onEdit={(category) =>
+                setDraft({
+                  id: category.id,
+                  name: category.name,
+                  type: category.type,
+                  color: category.color,
+                })
+              }
+              onMerge={setMergeSource}
+              onArchive={(category) => void archiveCategory(category)}
+              onDelete={setConfirmDelete}
+            />
+          </div>
+        )}
+      </RouteTabs>
 
       {/* Create / edit */}
       <Modal

--- a/web/src/app/dashboard/categories/CategoriesView.tsx
+++ b/web/src/app/dashboard/categories/CategoriesView.tsx
@@ -101,7 +101,10 @@ const CategoryList: React.FC<CategoryListProps> = ({
             <span className="min-w-0 flex-1 truncate text-[12px] text-text-2">
               {usageMeta(category)}
             </span>
-            <span className="flex shrink-0 items-center gap-3">
+            {/* min-w-0 + flex-wrap: four actions now share the cluster —
+                inside a md two-column card it wraps instead of pushing
+                the column wide (768 overflow sweep). */}
+            <span className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
               <Button kind="quiet" size="sm" onClick={() => onEdit(category)}>
                 Edit
               </Button>

--- a/web/src/app/dashboard/categories/archive/CategoriesArchiveView.test.tsx
+++ b/web/src/app/dashboard/categories/archive/CategoriesArchiveView.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * B8b Archive tab view states (design.md §8.1): loading skeleton, empty
+ * copy, populated rows with the absolute-date meta and a quiet
+ * Unarchive, and the error banner. The controller is mocked — views
+ * render only.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Category } from "@/models";
+import CategoriesArchiveView from "./CategoriesArchiveView";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard/categories/archive",
+}));
+
+const unarchive = vi.fn();
+const controller = {
+  items: [] as Category[],
+  loading: false,
+  error: null as string | null,
+  unarchive,
+};
+
+vi.mock("@/controllers", () => ({
+  useOrg: () => ({ activeOrgId: "org-x" }),
+  useCategoriesController: (
+    _orgId?: string,
+    options?: { archived?: boolean },
+  ) => {
+    // The archive view must ask for the archived registry.
+    expect(options?.archived).toBe(true);
+    return controller;
+  },
+}));
+
+const archivedCategory: Category = {
+  id: "cat-conferences",
+  org_id: "org-x",
+  name: "Conferences & travel",
+  type: "expense",
+  color: "#6E4BD6",
+  tax_treatment: "ignore",
+  vat_treatment: "exempt",
+  vat_basis: "inclusive",
+  txn_count_ytd: 0,
+  archived_at: "2026-03-14T09:30:00.000Z",
+};
+
+describe("CategoriesArchiveView (B8b)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller.items = [];
+    controller.loading = false;
+    controller.error = null;
+  });
+
+  it("renders the routed tab bar with Archive selected", () => {
+    render(<CategoriesArchiveView />);
+    const archiveTab = screen.getByRole("tab", { name: "Archive" });
+    expect(archiveTab).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Active" })).toHaveAttribute(
+      "href",
+      "/dashboard/categories",
+    );
+  });
+
+  it("shows the loading skeleton before the first page of data", () => {
+    controller.loading = true;
+    render(<CategoriesArchiveView />);
+    expect(screen.getByTestId("skeleton-chart")).toBeInTheDocument();
+  });
+
+  it("explains the empty archive", () => {
+    render(<CategoriesArchiveView />);
+    expect(
+      screen.getByText(/Nothing archived yet — archiving hides a category/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders archived rows with absolute-date meta and a quiet Unarchive", async () => {
+    controller.items = [archivedCategory];
+    unarchive.mockResolvedValue({ ...archivedCategory, archived_at: null });
+    render(<CategoriesArchiveView />);
+
+    expect(screen.getByText("Conferences & travel")).toBeInTheDocument();
+    // Finance idiom: absolute date, never relative phrasing.
+    expect(
+      screen.getByText("Archived 14 Mar 2026 · 0 transactions this year"),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Unarchive" }));
+    expect(unarchive).toHaveBeenCalledWith("cat-conferences");
+    expect(
+      await screen.findByText(
+        '"Conferences & travel" restored to the active registry',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces controller errors in a banner", () => {
+    controller.error = "Failed to load categories";
+    render(<CategoriesArchiveView />);
+    expect(screen.getByText("Failed to load categories")).toBeInTheDocument();
+  });
+});

--- a/web/src/app/dashboard/categories/archive/CategoriesArchiveView.tsx
+++ b/web/src/app/dashboard/categories/archive/CategoriesArchiveView.tsx
@@ -72,8 +72,8 @@ export const CategoriesArchiveView: React.FC = () => {
             </header>
             {categories.items.length === 0 ? (
               <p className="px-4 py-6 text-center text-[13px] text-text-2">
-                Nothing archived yet — archiving hides a category from
-                pickers and new imports without touching history.
+                Nothing archived yet — archiving hides a category from pickers
+                and new imports without touching history.
               </p>
             ) : (
               <ul className="list-none">

--- a/web/src/app/dashboard/categories/archive/CategoriesArchiveView.tsx
+++ b/web/src/app/dashboard/categories/archive/CategoriesArchiveView.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+/**
+ * B8b `/dashboard/categories/archive` — the registry's Archive tab
+ * (pages.md B8, ratified 2026-07-21). Archived categories keep their
+ * history but leave pickers, merge targets, and new imports; rows offer
+ * a quiet Unarchive (reversible — never a danger affordance). Absolute
+ * dates per the finance idiom. Render-only.
+ */
+
+import React from "react";
+import { useCategoriesController, useOrg } from "@/controllers";
+import type { Category } from "@/models";
+import { formatIso } from "@/lib/dates";
+import Banner from "@/components/ui/Banner";
+import Button from "@/components/ui/Button";
+import CategoryChip from "@/components/ui/CategoryChip";
+import RouteTabs from "@/components/ui/RouteTabs";
+import Skeleton from "@/components/ui/Skeleton";
+import PageHeader from "../../PageHeader";
+import ToastLayer from "../../ToastLayer";
+import { CATEGORY_TABS } from "../tabs";
+
+/** "Archived 14 Mar 2026 · 12 transactions this year" (absolute dates). */
+const archiveMeta = (category: Category): string => {
+  const count = category.txn_count_ytd ?? 0;
+  const usage = `${count} ${count === 1 ? "transaction" : "transactions"} this year`;
+  return category.archived_at
+    ? `Archived ${formatIso(category.archived_at, "d MMM yyyy")} · ${usage}`
+    : usage;
+};
+
+export const CategoriesArchiveView: React.FC = () => {
+  const { activeOrgId } = useOrg();
+  const categories = useCategoriesController(activeOrgId, { archived: true });
+  const [toast, setToast] = React.useState<string | null>(null);
+
+  const restore = async (category: Category) => {
+    try {
+      await categories.unarchive(category.id);
+      setToast(`"${category.name}" restored to the active registry`);
+    } catch (err) {
+      setToast(err instanceof Error ? err.message : "Restore failed");
+    }
+  };
+
+  return (
+    <>
+      <PageHeader
+        title="Categories"
+        description="The registry behind every chip, donut slice, and tax treatment."
+      />
+
+      <RouteTabs tabs={[...CATEGORY_TABS]} aria-label="Category registry views">
+        {categories.error ? (
+          <div className="mb-4">
+            <Banner kind="error">{categories.error}</Banner>
+          </div>
+        ) : null}
+
+        {categories.loading && categories.items.length === 0 ? (
+          <Skeleton variant="chart" />
+        ) : (
+          <section
+            aria-label="Archived categories"
+            className="rounded border border-border bg-bg"
+          >
+            <header className="border-b border-border px-4 py-2.5">
+              <h2 className="text-[13px] font-medium text-text">
+                Archived categories
+              </h2>
+            </header>
+            {categories.items.length === 0 ? (
+              <p className="px-4 py-6 text-center text-[13px] text-text-2">
+                Nothing archived yet — archiving hides a category from
+                pickers and new imports without touching history.
+              </p>
+            ) : (
+              <ul className="list-none">
+                {categories.items.map((category) => (
+                  <li
+                    key={category.id}
+                    // flex-wrap: at narrow widths the action wraps under
+                    // the chip instead of pushing the page wide (mobile
+                    // canon).
+                    className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b border-border px-4 py-2 last:border-b-0"
+                  >
+                    <CategoryChip
+                      category={{
+                        id: category.id,
+                        name: category.name,
+                        color: category.color,
+                      }}
+                    />
+                    <span className="min-w-0 flex-1 truncate text-[12px] text-text-2">
+                      {archiveMeta(category)}
+                    </span>
+                    <span className="flex shrink-0 items-center">
+                      <Button
+                        kind="quiet"
+                        size="sm"
+                        onClick={() => void restore(category)}
+                      >
+                        Unarchive
+                      </Button>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        )}
+      </RouteTabs>
+
+      <ToastLayer message={toast} onDismiss={() => setToast(null)} />
+    </>
+  );
+};
+
+export default CategoriesArchiveView;

--- a/web/src/app/dashboard/categories/archive/page.tsx
+++ b/web/src/app/dashboard/categories/archive/page.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import CategoriesArchiveView from "./CategoriesArchiveView";
+
+/** B8b `/dashboard/categories/archive` — archived registry (pages.md B8). */
+export default function CategoriesArchivePage() {
+  return <CategoriesArchiveView />;
+}

--- a/web/src/app/dashboard/categories/tabs.ts
+++ b/web/src/app/dashboard/categories/tabs.ts
@@ -1,0 +1,10 @@
+/**
+ * B8 `/dashboard/categories` — the registry's routed tab bar (ratified
+ * 2026-07-21): every tab is a real sub-route (RouteTabs idiom), so the
+ * archive deep-links and back/forward work. Active is the bare route.
+ */
+
+export const CATEGORY_TABS = [
+  { href: "/dashboard/categories", label: "Active" },
+  { href: "/dashboard/categories/archive", label: "Archive" },
+] as const;

--- a/web/src/components/ui/RouteTabs.test.tsx
+++ b/web/src/components/ui/RouteTabs.test.tsx
@@ -60,6 +60,29 @@ describe("RouteTabs (accessible routed-tabs pattern)", () => {
     );
   });
 
+  it("prefers the most specific tab when hrefs nest (categories Active/Archive)", () => {
+    pathname = "/dashboard/categories/archive";
+    render(
+      <RouteTabs
+        tabs={[
+          { href: "/dashboard/categories", label: "Active" },
+          { href: "/dashboard/categories/archive", label: "Archive" },
+        ]}
+        aria-label="Category registry views"
+      >
+        <p>Archive pane</p>
+      </RouteTabs>,
+    );
+    expect(screen.getByRole("tab", { name: "Archive" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: "Active" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+
   it("moves focus with arrows/Home/End (manual activation, wrapping)", async () => {
     const user = userEvent.setup();
     renderTabs();

--- a/web/src/components/ui/RouteTabs.tsx
+++ b/web/src/components/ui/RouteTabs.tsx
@@ -48,7 +48,13 @@ export const RouteTabs: React.FC<RouteTabsProps> = ({
 
   const isActive = (href: string) =>
     pathname === href || pathname.startsWith(`${href}/`);
-  const active = tabs.find((tab) => isActive(tab.href));
+  // Most-specific match wins: with nested tab routes (e.g. categories'
+  // Active at the bare route and Archive at a sub-route) the parent
+  // href prefix-matches every child, so the longest match is the tab
+  // the user is actually on.
+  const active = tabs
+    .filter((tab) => isActive(tab.href))
+    .sort((a, b) => b.href.length - a.href.length)[0];
   // Roving focus falls back to the first tab when no route matches.
   const rovingHref = active?.href ?? tabs[0]?.href;
 

--- a/web/src/controllers/use-categories.test.ts
+++ b/web/src/controllers/use-categories.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Categories controller (B8): one controller serves both registry tabs —
+ * default lists active, `{ archived: true }` lists the archive; archive
+ * and unarchive drop the row from the current list (it belongs to the
+ * other routed tab, which refetches on mount).
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
+import type { Category } from "@/models";
+import { useCategoriesController } from "./use-categories";
+import { categoriesRepo } from "@/models/repositories";
+
+vi.mock("@/models/repositories", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/models/repositories")>();
+  return {
+    ...mod,
+    categoriesRepo: {
+      ...mod.categoriesRepo,
+      list: vi.fn(),
+      archive: vi.fn(),
+      unarchive: vi.fn(),
+    },
+  };
+});
+
+const category = (id: string, archived = false): Category => ({
+  id,
+  org_id: "org-x",
+  name: id,
+  type: "expense",
+  color: "#6E6E76",
+  tax_treatment: "ignore",
+  vat_treatment: "exempt",
+  vat_basis: "inclusive",
+  archived_at: archived ? "2026-03-14T09:30:00.000Z" : null,
+});
+
+const listMock = vi.mocked(categoriesRepo.list);
+const archiveMock = vi.mocked(categoriesRepo.archive);
+const unarchiveMock = vi.mocked(categoriesRepo.unarchive);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useCategoriesController (B8 registry tabs)", () => {
+  it("lists the active registry by default", async () => {
+    listMock.mockResolvedValue({ items: [category("cat-a")] });
+    const { result } = renderHook(() => useCategoriesController("org-x"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(listMock).toHaveBeenCalledWith({
+      orgId: "org-x",
+      archived: false,
+    });
+    expect(result.current.items.map((item) => item.id)).toEqual(["cat-a"]);
+  });
+
+  it("lists the archive with { archived: true }", async () => {
+    listMock.mockResolvedValue({ items: [category("cat-z", true)] });
+    const { result } = renderHook(() =>
+      useCategoriesController("org-x", { archived: true }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(listMock).toHaveBeenCalledWith({ orgId: "org-x", archived: true });
+    expect(result.current.items[0].archived_at).not.toBeNull();
+  });
+
+  it("archive() drops the row from the current (active) list", async () => {
+    listMock.mockResolvedValue({
+      items: [category("cat-a"), category("cat-b")],
+    });
+    archiveMock.mockResolvedValue(category("cat-a", true));
+    const { result } = renderHook(() => useCategoriesController("org-x"));
+    await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.archive("cat-a");
+    });
+    expect(archiveMock).toHaveBeenCalledWith("cat-a", { orgId: "org-x" });
+    expect(result.current.items.map((item) => item.id)).toEqual(["cat-b"]);
+  });
+
+  it("unarchive() drops the row from the current (archived) list", async () => {
+    listMock.mockResolvedValue({ items: [category("cat-z", true)] });
+    unarchiveMock.mockResolvedValue(category("cat-z"));
+    const { result } = renderHook(() =>
+      useCategoriesController("org-x", { archived: true }),
+    );
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.unarchive("cat-z");
+    });
+    expect(unarchiveMock).toHaveBeenCalledWith("cat-z", { orgId: "org-x" });
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it("surfaces list failures through error", async () => {
+    listMock.mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() =>
+      useCategoriesController("org-x", { archived: true }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe("network down");
+    expect(result.current.items).toHaveLength(0);
+  });
+});

--- a/web/src/controllers/use-categories.ts
+++ b/web/src/controllers/use-categories.ts
@@ -1,8 +1,12 @@
 "use client";
 
 /**
- * Categories controller — CRUD + merge tool (pages.md B8). Views render
- * only; 409 category_in_use surfaces through `error` for the delete UX.
+ * Categories controller — CRUD + merge tool + archive (pages.md B8).
+ * Views render only; 409 category_in_use surfaces through `error` for
+ * the delete UX. One controller serves both registry tabs: the default
+ * lists active categories, `{ archived: true }` lists the archive.
+ * Archive/unarchive each drop the row from the current list (it now
+ * belongs to the other tab; routed tabs refetch on mount).
  */
 
 import { useCallback, useEffect, useState } from "react";
@@ -13,7 +17,15 @@ import {
   type CategoryUpdate,
 } from "@/models/repositories";
 
-export const useCategoriesController = (orgId?: string) => {
+export interface CategoriesControllerOptions {
+  /** List the archived registry (B8 Archive tab) instead of the active one. */
+  archived?: boolean;
+}
+
+export const useCategoriesController = (
+  orgId?: string,
+  { archived = false }: CategoriesControllerOptions = {},
+) => {
   const [items, setItems] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +34,7 @@ export const useCategoriesController = (orgId?: string) => {
     setLoading(true);
     setError(null);
     try {
-      const { items: data } = await categoriesRepo.list({ orgId });
+      const { items: data } = await categoriesRepo.list({ orgId, archived });
       setItems(data);
     } catch (err) {
       setError(
@@ -31,7 +43,7 @@ export const useCategoriesController = (orgId?: string) => {
     } finally {
       setLoading(false);
     }
-  }, [orgId]);
+  }, [orgId, archived]);
 
   useEffect(() => {
     // Defer to a microtask — effects must not set state synchronously.
@@ -76,5 +88,36 @@ export const useCategoriesController = (orgId?: string) => {
     [orgId],
   );
 
-  return { items, loading, error, refresh, create, update, remove, merge };
+  /** Quiet + reversible — the row moves to the Archive tab. */
+  const archiveCategory = useCallback(
+    async (id: string) => {
+      const category = await categoriesRepo.archive(id, { orgId });
+      setItems((prev) => prev.filter((item) => item.id !== id));
+      return category;
+    },
+    [orgId],
+  );
+
+  /** Restores an archived row to the active registry. */
+  const unarchiveCategory = useCallback(
+    async (id: string) => {
+      const category = await categoriesRepo.unarchive(id, { orgId });
+      setItems((prev) => prev.filter((item) => item.id !== id));
+      return category;
+    },
+    [orgId],
+  );
+
+  return {
+    items,
+    loading,
+    error,
+    refresh,
+    create,
+    update,
+    remove,
+    merge,
+    archive: archiveCategory,
+    unarchive: unarchiveCategory,
+  };
 };

--- a/web/src/mock/routes-categories.test.ts
+++ b/web/src/mock/routes-categories.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+
+/**
+ * Mock /categories archive surface (pages.md B8 Archive tab, ratified
+ * 2026-07-21): the default list is the active registry; ?archived=1 is
+ * the archive; archive/unarchive are idempotent POST subresources; the
+ * merge target must be active.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { GET as listCategories } from "@/app/api/mock/categories/route";
+import { POST as archiveCategory } from "@/app/api/mock/categories/[id]/archive/route";
+import { POST as unarchiveCategory } from "@/app/api/mock/categories/[id]/unarchive/route";
+import { POST as mergeCategory } from "@/app/api/mock/categories/[id]/merge/route";
+import type { Category } from "@/models";
+import { resetDb } from "./db";
+import { json, mockRequest, params } from "./test-helpers";
+
+const listIds = async (query = ""): Promise<string[]> => {
+  const res = await listCategories(
+    mockRequest(`/api/mock/categories${query}`),
+  );
+  const { items } = await json<{ items: Category[] }>(res);
+  return items.map((cat) => cat.id);
+};
+
+describe("mock /categories archive (B8 Archive tab)", () => {
+  beforeEach(() => {
+    resetDb();
+  });
+
+  it("default list is active-only; ?archived=1 lists the archived registry", async () => {
+    const active = await listIds();
+    expect(active).toContain("cat-cloud");
+    expect(active).not.toContain("cat-conferences");
+    expect(active).not.toContain("cat-print");
+
+    const archived = await listIds("?archived=1");
+    expect(archived).toEqual(
+      expect.arrayContaining(["cat-conferences", "cat-print"]),
+    );
+    expect(archived).not.toContain("cat-cloud");
+  });
+
+  it("archive stamps archived_at (idempotently) and moves the row between lists", async () => {
+    const first = await archiveCategory(
+      mockRequest("/api/mock/categories/cat-meals/archive", {
+        method: "POST",
+      }),
+      params({ id: "cat-meals" }),
+    );
+    expect(first.status).toBe(200);
+    const stamped = await json<Category>(first);
+    // Absolute mock-clock stamp — the seed narrative's "today".
+    expect(stamped.archived_at).toBe("2026-07-20T11:00:00.000Z");
+
+    // Idempotent: a second archive keeps the original stamp.
+    const again = await json<Category>(
+      await archiveCategory(
+        mockRequest("/api/mock/categories/cat-meals/archive", {
+          method: "POST",
+        }),
+        params({ id: "cat-meals" }),
+      ),
+    );
+    expect(again.archived_at).toBe(stamped.archived_at);
+
+    expect(await listIds()).not.toContain("cat-meals");
+    expect(await listIds("?archived=1")).toContain("cat-meals");
+  });
+
+  it("unarchive clears the stamp and restores the row to the active list", async () => {
+    const res = await unarchiveCategory(
+      mockRequest("/api/mock/categories/cat-conferences/unarchive", {
+        method: "POST",
+      }),
+      params({ id: "cat-conferences" }),
+    );
+    expect(res.status).toBe(200);
+    expect((await json<Category>(res)).archived_at).toBeNull();
+
+    expect(await listIds()).toContain("cat-conferences");
+    expect(await listIds("?archived=1")).not.toContain("cat-conferences");
+  });
+
+  it("404s on unknown ids and other-org categories", async () => {
+    const unknown = await archiveCategory(
+      mockRequest("/api/mock/categories/cat-nope/archive", { method: "POST" }),
+      params({ id: "cat-nope" }),
+    );
+    expect(unknown.status).toBe(404);
+
+    // cat-personal-living belongs to the personal org, not Cuesoft.
+    const crossOrg = await archiveCategory(
+      mockRequest("/api/mock/categories/cat-personal-living/archive", {
+        method: "POST",
+      }),
+      params({ id: "cat-personal-living" }),
+    );
+    expect(crossOrg.status).toBe(404);
+  });
+
+  it("merge refuses an archived target (merge_target_archived)", async () => {
+    const res = await mergeCategory(
+      mockRequest("/api/mock/categories/cat-meals/merge", {
+        method: "POST",
+        body: { into: "cat-conferences" },
+      }),
+      params({ id: "cat-meals" }),
+    );
+    expect(res.status).toBe(422);
+    const envelope = await json<{ error: { code: string } }>(res);
+    expect(envelope.error.code).toBe("merge_target_archived");
+  });
+});

--- a/web/src/mock/routes-categories.test.ts
+++ b/web/src/mock/routes-categories.test.ts
@@ -17,9 +17,7 @@ import { resetDb } from "./db";
 import { json, mockRequest, params } from "./test-helpers";
 
 const listIds = async (query = ""): Promise<string[]> => {
-  const res = await listCategories(
-    mockRequest(`/api/mock/categories${query}`),
-  );
+  const res = await listCategories(mockRequest(`/api/mock/categories${query}`));
   const { items } = await json<{ items: Category[] }>(res);
   return items.map((cat) => cat.id);
 };

--- a/web/src/mock/seed.ts
+++ b/web/src/mock/seed.ts
@@ -292,6 +292,30 @@ const categories: Category[] = [
     ai_proposed: true,
     ai_note: "AI proposed from 3 vendors",
   },
+  // Archived registry (B8b frame): unused this year, archived out of the
+  // pickers — history untouched. Dates are the frame's mock narrative.
+  {
+    id: "cat-conferences",
+    org_id: ORG_CUESOFT,
+    name: "Conferences & travel",
+    type: "expense",
+    color: "#6E4BD6",
+    tax_treatment: "ignore",
+    vat_treatment: "exempt",
+    vat_basis: "inclusive",
+    archived_at: "2026-03-14T09:30:00.000Z",
+  },
+  {
+    id: "cat-print",
+    org_id: ORG_CUESOFT,
+    name: "Print & stationery",
+    type: "expense",
+    color: "#0E8B8B",
+    tax_treatment: "ignore",
+    vat_treatment: "exempt",
+    vat_basis: "inclusive",
+    archived_at: "2026-01-05T10:00:00.000Z",
+  },
   // Personal org — the freelancer dataset
   {
     id: "cat-personal-income",

--- a/web/src/models/category.ts
+++ b/web/src/models/category.ts
@@ -35,4 +35,10 @@ export interface Category {
    * (B8 merge-safety context: "N transactions this year").
    */
   txn_count_ytd?: number;
+  /**
+   * Set when the category is archived (B8 Archive tab). Archived
+   * categories keep their history but leave the default list, so
+   * pickers, merge targets, and new imports never offer them.
+   */
+  archived_at?: string | null;
 }

--- a/web/src/models/repositories/categories.ts
+++ b/web/src/models/repositories/categories.ts
@@ -1,14 +1,23 @@
-/** Categories repository — CRUD (pages.md B8). */
+/** Categories repository — CRUD + archive (pages.md B8). */
 
 import type { Category } from "../category";
 import { api, type RequestOptions } from "./client";
 
-export type CategoryCreate = Omit<Category, "id" | "org_id">;
+export type CategoryCreate = Omit<Category, "id" | "org_id" | "archived_at">;
 export type CategoryUpdate = Partial<CategoryCreate>;
 
+export interface CategoryListOptions extends RequestOptions {
+  /** List the archived registry instead of the active one (B8 Archive tab). */
+  archived?: boolean;
+}
+
 export const categoriesRepo = {
-  list: (options?: RequestOptions) =>
-    api.get<{ items: Category[] }>("/categories", options),
+  /** Active categories by default; `archived: true` lists the archive. */
+  list: ({ archived, ...options }: CategoryListOptions = {}) =>
+    api.get<{ items: Category[] }>("/categories", {
+      ...options,
+      query: { ...options.query, ...(archived ? { archived: 1 } : {}) },
+    }),
 
   get: (id: string, options?: RequestOptions) =>
     api.get<Category>(`/categories/${id}`, options),
@@ -29,4 +38,12 @@ export const categoriesRepo = {
       { into: intoCategoryId },
       options,
     ),
+
+  /** Archive (B8 Archive tab) — quiet and reversible, never destructive. */
+  archive: (id: string, options?: RequestOptions) =>
+    api.post<Category>(`/categories/${id}/archive`, undefined, options),
+
+  /** Restore an archived category to the active registry. */
+  unarchive: (id: string, options?: RequestOptions) =>
+    api.post<Category>(`/categories/${id}/unarchive`, undefined, options),
 };

--- a/web/src/models/repositories/index.ts
+++ b/web/src/models/repositories/index.ts
@@ -7,6 +7,7 @@ export {
 export {
   categoriesRepo,
   type CategoryCreate,
+  type CategoryListOptions,
   type CategoryUpdate,
 } from "./categories";
 export { importsRepo, type ImportJobDetail } from "./imports";


### PR DESCRIPTION
Ships the deferred Archive-tab backlog item (user greenlit 2026-07-21). Design ratified on canvas first, then code, docs, and tests in one pass.

## Design decisions (ratified 2026-07-21)

- **Where the archive lives.** The only canvas/doc trace of the deferred proposal was the stale `Statements / Ratios / Trends / Archive` tab row on the B6 empty/loading frames — but B6's two-page IA is adjudicated parity, and the concrete need (reversible retirement of registry entries, the soft path next to Delete→merge) belongs to the category registry. The archive ships on **B8 `/categories`**; B6 keeps its two-page IA with no hub tab row. `docs/pages.md` B6 marker flipped `[Proposed — deferred]` → `[Ratified 2026-07-21]`.
- **Route-backed tabs, not in-view state.** `Active` (`/dashboard/categories`) | `Archive` (`/dashboard/categories/archive`) per the RouteTabs canon — deep-linkable, back/forward-safe, mirrors the settings routed-tabs precedent. `RouteTabs` now resolves the **most specific** matching href (the bare Active route used to capture its child route); regression-locked in `RouteTabs.test.tsx`. The Categories nav entry gains `nested: true` so the sub-route keeps it highlighted (same ratified pattern as settings).
- **Danger ladder.** Archive/unarchive are **quiet** row actions — reversible, no confirm, never styled danger. Delete stays the danger affordance with its confirm + `category_in_use` merge pivot.
- **Contract.** `Category.archived_at` (ISO, null = active). `GET /categories` serves the active registry only, so pickers, merge targets, and recategorize menus never see archived rows; `?archived=1` lists the archive. `POST /categories/{id}/archive` / `.../unarchive` are idempotent; merge refuses an archived target (`422 merge_target_archived`). Documented in `docs/api.md` §2.
- **Dates.** Archive rows read `Archived d MMM yyyy · N transactions this year` — absolute, per the adjudicated finance date idiom.

## Canvas (Figma `P2lGfKFLJPS9k9kTKlii1n`, Dashboard page)

- `B8 — Categories` (190:2836): routed tab row added (Tabs instance `506:2`, Active selected); row actions now `Edit · Merge · Archive` + danger Delete.
- **`B8b — Categories (Archive) [Ratified 2026-07-21]`** (`506:11879`, at x=1520): Archive tab active, single "Archived categories" card — `Conferences & travel` / `Print & stationery` with archived-date meta and quiet Unarchive (matches the seed narrative verbatim).
- Ratification note `507:12022`; screen index row `507:12023`. The stale B6/B6b empty/loading tab rows were left for the audit lane (already ledgered there).

## Code

- Model/repo: `models/category.ts`, `models/repositories/categories.ts` (`list({archived})`, `archive`, `unarchive`).
- Mock: `api/mock/categories/route.ts` (archived filter), new `[id]/archive` + `[id]/unarchive` handlers, merge guard, two seeded archived categories (Cuesoft org).
- Controller: `use-categories.ts` — one controller, `{ archived }` option; archive/unarchive drop the row from the current tab's list.
- Views: `categories/tabs.ts`, `CategoriesView.tsx` (RouteTabs + quiet Archive action), new `categories/archive/` page + `CategoriesArchiveView.tsx` (empty/loading/error states per the screen-state rule).

## Evidence

- Unit: `routes-categories.test.ts` (5), `use-categories.test.ts` (5), `CategoriesArchiveView.test.tsx` (5), RouteTabs nested-href case — full vitest **91 files / 468 tests green**.
- e2e: `categories-archive.spec.ts` — archive → appears under Archive → unarchive returns it → fixture cleanup; deep-link keeps tab + nav state. Mobile sweep gains `/dashboard/categories/archive`; the 768 sweep caught the four-action row cluster pushing the md column wide — the cluster now wraps (`min-w-0 flex-wrap`).
- Gates (final pass): prettier ✓ · eslint ✓ · check:boundaries ✓ (335 files) · typecheck ✓ · vitest **91 files / 468 tests** ✓ · next build ✓ (routes `/dashboard/categories/archive`, `/api/mock/categories/[id]/(un)archive` present) · **full Playwright 69/69** on PW_PORT=4411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
