### PR TITLE
fix(web): a11y blockers — named checkboxes (axe critical ×60 → 0) + overlay focus restore

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -468,6 +468,29 @@ Unit: `routes-categories.test.ts`, `use-categories.test.ts`,
 delete-cleanup, plus the deep-link) and the 390 sweep gains the archive
 route.
 
+**A11y blockers as-built (2026-07-21 audit).** Two component contracts
+hardened at the shared layer:
+
+- **Checkbox requires an accessible name.** `CheckboxProps` is a union:
+  either a visible `label` or an `aria-label` — a name-less usage is a
+  compile error (the audit found the row-select checkboxes shipped as
+  unnamed `button[role="checkbox"]`, axe `button-name` critical ×50 on
+  transactions, ×5 on overview and the home demo). `TxnTableRow` names
+  each row select "Select transaction {description}, {d MMM}";
+  `TableHeader`'s `selectAll` slot takes a required `label` ("Select all
+  transactions"). Unit: `Checkbox.test.tsx` (aria-label naming +
+  `@ts-expect-error` name-less lock), `TableHeader.test.tsx`; e2e:
+  `axe-transactions.spec.ts` (@axe-core/playwright) gates the ledger at
+  zero critical violations and zero `button-name`, ever.
+- **Overlays return focus to their opener.** `Modal` and `CommandPalette`
+  own the focus contract (fleet P4): the opener is captured on open
+  (before autofocus moves into the overlay) and refocused on close —
+  Radix's default targets a null trigger on controlled dialogs and the
+  palette opens programmatically via ⌘K, so both previously dropped focus
+  on `<body>`. `Modal` is also announced `aria-modal`. e2e:
+  `focus-restore.spec.ts` (open → Tab inside → Escape → trigger
+  refocused) for the palette and the merge modal.
+
 ## 3. Token mapping — design.md §2 → `web/src/design/tokens.css`
 
 One custom property per Figma variable in the `expendit/tokens` collection

--- a/web/e2e/axe-transactions.spec.ts
+++ b/web/e2e/axe-transactions.spec.ts
@@ -1,0 +1,41 @@
+// axe gate for the transactions ledger (2026-07-21 a11y audit): the
+// row-select checkboxes shipped with NO accessible name — axe
+// `button-name` critical ×50 on this surface (×5 on overview and the
+// marketing home demo, which render the same TxnTableRow/TableHeader).
+// The gate pins the blocker class at zero: no critical violations, and
+// specifically no unnamed buttons/checkboxes, ever again. (Serious-level
+// light-theme color-contrast is token work tracked separately — not
+// gated here.)
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+const signIn = async (page: Page): Promise<void> => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: "Continue with Google" }).click();
+  await page.waitForURL("**/dashboard", { timeout: 15_000 });
+};
+
+test("transactions ledger has zero critical axe violations (button-name lock)", async ({
+  page,
+}) => {
+  await signIn(page);
+  await page.goto("/dashboard/transactions");
+  // Ledger rows rendered — the surface the ×50 finding came from.
+  await expect(
+    page.getByRole("checkbox", { name: /^Select transaction / }).first(),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("checkbox", { name: "Select all transactions" }),
+  ).toBeVisible();
+
+  const results = await new AxeBuilder({ page }).analyze();
+  const critical = results.violations.filter(
+    (violation) => violation.impact === "critical",
+  );
+  expect(
+    critical.map((violation) => `${violation.id} ×${violation.nodes.length}`),
+  ).toEqual([]);
+  expect(
+    results.violations.find((violation) => violation.id === "button-name"),
+  ).toBeUndefined();
+});

