### PR TITLE
chore(web): retire dead NEXT_PUBLIC_BASE_URL plumbing (fleet decision)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,6 @@
 JWT_SECRET=dev-secret-change-me
 FRONTEND_URL=http://localhost:3000
 
-# Web (browser-exposed, inlined at build time)
-NEXT_PUBLIC_BASE_URL=http://localhost:8080
-
 # Optional integrations (features degrade gracefully if unset)
 GOOGLE_CLIENT_ID=
 GEMINI_API_KEY=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,8 +56,6 @@ services:
       # web/Dockerfile.dockerignore.
       context: .
       dockerfile: web/Dockerfile
-      args:
-        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:8080}
     ports:
       - "3000:3000"
     depends_on:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,12 +27,6 @@ commit real `.env` files — `make up` reads the root `.env`.
 | `REDIS_URL` | Redis connection string (optional) |
 | `FRONTEND_URL` | Web app URL for CORS/redirects |
 
-### Web (`web`)
-
-| Variable | Description |
-| -------- | ----------- |
-| `NEXT_PUBLIC_BASE_URL` | Base URL of the API (e.g. `http://localhost:8080`) |
-
 ## Quick start (Docker)
 
 ```bash

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -571,7 +571,7 @@ on it:
    (incl. the `X-Org-Id` context header), so repositories are identical in
    both modes except for the base URL.
 
-Unset (or `0`) → real `FirebaseAuthProvider` + `NEXT_PUBLIC_BASE_URL`
+Unset (or `0`) → real `FirebaseAuthProvider` + the real `/api/v1` base
 (api/common). TEST_MODE is how Playwright runs in CI and how the app is
 developed before the v1 backend consolidation lands.
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,6 +1,5 @@
 # Native-run config for web (compose users: use the root .env instead).
 # NEXT_PUBLIC_* are inlined at build time.
-NEXT_PUBLIC_BASE_URL=http://localhost:8080
 # TEST_MODE (web standard): 1 = Google button goes straight to /dashboard
 # (no Firebase) and the API client targets the in-app mock server.
 NEXT_PUBLIC_TEST_MODE=

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -17,9 +17,6 @@ WORKDIR /app/web
 COPY --from=deps /app/web/node_modules ./node_modules
 COPY web/ ./
 COPY docs/api/openapi.yaml /app/docs/api/openapi.yaml
-# NEXT_PUBLIC_* are inlined at build time.
-ARG NEXT_PUBLIC_BASE_URL
-ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
 RUN npm run build
 
 # ---- runner ----


### PR DESCRIPTION
## Summary

Fleet-level dead-env cleanup, item 2 (naming drift), converged from the per-repo sweeps (#247, apparule#122, upstat#190). #247's commit a094c33 removed `NEXT_PUBLIC_GOOGLE_CLIENT_ID` and explicitly deferred `NEXT_PUBLIC_BASE_URL` "pending a fleet-level decision" — this is that decision landing: the var is plumbed but unread, so the plumbing goes.

## Evidence — no reader exists

- The API base is `web/src/config/env.ts` `apiBase()` → `"/api/v1"` (or `"/api/mock"` in TEST_MODE) — a relative path with **no env input**.
- `git grep "process.env.NEXT_PUBLIC" web/` → only `NEXT_PUBLIC_TEST_MODE` (env.ts, dev gallery) and `NEXT_PUBLIC_UPSTAT_EVENTS_URL` (use-analytics).
- `web/next.config.ts` has no rewrites/env usage; CI workflows only set `NEXT_PUBLIC_TEST_MODE`.

## Removals (per row)

| File | Row removed |
| --- | --- |
| `web/Dockerfile` | `ARG NEXT_PUBLIC_BASE_URL` + `ENV NEXT_PUBLIC_BASE_URL=...` + now-orphaned `# NEXT_PUBLIC_* are inlined at build time.` comment |
| `docker-compose.yml` | web-service `args:` block (BASE_URL was its only arg) |
| `.env.example` | `# Web (browser-exposed, inlined at build time)` section + `NEXT_PUBLIC_BASE_URL=` row |
| `web/.env.example` | `NEXT_PUBLIC_BASE_URL=` row (TEST_MODE rows stay) |
| `docs/setup.md` | the `### Web (web)` env table (BASE_URL was its only row) |

## Docs fix (describe the current system)

`docs/web-implementation.md` §5: "real `FirebaseAuthProvider` + `NEXT_PUBLIC_BASE_URL` (api/common)" → "real `FirebaseAuthProvider` + the real `/api/v1` base (api/common)" — names the actual mechanism instead of the unread var.

## Fleet parity

- upstat: same removal landing in its own PR (its reader is `NEXT_PUBLIC_API_BASE`; docs there get renamed to the real var).
- apparule: **keeps** `NEXT_PUBLIC_BASE_URL` — its `web/src/config/env.ts` genuinely reads it.

## Gates

- `npm run lint` (prettier check + eslint + boundaries) — clean
- `npm run typecheck` — clean
- `npm test` — 91 files / 468 tests passed
- `npm run build` (next build) — success
- `docker compose config -q` — OK

No runtime behavior changes — deletions of unread configuration plus a one-line docs correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)