### PR TITLE
fix(web): danger ladder lands in code — quiet-danger Button kind (ledger closeout)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -256,7 +256,7 @@ never on screens.
 
 | Component | Variants × states |
 | --- | --- |
-| Button | primary (accent) / quiet / destructive / danger-armed (countdown) · md/sm · default/pressed/disabled/loading · theme ×2 |
+| Button | primary (accent) / quiet / quiet-danger (danger text on quiet chrome — row-level destructive per the danger-affordance ladder) / destructive (filled — armed/confirm surfaces only) / danger-armed (countdown) · md/sm · default/pressed/disabled/loading · theme ×2 |
 | Input | type: text / search · state: default / focus / filled / disabled / error |
 | MoneyCell | direction: income / expense / zero · size: table / stat |
 | CategoryChip | confirmed / AI-suggested (✨) / editing (combobox open) |

--- a/web/src/app/dashboard/accounts/AccountsView.tsx
+++ b/web/src/app/dashboard/accounts/AccountsView.tsx
@@ -292,8 +292,11 @@ export const AccountsView: React.FC = () => {
                           {link.status === "paused" ? "Resume" : "Pause"}
                         </Button>
                       ) : null}
+                      {/* Danger ladder: row-level destructive = quiet
+                          danger text; the confirm modal keeps the filled
+                          Unlink (B4 frame + SKILL.md, ratified 2026-07-20). */}
                       <Button
-                        kind="destructive"
+                        kind="quiet-danger"
                         size="sm"
                         onClick={() => setUnlinkTarget(link)}
                       >

--- a/web/src/app/dashboard/transactions/TransactionsView.tsx
+++ b/web/src/app/dashboard/transactions/TransactionsView.tsx
@@ -892,8 +892,11 @@ export const TransactionsView: React.FC = () => {
         footer={
           <div className="flex items-center justify-between gap-2">
             {inspector.kind === "record" && activeTxn ? (
+              // Danger ladder: the editor-footer Delete is the master's
+              // "Button (quiet-danger)" — danger text on quiet chrome,
+              // never a filled block (SKILL.md, ratified 2026-07-20).
               <Button
-                kind="destructive"
+                kind="quiet-danger"
                 size="sm"
                 onClick={() => {
                   void txns.remove(activeTxn.id).then(() => {

--- a/web/src/components/ui/Button.test.tsx
+++ b/web/src/components/ui/Button.test.tsx
@@ -14,6 +14,12 @@ describe("Button (design.md §8.2)", () => {
     expect(screen.getByRole("button")).not.toHaveClass("border-border");
     rerender(<Button kind="destructive">Delete</Button>);
     expect(screen.getByRole("button")).toHaveClass("bg-expense");
+    // Danger ladder (SKILL.md 2026-07-20): quiet-danger = danger TEXT on
+    // quiet chrome — row-level destructive actions never render filled.
+    rerender(<Button kind="quiet-danger">Unlink</Button>);
+    expect(screen.getByRole("button")).toHaveClass("bg-transparent");
+    expect(screen.getByRole("button")).toHaveClass("text-expense");
+    expect(screen.getByRole("button")).not.toHaveClass("bg-expense");
   });
 
   it("supports md/sm sizes (Figma: 36px / 28px)", () => {

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,16 +1,21 @@
 "use client";
 
 /**
- * Button — design.md §8.2: kind primary (accent) / quiet / destructive /
- * danger-armed (MI-15 countdown) · md/sm · default/pressed/disabled/
- * loading. Primary/destructive labels bind to on-accent.
+ * Button — design.md §8.2: kind primary (accent) / quiet / quiet-danger /
+ * destructive / danger-armed (MI-15 countdown) · md/sm · default/pressed/
+ * disabled/loading. Primary/destructive labels bind to on-accent.
+ * Danger-affordance ladder (SKILL.md, ratified 2026-07-20): row-level
+ * destructive actions use quiet-danger (danger TEXT on quiet chrome —
+ * Figma "Button (quiet-danger)"); filled destructive is reserved for
+ * armed/confirm surfaces.
  */
 
 import React, { useEffect, useState } from "react";
 import { TriangleAlert } from "lucide-react";
 import { cn } from "@/lib/cn";
 
-export type ButtonKind = "primary" | "quiet" | "destructive" | "danger-armed";
+export type ButtonKind =
+  "primary" | "quiet" | "quiet-danger" | "destructive" | "danger-armed";
 export type ButtonSize = "md" | "sm";
 
 export interface ButtonProps extends Omit<
@@ -30,6 +35,10 @@ export interface ButtonProps extends Omit<
 const KIND_CLASSES: Record<ButtonKind, string> = {
   primary: "bg-accent text-on-accent hover:opacity-90 active:opacity-80",
   quiet: "bg-transparent text-text hover:bg-bg-elev active:bg-bg-elev",
+  // Quiet chrome, danger text — the ladder's row-level destructive
+  // affordance (canvas: empty fills + expense-bound label).
+  "quiet-danger":
+    "bg-transparent text-expense hover:bg-bg-elev active:bg-bg-elev",
   destructive: "bg-expense text-on-accent hover:opacity-90 active:opacity-80",
   "danger-armed": "bg-expense text-on-accent",
 };


### PR DESCRIPTION
## What

Closes the code side of the audit-ledger **"Danger-button usage"** parity row (SKILL.md danger-affordance ladder, ratified 2026-07-20): row-level destructive actions render as quiet danger text links; filled danger buttons are reserved for armed/confirm surfaces.

- `Button` gains `kind="quiet-danger"` — danger text on quiet chrome (`bg-transparent text-expense`, `bg-elev` hover), mirroring the canvas "Button (quiet-danger)" instances (empty fills + expense-bound label).
- **B4 accounts card** action-row `Unlink` → quiet-danger (the confirm modal keeps the filled Unlink — that's the ladder's armed/confirm tier).
- **B2 record-inspector footer** `Delete` → quiet-danger (matches the rebuilt Inspector master 67:264).
- `docs/design.md` §8.2 Button row documents the kind axis as built; SKILL.md ladder entry now names this as the reference implementation.
- Button unit test covers the new kind (transparent + text-expense, never bg-expense).

**Deliberately NOT included:** `CategoriesView.tsx:107` row Delete has the same violation, but categories code is frozen under the concurrent `feat/categories-archive-tab` lane — deferred with a coordination note (one-line swap post-merge).

## Ledger closeout context

This PR is the only code fix left from the expendit Figma↔code convergence ledger closeout — verification found the 2026-07-20/21 waves (#229–#244 + canvas passes) already closed the mission's headline rows (Mobile page 39:2 now has 7 exemplar frames; MarketingNav mobile variants exist; LinkAccountCard master rebuilt with the trust-path switch; B9c grace-pending frame exists; settings four-tab IA restaged on canvas). Remaining Figma-side items are pre-adjudicated and queued (14 ops) in the audit ledger — the Figma MCP disconnected mid-pass (host crash), so no canvas write was issued.

## Gates

- `npm test` — 88 files / 452 passed
- `npm run lint` + `npm run typecheck` — clean
- `TEST_MODE=1 npm run build` — clean
- `PW_PORT=4413 npm run test:e2e` — 67 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)