--- a/web/e2e/focus-restore.spec.ts
+++ b/web/e2e/focus-restore.spec.ts
@@ -1,0 +1,53 @@
+// Overlay focus-restore canon (2026-07-21 a11y audit, fleet finding P4):
+// closing any Modal/command-palette must return focus to the element that
+// opened it. The palette opens programmatically (⌘K) and modals are
+// controlled Radix dialogs without a Radix Trigger, so before the fix
+// Escape dropped focus on <body>. Probe shape: open → move focus inside →
+// Escape → overlay closed AND focus is back on the trigger.
+import { expect, test, type Page } from "@playwright/test";
+
+const signIn = async (page: Page): Promise<void> => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: "Continue with Google" }).click();
+  await page.waitForURL("**/dashboard", { timeout: 15_000 });
+};
+
+test("command palette returns focus to the pre-open element on Escape", async ({
+  page,
+}) => {
+  await signIn(page);
+  const anchor = page
+    .getByRole("navigation", { name: "Primary" })
+    .getByRole("link", { name: /^Transactions/ });
+  await anchor.focus();
+  await expect(anchor).toBeFocused();
+
+  await page.keyboard.press("ControlOrMeta+k");
+  const palette = page.getByRole("dialog", { name: "Command palette" });
+  await expect(palette).toBeVisible();
+
+  // Move focus off the search input and onto an option before dismissing.
+  await page.keyboard.press("Tab");
+  await page.keyboard.press("Escape");
+
+  await expect(palette).toBeHidden();
+  await expect(anchor).toBeFocused();
+});
+
+test("merge modal returns focus to its trigger on Escape", async ({ page }) => {
+  await signIn(page);
+  await page.goto("/dashboard/categories");
+  const trigger = page.getByRole("button", { name: "Merge" }).first();
+  await trigger.click();
+
+  const dialog = page.getByRole("dialog", { name: /^Merge/ });
+  await expect(dialog).toBeVisible();
+  // Announced as modal (fleet parity with the apparule Sheet fix).
+  await expect(dialog).toHaveAttribute("aria-modal", "true");
+
+  await page.keyboard.press("Tab");
+  await page.keyboard.press("Escape");
+
+  await expect(dialog).toBeHidden();
+  await expect(trigger).toBeFocused();
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,6 +24,7 @@
         "react-dom": "^19"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.4.1",
@@ -187,6 +188,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",

--- a/web/package.json
+++ b/web/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^19"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",

--- a/web/src/app/dashboard/transactions/TransactionsView.tsx
+++ b/web/src/app/dashboard/transactions/TransactionsView.tsx
@@ -692,6 +692,7 @@ export const TransactionsView: React.FC = () => {
                 setSort(direction === "none" ? null : { columnId, direction })
               }
               selectAll={{
+                label: "Select all transactions",
                 checked: allSelected
                   ? true
                   : someSelected

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -1380,6 +1380,7 @@ export const ComponentGallery: React.FC = () => {
                 ]}
                 sort={{ columnId: "amt", direction: "asc" }}
                 selectAll={{
+                  label: "Select all rows",
                   checked: "indeterminate",
                   onCheckedChange: () => undefined,
                 }}

--- a/web/src/components/ui/Checkbox.test.tsx
+++ b/web/src/components/ui/Checkbox.test.tsx
@@ -30,9 +30,38 @@ describe("Checkbox (design.md §8.2b)", () => {
   it("disabled blocks interaction", async () => {
     const onCheckedChange = vi.fn();
     render(
-      <Checkbox checked={false} onCheckedChange={onCheckedChange} disabled />,
+      <Checkbox
+        checked={false}
+        onCheckedChange={onCheckedChange}
+        disabled
+        aria-label="Disabled box"
+      />,
     );
     await userEvent.click(screen.getByRole("checkbox")).catch(() => undefined);
     expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+
+  // 2026-07-21 a11y audit lock: the API cannot produce an unnamed control.
+  // Label-less checkboxes (table row selects) take aria-label as their
+  // accessible name; the CheckboxProps union makes one of label/aria-label
+  // compile-mandatory.
+  it("aria-label names a label-less checkbox", () => {
+    render(
+      <Checkbox
+        checked={false}
+        aria-label="Select transaction Jumia order, 12 Jan"
+      />,
+    );
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Select transaction Jumia order, 12 Jan",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("rejects a name-less usage at the type level", () => {
+    // @ts-expect-error — accessible name (label or aria-label) is required.
+    const nameless = <Checkbox checked={false} />;
+    expect(nameless).toBeTruthy();
   });
 });

--- a/web/src/components/ui/Checkbox.tsx
+++ b/web/src/components/ui/Checkbox.tsx
@@ -11,13 +11,21 @@ import * as RadixCheckbox from "@radix-ui/react-checkbox";
 import { Check, Minus } from "lucide-react";
 import { cn } from "@/lib/cn";
 
-export interface CheckboxProps {
+/**
+ * Every checkbox must carry an accessible name (2026-07-21 a11y audit:
+ * label-less row selects shipped as unnamed `button[role="checkbox"]`,
+ * axe `button-name` critical). Either render a visible `label` or pass
+ * `aria-label` — the union makes a name compile-mandatory.
+ */
+export type CheckboxProps = {
   checked: boolean | "indeterminate";
   onCheckedChange?: (checked: boolean | "indeterminate") => void;
-  label?: string;
   disabled?: boolean;
   id?: string;
-}
+} & (
+  | { label: string; "aria-label"?: string }
+  | { label?: undefined; "aria-label": string }
+);
 
 export const Checkbox: React.FC<CheckboxProps> = ({
   checked,
@@ -25,6 +33,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   label,
   disabled = false,
   id,
+  "aria-label": ariaLabel,
 }) => (
   <label
     className={cn(
@@ -34,6 +43,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   >
     <RadixCheckbox.Root
       id={id}
+      aria-label={ariaLabel}
       checked={checked}
       onCheckedChange={onCheckedChange}
       disabled={disabled}

--- a/web/src/components/ui/CommandPalette.tsx
+++ b/web/src/components/ui/CommandPalette.tsx
@@ -61,6 +61,12 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const listRef = useRef<HTMLUListElement>(null);
+  // Focus restore (2026-07-21 a11y audit, fleet P4): the palette opens
+  // programmatically (⌘K), so closing must hand focus back to whatever
+  // element had it before the palette autofocused its input — Escape
+  // previously dropped focus on <body>.
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // MI-1: global ⌘K / Ctrl+K toggle.
   useEffect(() => {
@@ -84,6 +90,24 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
       setActiveIndex(0);
     }
   }
+
+  // Opening snapshots the opener, then moves focus into the search input
+  // (the input carries no autoFocus so document.activeElement is still the
+  // trigger when this runs); closing sends focus back to the opener after
+  // the palette's DOM is gone.
+  useEffect(() => {
+    if (open) {
+      returnFocusRef.current =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+      inputRef.current?.focus();
+    } else {
+      const opener = returnFocusRef.current;
+      returnFocusRef.current = null;
+      if (opener?.isConnected) opener.focus();
+    }
+  }, [open]);
 
   const filtered = useMemo(() => {
     const matched = query
@@ -137,7 +161,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
         <div className="flex items-center gap-2 border-b border-border px-3">
           <Search aria-hidden className="h-4 w-4 text-text-2" />
           <input
-            autoFocus
+            ref={inputRef}
             role="combobox"
             aria-expanded="true"
             aria-controls="command-palette-list"

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -7,7 +7,7 @@
  * supplies focus trap + ESC semantics (reuse policy).
  */
 
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import { cn } from "@/lib/cn";
@@ -54,6 +54,12 @@ export const Modal: React.FC<ModalProps> = ({
 }) => {
   const [typed, setTyped] = useState("");
   const confirmReady = !confirmPhrase || typed === confirmPhrase;
+  // Focus restore (2026-07-21 a11y audit, fleet P4): modals are controlled
+  // dialogs with no Radix Trigger, so Radix's default close autofocus
+  // targets a null triggerRef and focus falls to <body>. Capture the opener
+  // ourselves (onOpenAutoFocus fires before Radix moves focus in) and
+  // return focus on close.
+  const returnFocusRef = useRef<HTMLElement | null>(null);
 
   return (
     <Dialog.Root
@@ -67,6 +73,20 @@ export const Modal: React.FC<ModalProps> = ({
         <Dialog.Overlay className="fixed inset-0 z-overlay bg-bg-editorial/60 animate-fade-in motion-reduce:animate-none" />
         <Dialog.Content
           aria-describedby={undefined}
+          aria-modal="true"
+          onOpenAutoFocus={() => {
+            returnFocusRef.current =
+              document.activeElement instanceof HTMLElement
+                ? document.activeElement
+                : null;
+          }}
+          onCloseAutoFocus={(event) => {
+            // preventDefault also skips Radix's own (null-trigger) handler.
+            event.preventDefault();
+            const opener = returnFocusRef.current;
+            returnFocusRef.current = null;
+            if (opener?.isConnected) opener.focus();
+          }}
           // App floating layers (portaled Select menus) live under
           // <body>, outside the Radix content subtree — without this
           // guard a click inside one dismisses the whole dialog

--- a/web/src/components/ui/TableHeader.test.tsx
+++ b/web/src/components/ui/TableHeader.test.tsx
@@ -65,15 +65,21 @@ describe("TableHeader (design.md §8.2b)", () => {
     expect(screen.getByRole("row")).toHaveClass("h-[44px]");
   });
 
-  it("select-all slot wires the checkbox", async () => {
+  it("select-all slot wires the checkbox and names it (a11y audit)", async () => {
     const onCheckedChange = vi.fn();
     render(
       <TableHeader
         columns={columns}
-        selectAll={{ checked: "indeterminate", onCheckedChange }}
+        selectAll={{
+          checked: "indeterminate",
+          onCheckedChange,
+          label: "Select all transactions",
+        }}
       />,
     );
-    const box = screen.getByRole("checkbox");
+    const box = screen.getByRole("checkbox", {
+      name: "Select all transactions",
+    });
     expect(box).toHaveAttribute("aria-checked", "mixed");
     await userEvent.click(box);
     expect(onCheckedChange).toHaveBeenCalled();

--- a/web/src/components/ui/TableHeader.tsx
+++ b/web/src/components/ui/TableHeader.tsx
@@ -28,10 +28,12 @@ export interface TableHeaderProps {
   density?: "compact" | "comfortable";
   sort?: { columnId: string; direction: Exclude<SortDirection, "none"> } | null;
   onSortChange?: (columnId: string, direction: SortDirection) => void;
-  /** Select-all slot. */
+  /** Select-all slot. `label` is its accessible name (a11y audit: the
+   * select-all checkbox shipped unnamed — axe button-name critical). */
   selectAll?: {
     checked: boolean | "indeterminate";
     onCheckedChange: (checked: boolean | "indeterminate") => void;
+    label: string;
   };
   sticky?: boolean;
   className?: string;
@@ -65,6 +67,7 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
       {selectAll ? (
         <th scope="col" className="flex shrink-0 items-center">
           <Checkbox
+            aria-label={selectAll.label}
             checked={selectAll.checked}
             onCheckedChange={selectAll.onCheckedChange}
           />

--- a/web/src/components/ui/TxnTableRow.tsx
+++ b/web/src/components/ui/TxnTableRow.tsx
@@ -109,6 +109,12 @@ export const TxnTableRow: React.FC<TxnTableRowProps> = ({
     >
       <td className="flex shrink-0 items-center">
         <Checkbox
+          // Per-row accessible name (2026-07-21 a11y audit: unnamed row
+          // selects were an axe button-name critical ×50).
+          aria-label={`Select transaction ${txn.description}, ${formatIso(
+            txn.txn_date,
+            "d MMM",
+          )}`}
           checked={selected}
           onCheckedChange={
             onSelectedChange


### PR DESCRIPTION
## What

Fleet a11y-blocker wave (adjudicated 2026-07-21 audit), expendit slice — the fleet's only axe **critical** class (P6) plus the focus-restore canon (P4).

| Fix | Where | Before (audit) | After |
|---|---|---|---|
| Checkbox API requires an accessible name | `ui/Checkbox.tsx` — `CheckboxProps` union: visible `label` or `aria-label`, one compile-mandatory | axe `button-name` **critical ×50** (transactions) **×5** (overview) **×5** (home demo) — the API couldn't even receive a name | **0 critical** — axe-gated |
| Per-row names at every caller | `ui/TxnTableRow.tsx` ("Select transaction {description}, {d MMM}"), `ui/TableHeader.tsx` `selectAll.label` (required — "Select all transactions"), gallery | unnamed `button[role="checkbox"]` | meaningful per-row names on every surface (transactions/overview/home demo/import detail render the same shared components) |
| ⌘K palette restores focus on close | `ui/CommandPalette.tsx` | palette-probe: Escape → `active: BODY` | opener snapshotted on open (autoFocus moved into a post-snapshot effect), refocused on close |
| Modal restores focus + aria-modal | `ui/Modal.tsx` | same null-trigger Radix construction as apparule's Sheet | opener captured in `onOpenAutoFocus`, restored in `onCloseAutoFocus`; `aria-modal="true"` |

## axe delta (transactions surface)

- Before: `button-name` critical ×50 (plus ×5 overview, ×5 home — same components).
- After: `axe-transactions.spec.ts` (@axe-core/playwright, new devDependency) gates the ledger at **zero critical violations and zero `button-name`** — green. Serious light-theme color-contrast is token work tracked separately (P2), deliberately not gated here.

## Locks (all verified red against the unfixed components)

- Unit: `Checkbox.test.tsx` — aria-label names a label-less checkbox; `@ts-expect-error` pins that a name-less usage no longer compiles. `TableHeader.test.tsx` — named select-all.
- e2e: `axe-transactions.spec.ts` (axe gate) · `focus-restore.spec.ts` — org P4 probe (open → Tab inside → Escape closes → focus back on trigger) for the ⌘K palette and the categories merge modal.

## Gates (all green)

prettier ✓ · eslint ✓ · boundaries ✓ (335 files) · typecheck ✓ (union type surfaced every caller) · vitest 470/470 ✓ · next build ✓ · Playwright **72/72** ✓ (PW_PORT=4427)

Docs: `docs/web-implementation.md` — a11y-blockers as-built note (Checkbox name contract + overlay focus contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)