### PR TITLE
fix(web): B8 row Delete rides quiet-danger (deferred ladder one-liner)

### DIFF
--- a/web/src/app/dashboard/categories/CategoriesView.tsx
+++ b/web/src/app/dashboard/categories/CategoriesView.tsx
@@ -121,8 +121,10 @@ const CategoryList: React.FC<CategoryListProps> = ({
               >
                 Archive
               </Button>
+              {/* Row-level destructive = quiet-danger (ladder); the
+                  filled kind stays on the confirm modal's Delete. */}
               <Button
-                kind="destructive"
+                kind="quiet-danger"
                 size="sm"
                 onClick={() => onDelete(category)}
               >


### PR DESCRIPTION
Closes the documented deferral from #246: the categories row-level Delete moves onto `kind="quiet-danger"` per the ratified ladder (SKILL #104); the confirm modal's filled Delete stays. Targeted tests green; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)