### PR TITLE
fix(web): contrast-token canon — AA `-text` variants for the tinted-chip recipe

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -38,6 +38,8 @@
 | `expense` | #C6373C | #FF6B6E | outflows, negative deltas |
 | `warn` | #B26A00 | #FFB020 | anomalies, tax deadlines |
 | `info` | #2456D6 | #7DA2FF | AI/insight chips |
+| `accent-text` | #AE4501 | #F46A1F | AA text variant — readable accent text (links, active nav, chip labels, toast/banner actions) binds this; fills/borders/icons/focus rings keep `accent`. Light value darkens `accent` in OKLCH (L only) until ≥4.5:1 on the tinted-chip recipe (`text-X` on `bg-X/10–20`) and both surfaces; the dark base already clears AA, so dark aliases it |
+| `warn-text/income-text/expense-text` | #804C05 / #077542 / #BC2D34 | #FFB020 / #34C77B / #FF6B6E | AA text variants for warn/income/expense as readable text (tinted chips, deadline copy, statement flags); same OKLCH derivation, dark aliases the base. `info` needs no variant (base clears its /12 chip) |
 | Afrocentric pattern | 4% opacity line motif | — | dark editorial sections only |
 
 ### Type

--- a/web/e2e/contrast-tokens.spec.ts
+++ b/web/e2e/contrast-tokens.spec.ts
@@ -1,0 +1,259 @@
+// Contrast-token lock (design.md §2 AA text variants) — recomputes the
+// 2026-07-21 audit's failing pairs from the SERVED CSS (custom-property
+// values off the live document, both themes) and asserts WCAG AA. The
+// tinted-chip recipe (`text-X` on `bg-X/10–20`) plus accent/warn as plain
+// text must stay ≥4.5:1; a scoped axe pass plus a rendered-chip sweep lock
+// the composed result on the audited dashboard surfaces.
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+const AA = 4.5;
+
+// ---- WCAG 2.x math over sRGB --------------------------------------------
+type Rgb = { r: number; g: number; b: number };
+
+function hexToRgb(hex: string): Rgb {
+  const h = hex.trim().replace("#", "");
+  const v =
+    h.length === 3
+      ? h
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : h;
+  return {
+    r: parseInt(v.slice(0, 2), 16),
+    g: parseInt(v.slice(2, 4), 16),
+    b: parseInt(v.slice(4, 6), 16),
+  };
+}
+
+function luminance({ r, g, b }: Rgb): number {
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+  const [lo, hi] = [luminance(a), luminance(b)].sort((x, y) => x - y);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** `bg-X/nn` composited over an opaque base (what the browser paints). */
+function tint(hue: Rgb, alpha: number, base: Rgb): Rgb {
+  const mix = (f: number, g: number) => Math.round(alpha * f + (1 - alpha) * g);
+  return {
+    r: mix(hue.r, base.r),
+    g: mix(hue.g, base.g),
+    b: mix(hue.b, base.b),
+  };
+}
+
+// ---- served-CSS readers ---------------------------------------------------
+async function readTokens(
+  page: Page,
+  theme: "light" | "dark",
+  names: string[],
+): Promise<Record<string, Rgb>> {
+  const raw = await page.evaluate(
+    ({ t, ns }: { t: string; ns: string[] }) => {
+      document.documentElement.setAttribute("data-theme", t);
+      const cs = getComputedStyle(document.documentElement);
+      return Object.fromEntries(
+        ns.map((n) => [n, cs.getPropertyValue(n).trim()]),
+      );
+    },
+    { t: theme, ns: names },
+  );
+  const out: Record<string, Rgb> = {};
+  for (const [name, value] of Object.entries(raw)) {
+    // The dev server may serve minified hex (#fff) — accept both forms.
+    expect(value, `${name} is declared in the served CSS (${theme})`).toMatch(
+      /^#([0-9a-f]{3}|[0-9a-f]{6})$/i,
+    );
+    out[name] = hexToRgb(value);
+  }
+  return out;
+}
+
+const TOKENS = [
+  "--color-bg",
+  "--color-bg-elev",
+  "--color-text-2",
+  "--color-accent",
+  "--color-warn",
+  "--color-income",
+  "--color-expense",
+  "--color-info",
+  "--color-accent-text",
+  "--color-warn-text",
+  "--color-income-text",
+  "--color-expense-text",
+];
+
+test("§2 token pairs recomputed from served CSS clear WCAG AA in both themes", async ({
+  page,
+}) => {
+  await page.goto("/");
+  for (const theme of ["light", "dark"] as const) {
+    const t = await readTokens(page, theme, TOKENS);
+    const cases: Array<{ name: string; fg: Rgb; bg: Rgb }> = [];
+    const surfaces = ["--color-bg", "--color-bg-elev"] as const;
+
+    // Tinted-recipe pairs: the `-text` label on every alpha its hue ships
+    // with (Tag /12, AppNav-EditorialCard /10, Avatar /15, TaxCalendarRow
+    // /8–/20, StatementView /10), over both surfaces.
+    const recipes: Array<[string, string, number[]]> = [
+      ["--color-accent-text", "--color-accent", [0.1, 0.12, 0.15]],
+      ["--color-warn-text", "--color-warn", [0.08, 0.1, 0.12, 0.15, 0.2]],
+      ["--color-income-text", "--color-income", [0.1, 0.12]],
+      ["--color-expense-text", "--color-expense", [0.1, 0.12]],
+      ["--color-info", "--color-info", [0.12]], // base stays — locked
+    ];
+    for (const [fg, hue, alphas] of recipes) {
+      for (const alpha of alphas) {
+        for (const surface of surfaces) {
+          cases.push({
+            name: `${fg} on ${hue}/${alpha * 100} over ${surface}`,
+            fg: t[fg],
+            bg: tint(t[hue], alpha, t[surface]),
+          });
+        }
+      }
+    }
+
+    // TaxCalendarRow T-1 compound: chip warn/20 over the row's warn/12.
+    for (const surface of surfaces) {
+      cases.push({
+        name: `--color-warn-text on warn/20 over warn/12 over ${surface}`,
+        fg: t["--color-warn-text"],
+        bg: tint(
+          t["--color-warn"],
+          0.2,
+          tint(t["--color-warn"], 0.12, t[surface]),
+        ),
+      });
+    }
+
+    // Plain text on the page surfaces (links, deadline copy, neutral Tag).
+    for (const fg of [
+      "--color-accent-text",
+      "--color-warn-text",
+      "--color-income-text",
+      "--color-expense-text",
+      "--color-text-2",
+    ]) {
+      for (const surface of surfaces) {
+        cases.push({ name: `${fg} on ${surface}`, fg: t[fg], bg: t[surface] });
+      }
+    }
+
+    for (const c of cases) {
+      const ratio = contrast(c.fg, c.bg);
+      expect
+        .soft(ratio, `${theme}: ${c.name} ≥ ${AA} (got ${ratio.toFixed(2)})`)
+        .toBeGreaterThanOrEqual(AA);
+    }
+  }
+});
+
+// ---- axe: the fixed classes on the audited surfaces ------------------------
+const signIn = async (page: Page): Promise<void> => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: "Continue with Google" }).click();
+  await page.waitForURL("**/dashboard", { timeout: 15_000 });
+};
+
+test("axe color-contrast is clean for the -text classes on the audited surfaces (light)", async ({
+  page,
+}) => {
+  await signIn(page);
+  await page.goto("/dashboard/transactions");
+  await expect(page.locator(".text-accent-text").first()).toBeVisible();
+
+  const results = await new AxeBuilder({ page })
+    .include(".text-accent-text")
+    .include(".text-warn-text")
+    .include(".text-income-text")
+    .include(".text-expense-text")
+    .withRules(["color-contrast"])
+    .analyze();
+  expect(
+    results.violations.map(
+      (violation) => `${violation.id} ×${violation.nodes.length}`,
+    ),
+  ).toEqual([]);
+});
+
+// ---- rendered surface: overview delta pills + tags, light theme ------------
+test("overview tinted chips render ≥4.5:1 in light theme (served pages)", async ({
+  page,
+}) => {
+  await signIn(page);
+  await page.goto("/dashboard");
+  const chips = page.locator('[data-testid="stat-delta"], [data-tint]');
+  await chips.first().waitFor({ state: "visible", timeout: 15_000 });
+  const count = await chips.count();
+  expect(count, "overview renders tinted chips").toBeGreaterThan(0);
+
+  for (let i = 0; i < count; i++) {
+    const chip = chips.nth(i);
+    if (!(await chip.isVisible())) continue;
+    const result = await chip.evaluate((el) => {
+      type C = { r: number; g: number; b: number; a: number };
+      const parse = (s: string): C => {
+        const m = s.match(/rgba?\(([^)]+)\)/);
+        if (!m) return { r: 0, g: 0, b: 0, a: 0 };
+        const [r, g, b, a = "1"] = m[1].split(/[,/ ]+/).filter(Boolean);
+        return { r: Number(r), g: Number(g), b: Number(b), a: Number(a) };
+      };
+      const over = (top: C, base: C): C => ({
+        r: top.r * top.a + base.r * (1 - top.a),
+        g: top.g * top.a + base.g * (1 - top.a),
+        b: top.b * top.a + base.b * (1 - top.a),
+        a: 1,
+      });
+      const layers: C[] = [];
+      let node: Element | null = el;
+      let opaque = false;
+      while (node) {
+        const bg = parse(getComputedStyle(node).backgroundColor);
+        if (bg.a > 0) layers.push(bg);
+        if (bg.a >= 1) {
+          opaque = true;
+          break;
+        }
+        node = node.parentElement;
+      }
+      if (!opaque)
+        layers.push(parse(getComputedStyle(document.body).backgroundColor));
+      let backdrop = layers[layers.length - 1];
+      for (let j = layers.length - 2; j >= 0; j--) {
+        backdrop = over(layers[j], backdrop);
+      }
+      const fg = parse(getComputedStyle(el).color);
+      if (fg.a < 1) return null;
+      const lum = (c: C) => {
+        const lin = (v: number) => {
+          const s = v / 255;
+          return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+        };
+        return 0.2126 * lin(c.r) + 0.7152 * lin(c.g) + 0.0722 * lin(c.b);
+      };
+      const [lo, hi] = [lum(fg), lum(backdrop)].sort((x, y) => x - y);
+      return {
+        label: el.textContent?.slice(0, 24) ?? "",
+        ratio: (hi + 0.05) / (lo + 0.05),
+      };
+    });
+    if (result === null) continue;
+    expect
+      .soft(
+        result.ratio,
+        `chip "${result.label}" renders ≥ ${AA} (got ${result.ratio.toFixed(2)})`,
+      )
+      .toBeGreaterThanOrEqual(AA);
+  }
+});

--- a/web/src/app/dashboard/OverviewView.tsx
+++ b/web/src/app/dashboard/OverviewView.tsx
@@ -289,7 +289,7 @@ export const OverviewView: React.FC = () => {
             action={
               <Link
                 href="/dashboard/taxes/file"
-                className="text-[13px] font-medium text-accent hover:underline"
+                className="text-[13px] font-medium text-accent-text hover:underline"
               >
                 Prepare filing
               </Link>
@@ -549,7 +549,7 @@ export const OverviewView: React.FC = () => {
                 </ul>
                 <Link
                   href="/dashboard/transactions?anomalies=1"
-                  className="mt-3 inline-block text-[13px] font-medium text-accent hover:underline"
+                  className="mt-3 inline-block text-[13px] font-medium text-accent-text hover:underline"
                 >
                   Explain in ledger →
                 </Link>
@@ -565,7 +565,7 @@ export const OverviewView: React.FC = () => {
         action={
           <Link
             href="/dashboard/transactions"
-            className="text-[13px] font-medium text-accent hover:underline"
+            className="text-[13px] font-medium text-accent-text hover:underline"
           >
             View all →
           </Link>

--- a/web/src/app/dashboard/company/ratios/RatiosView.tsx
+++ b/web/src/app/dashboard/company/ratios/RatiosView.tsx
@@ -268,7 +268,7 @@ export const RatiosView: React.FC = () => {
                             type="button"
                             onClick={() => void openTrace(result)}
                             aria-label={`${result.label} — how we got this`}
-                            className="absolute right-3 top-3 rounded border border-border px-1.5 py-0.5 font-mono text-[11px] italic text-accent transition-colors duration-fast ease-standard hover:bg-bg-elev focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                            className="absolute right-3 top-3 rounded border border-border px-1.5 py-0.5 font-mono text-[11px] italic text-accent-text transition-colors duration-fast ease-standard hover:bg-bg-elev focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                           >
                             {/* Figma 187:2074: the ƒ formula chip at card top-right. */}
                             ƒ
@@ -443,7 +443,7 @@ export const RatiosView: React.FC = () => {
               {trace.benchmark_band ? ` · band: ${trace.benchmark_band}` : ""}
             </p>
             {trace.na_reason ? (
-              <p className="text-warn">{trace.na_reason}</p>
+              <p className="text-warn-text">{trace.na_reason}</p>
             ) : null}
             {trace.inputs.length > 0 ? (
               <section aria-label="Inputs">

--- a/web/src/app/dashboard/company/statements/[id]/StatementDetailView.tsx
+++ b/web/src/app/dashboard/company/statements/[id]/StatementDetailView.tsx
@@ -378,7 +378,7 @@ export const StatementDetailView: React.FC = () => {
         action={
           <button
             type="button"
-            className="font-medium text-accent"
+            className="font-medium text-accent-text"
             onClick={() => router.push("/dashboard/company/ratios")}
           >
             View ratios

--- a/web/src/app/dashboard/taxes/TaxesView.tsx
+++ b/web/src/app/dashboard/taxes/TaxesView.tsx
@@ -220,7 +220,9 @@ export const TaxesView: React.FC = () => {
                   />
                 ) : (
                   <p className="font-mono text-[13px] text-text">
-                    {values.tin ?? <span className="text-warn">missing</span>}
+                    {values.tin ?? (
+                      <span className="text-warn-text">missing</span>
+                    )}
                   </p>
                 )
               }
@@ -243,7 +245,7 @@ export const TaxesView: React.FC = () => {
                   ) : (
                     <p className="font-mono text-[13px] text-text">
                       {values.rc_number ?? (
-                        <span className="text-warn">missing</span>
+                        <span className="text-warn-text">missing</span>
                       )}
                     </p>
                   )
@@ -272,7 +274,9 @@ export const TaxesView: React.FC = () => {
                     <p className="text-[13px] text-text">
                       {NG_STATES.find(
                         (state) => state.value === values.state_of_residence,
-                      )?.label ?? <span className="text-warn">missing</span>}
+                      )?.label ?? (
+                        <span className="text-warn-text">missing</span>
+                      )}
                     </p>
                   )
                 }

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -99,7 +99,7 @@ const Section: React.FC<{ title: string; children: React.ReactNode }> = ({
   children,
 }) => (
   <section id={title} className="border-b border-border pb-8">
-    <h2 className="mb-4 pt-8 font-mono text-[13px] font-semibold text-accent">
+    <h2 className="mb-4 pt-8 font-mono text-[13px] font-semibold text-accent-text">
       {title}
     </h2>
     <div className="space-y-4">{children}</div>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -24,6 +24,12 @@
   --color-expense: var(--color-expense);
   --color-warn: var(--color-warn);
   --color-info: var(--color-info);
+  /* AA text variants — readable text in a hue binds these; fills/
+     borders/icons keep the base hue (design.md §2) */
+  --color-accent-text: var(--color-accent-text);
+  --color-warn-text: var(--color-warn-text);
+  --color-income-text: var(--color-income-text);
+  --color-expense-text: var(--color-expense-text);
   --color-transparent: transparent;
   --color-current: currentColor;
 

--- a/web/src/components/home/ContributeSection.tsx
+++ b/web/src/components/home/ContributeSection.tsx
@@ -159,7 +159,7 @@ export const ContributeSection: React.FC = () => {
                 onClick={() =>
                   track("contribute_click", { target: "contributing_md" })
                 }
-                className="rounded text-sm font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                className="rounded text-sm font-medium text-accent-text hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               >
                 CONTRIBUTING.md →
               </a>

--- a/web/src/components/home/DeepDivesSection.tsx
+++ b/web/src/components/home/DeepDivesSection.tsx
@@ -164,7 +164,7 @@ export const DeepDivesSection: React.FC = () => (
               dive.copySide === "right" && "md:order-2 md:justify-self-end",
             )}
           >
-            <div className="text-[11px] font-semibold uppercase tracking-wider text-accent">
+            <div className="text-[11px] font-semibold uppercase tracking-wider text-accent-text">
               {dive.eyebrow}
             </div>
             <h3 className="mt-3 font-display text-2xl font-bold tracking-tight text-text">

--- a/web/src/components/home/SelfHostCommunity.tsx
+++ b/web/src/components/home/SelfHostCommunity.tsx
@@ -74,7 +74,7 @@ export const SelfHostSection: React.FC = () => {
             target="_blank"
             rel="noreferrer"
             onClick={() => track("github_click", { source: "self_host" })}
-            className="rounded text-sm font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            className="rounded text-sm font-medium text-accent-text hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           >
             github.com/cuesoftinc/expendit →
           </a>
@@ -83,7 +83,7 @@ export const SelfHostSection: React.FC = () => {
             target="_blank"
             rel="noreferrer"
             onClick={() => track("self_host_click", { target: "docs" })}
-            className="rounded text-sm font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            className="rounded text-sm font-medium text-accent-text hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           >
             Self-hosting docs →
           </a>
@@ -111,7 +111,7 @@ export const CommunitySection: React.FC = () => (
           href={ROADMAP_URL}
           target="_blank"
           rel="noreferrer"
-          className="shrink-0 rounded text-sm font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          className="shrink-0 rounded text-sm font-medium text-accent-text hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           See the public roadmap →
         </a>

--- a/web/src/components/home/TrustSections.tsx
+++ b/web/src/components/home/TrustSections.tsx
@@ -64,7 +64,7 @@ export const SecuritySection: React.FC = () => (
           href={SECURITY_POLICY_URL}
           target="_blank"
           rel="noreferrer"
-          className="rounded text-sm font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          className="rounded text-sm font-medium text-accent-text hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           View Security Policy →
         </a>
@@ -72,7 +72,7 @@ export const SecuritySection: React.FC = () => (
           href={PRIVACY_HUB_URL}
           target="_blank"
           rel="noreferrer"
-          className="rounded text-sm font-medium text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          className="rounded text-sm font-medium text-accent-text hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           Privacy hub →
         </a>

--- a/web/src/components/home/embeds.tsx
+++ b/web/src/components/home/embeds.tsx
@@ -212,7 +212,7 @@ export const DashboardEmbed: React.FC = () => {
         <Banner
           kind="warn"
           action={
-            <span className="text-[13px] font-medium text-accent">
+            <span className="text-[13px] font-medium text-accent-text">
               Prepare filing
             </span>
           }
@@ -312,7 +312,7 @@ export const DashboardEmbed: React.FC = () => {
                   timestamp="8 Jul"
                 />
               </div>
-              <div className="mt-2 text-[11px] font-medium text-accent">
+              <div className="mt-2 text-[11px] font-medium text-accent-text">
                 Explain in ledger →
               </div>
             </div>
@@ -323,7 +323,7 @@ export const DashboardEmbed: React.FC = () => {
             <span className="text-[13px] font-medium text-text">
               Latest transactions
             </span>
-            <span className="text-[11px] font-medium text-accent">
+            <span className="text-[11px] font-medium text-accent-text">
               View all →
             </span>
           </div>

--- a/web/src/components/ui/AnomalyBadge.test.tsx
+++ b/web/src/components/ui/AnomalyBadge.test.tsx
@@ -21,11 +21,11 @@ describe("AnomalyBadge (design.md §8.2, MI-5)", () => {
     const { rerender } = render(
       <AnomalyBadge type="spending_spike" severity="warn" />,
     );
-    expect(screen.getByRole("button")).toHaveClass("text-expense");
+    expect(screen.getByRole("button")).toHaveClass("text-expense-text");
     rerender(<AnomalyBadge type="abnormal_category" severity="info" />);
     expect(screen.getByRole("button")).toHaveClass("text-info");
     rerender(<AnomalyBadge type="large_transaction" severity="warn" />);
-    expect(screen.getByRole("button")).toHaveClass("text-warn");
+    expect(screen.getByRole("button")).toHaveClass("text-warn-text");
   });
 
   it("inline shows the Figma short label", () => {

--- a/web/src/components/ui/AnomalyBadge.tsx
+++ b/web/src/components/ui/AnomalyBadge.tsx
@@ -49,8 +49,8 @@ const TYPE_META: Record<
 };
 
 const TONE_TEXT: Record<string, string> = {
-  warn: "text-warn",
-  expense: "text-expense",
+  warn: "text-warn-text",
+  expense: "text-expense-text",
   info: "text-info",
 };
 

--- a/web/src/components/ui/AppNav.tsx
+++ b/web/src/components/ui/AppNav.tsx
@@ -38,7 +38,7 @@ export const NavItem: React.FC<NavItemProps> = ({
     "group/nav-item relative flex w-full items-center gap-2.5 rounded px-2.5 py-1.5 text-left text-[13px] font-medium",
     "transition-colors duration-fast ease-standard",
     active
-      ? "bg-accent/10 text-accent"
+      ? "bg-accent/10 text-accent-text"
       : "text-text-2 hover:bg-bg-elev hover:text-text",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
     collapsed && "justify-center px-0",

--- a/web/src/components/ui/Avatar.tsx
+++ b/web/src/components/ui/Avatar.tsx
@@ -33,7 +33,7 @@ export const Avatar: React.FC<AvatarProps> = ({ name, src, size = "sm" }) => (
       // Figma: initials disc = 15% accent tint + accent text (no border);
       // image/icon fallbacks stay neutral.
       !src && name
-        ? "bg-accent/[0.15] text-accent"
+        ? "bg-accent/[0.15] text-accent-text"
         : "border border-border bg-bg-elev text-text-2",
       SIZE_CLASSES[size],
     )}

--- a/web/src/components/ui/Banner.tsx
+++ b/web/src/components/ui/Banner.tsx
@@ -67,7 +67,7 @@ export const Banner: React.FC<BannerProps> = ({
         <div
           className={cn(
             "shrink-0 text-[13px] font-medium leading-4",
-            kind === "error" ? "text-expense" : "text-accent",
+            kind === "error" ? "text-expense-text" : "text-accent-text",
           )}
         >
           {action}

--- a/web/src/components/ui/EditorialCard.test.tsx
+++ b/web/src/components/ui/EditorialCard.test.tsx
@@ -44,6 +44,6 @@ describe("EditorialCard (design.md §8.2b)", () => {
         href="/signin"
       />,
     );
-    expect(screen.getByText("Explore imports")).toHaveClass("text-accent");
+    expect(screen.getByText("Explore imports")).toHaveClass("text-accent-text");
   });
 });

--- a/web/src/components/ui/EditorialCard.tsx
+++ b/web/src/components/ui/EditorialCard.tsx
@@ -51,7 +51,7 @@ export const EditorialCard: React.FC<EditorialCardProps> = ({
             "mb-4 flex h-9 w-9 items-center justify-center rounded-full",
             kind === "community"
               ? "bg-info/10 text-info"
-              : "bg-accent/10 text-accent",
+              : "bg-accent/10 text-accent-text",
           )}
         >
           {/* 24px — h-4.5 was outside the v3 spacing scale, so the lucide
@@ -82,7 +82,7 @@ export const EditorialCard: React.FC<EditorialCardProps> = ({
       {/* Body/14 Regular (14/20); the CTA line is Body/14 Medium. */}
       <p className="mt-2 text-sm leading-5 text-text-2">{body}</p>
       {cta ? (
-        <span className="mt-4 inline-flex items-center gap-1 text-sm font-medium leading-5 text-accent">
+        <span className="mt-4 inline-flex items-center gap-1 text-sm font-medium leading-5 text-accent-text">
           {cta}
           <ChevronRight aria-hidden className="h-3.5 w-3.5" />
         </span>

--- a/web/src/components/ui/Inspector.tsx
+++ b/web/src/components/ui/Inspector.tsx
@@ -63,7 +63,7 @@ export const Inspector: React.FC<InspectorProps> = ({
           <h2
             className={cn(
               "text-sm font-semibold",
-              variant === "anomaly-explain" ? "text-warn" : "text-text",
+              variant === "anomaly-explain" ? "text-warn-text" : "text-text",
             )}
           >
             {title}

--- a/web/src/components/ui/LinkAccountCard.test.tsx
+++ b/web/src/components/ui/LinkAccountCard.test.tsx
@@ -57,6 +57,6 @@ describe("LinkAccountCard (design.md §8.2, MI-9)", () => {
     const pill = screen.getByText("Re-auth required");
     expect(pill).toBeInTheDocument();
     // Figma: reauth pill is warn-tinted (not expense).
-    expect(pill.closest("span")).toHaveClass("text-warn");
+    expect(pill.closest("span")).toHaveClass("text-warn-text");
   });
 });

--- a/web/src/components/ui/LinkAccountCard.tsx
+++ b/web/src/components/ui/LinkAccountCard.tsx
@@ -24,18 +24,18 @@ const STATUS_META: Record<
   },
   active: {
     label: "Active",
-    pillClass: "bg-income/[0.12] text-income",
+    pillClass: "bg-income/[0.12] text-income-text",
     dotClass: "bg-income",
     breathe: true,
   },
   reauth_required: {
     label: "Re-auth required",
-    pillClass: "bg-warn/[0.12] text-warn",
+    pillClass: "bg-warn/[0.12] text-warn-text",
     dotClass: "bg-warn",
   },
   degraded: {
     label: "Degraded",
-    pillClass: "bg-warn/[0.12] text-warn",
+    pillClass: "bg-warn/[0.12] text-warn-text",
     dotClass: "bg-warn",
   },
   paused: {

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -58,7 +58,7 @@ export const MarketingFooter: React.FC<MarketingFooterProps> = ({
                     {...(/^https?:\/\//.test(link.href)
                       ? { target: "_blank", rel: "noreferrer" }
                       : {})}
-                    className="rounded text-[13px] text-text transition-colors duration-fast ease-standard hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                    className="rounded text-[13px] text-text transition-colors duration-fast ease-standard hover:text-accent-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                   >
                     {link.label}
                   </a>

--- a/web/src/components/ui/OrgSwitcher.tsx
+++ b/web/src/components/ui/OrgSwitcher.tsx
@@ -44,7 +44,7 @@ const OrgTile: React.FC<{ org: Org; className?: string }> = ({
       "flex shrink-0 items-center justify-center rounded",
       org.kind === "company"
         ? "bg-info/[0.12] text-info"
-        : "bg-accent/[0.12] text-accent",
+        : "bg-accent/[0.12] text-accent-text",
       className,
     )}
   >

--- a/web/src/components/ui/PeriodPicker.tsx
+++ b/web/src/components/ui/PeriodPicker.tsx
@@ -335,7 +335,7 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
                   className={cn(
                     "rounded border border-border bg-bg-elev px-2 py-0.5 text-[13px] tabular-nums text-text",
                     "transition-colors duration-fast ease-standard hover:border-text-2",
-                    preset.value === value && "border-accent text-accent",
+                    preset.value === value && "border-accent text-accent-text",
                   )}
                 >
                   {preset.label}

--- a/web/src/components/ui/RemitToCard.tsx
+++ b/web/src/components/ui/RemitToCard.tsx
@@ -73,7 +73,7 @@ export const RemitToCard: React.FC<RemitToCardProps> = ({
         <Calendar aria-hidden className="h-3.5 w-3.5" />
         <span className="tabular-nums">Due {due}</span>
         {threshold !== "none" ? (
-          <span className="rounded-full bg-warn/[0.15] px-1.5 py-0.5 text-[11px] font-medium uppercase leading-4 text-warn">
+          <span className="rounded-full bg-warn/[0.15] px-1.5 py-0.5 text-[11px] font-medium uppercase leading-4 text-warn-text">
             {threshold}
           </span>
         ) : null}

--- a/web/src/components/ui/StagedReviewHeader.tsx
+++ b/web/src/components/ui/StagedReviewHeader.tsx
@@ -49,7 +49,8 @@ export const StagedReviewHeader: React.FC<StagedReviewHeaderProps> = ({
         {duplicateCount > 0 ? (
           <span className="text-text-2">
             {" "}
-            · <span className="tabular-nums text-warn">
+            ·{" "}
+            <span className="tabular-nums text-warn-text">
               {duplicateCount}
             </span>{" "}
             {duplicateCount === 1 ? "duplicate" : "duplicates"} flagged for

--- a/web/src/components/ui/StatCard.test.tsx
+++ b/web/src/components/ui/StatCard.test.tsx
@@ -19,10 +19,10 @@ describe("StatCard (design.md §8.2, MI-7)", () => {
       <StatCard label="Income" value={100} delta={0.042} />,
     );
     expect(screen.getByTestId("stat-delta")).toHaveTextContent("+4.2%");
-    expect(screen.getByTestId("stat-delta")).toHaveClass("text-income");
+    expect(screen.getByTestId("stat-delta")).toHaveClass("text-income-text");
     rerender(<StatCard label="Income" value={100} delta={-0.08} />);
     expect(screen.getByTestId("stat-delta")).toHaveTextContent("−8.0%");
-    expect(screen.getByTestId("stat-delta")).toHaveClass("text-expense");
+    expect(screen.getByTestId("stat-delta")).toHaveClass("text-expense-text");
   });
 
   it("sparkline renders as bespoke SVG when series given", () => {
@@ -70,7 +70,7 @@ describe("StatCard (design.md §8.2, MI-7)", () => {
       />,
     );
     const chip = screen.getByTestId("stat-delta");
-    expect(chip.className).toContain("text-income");
+    expect(chip.className).toContain("text-income-text");
     // Sign still encodes the raw direction (design.md §5).
     expect(chip.textContent).toContain("−68.6%");
   });
@@ -85,7 +85,7 @@ describe("StatCard (design.md §8.2, MI-7)", () => {
       />,
     );
     expect(screen.getByTestId("stat-delta").className).toContain(
-      "text-expense",
+      "text-expense-text",
     );
   });
 });

--- a/web/src/components/ui/StatCard.tsx
+++ b/web/src/components/ui/StatCard.tsx
@@ -148,8 +148,8 @@ export const StatCard: React.FC<StatCardProps> = ({
                 "inline-flex items-center gap-1 rounded-full px-1.5 py-0.5",
                 "text-[13px] font-medium leading-4 tabular-nums",
                 improving
-                  ? "bg-income/[0.12] text-income"
-                  : "bg-expense/[0.12] text-expense",
+                  ? "bg-income/[0.12] text-income-text"
+                  : "bg-expense/[0.12] text-expense-text",
               )}
             >
               {positive ? (

--- a/web/src/components/ui/StatementView.tsx
+++ b/web/src/components/ui/StatementView.tsx
@@ -139,7 +139,7 @@ export const StatementView: React.FC<StatementViewProps> = ({
           {mappingWarnings.map((warning) => (
             <span
               key={warning}
-              className="mr-1.5 inline-flex items-center gap-1 rounded border border-warn/40 bg-warn/10 px-1.5 py-0 text-[11px] font-medium text-warn"
+              className="mr-1.5 inline-flex items-center gap-1 rounded border border-warn/40 bg-warn/10 px-1.5 py-0 text-[11px] font-medium text-warn-text"
             >
               <TriangleAlert aria-hidden className="h-3 w-3" />
               {warning}
@@ -215,7 +215,9 @@ export const StatementView: React.FC<StatementViewProps> = ({
           data-identity={identityHolds ? "pass" : "fail"}
           className={cn(
             "flex items-center gap-1.5 border-t border-border px-4 py-2 text-[12px] font-medium",
-            identityHolds ? "bg-income/10 text-income" : "bg-warn/10 text-warn",
+            identityHolds
+              ? "bg-income/10 text-income-text"
+              : "bg-warn/10 text-warn-text",
           )}
         >
           {identityHolds ? (

--- a/web/src/components/ui/Tag.tsx
+++ b/web/src/components/ui/Tag.tsx
@@ -21,10 +21,10 @@ export interface TagProps {
 const TINT_CLASSES: Record<TagTint, string> = {
   neutral: "bg-bg-elev text-text-2",
   info: "bg-info/[0.12] text-info",
-  warn: "bg-warn/[0.12] text-warn",
-  error: "bg-expense/[0.12] text-expense",
-  success: "bg-income/[0.12] text-income",
-  "new-accent": "bg-accent/[0.12] text-accent",
+  warn: "bg-warn/[0.12] text-warn-text",
+  error: "bg-expense/[0.12] text-expense-text",
+  success: "bg-income/[0.12] text-income-text",
+  "new-accent": "bg-accent/[0.12] text-accent-text",
 };
 
 export const Tag: React.FC<TagProps> = ({

--- a/web/src/components/ui/TaxCalendarRow.tsx
+++ b/web/src/components/ui/TaxCalendarRow.tsx
@@ -33,8 +33,8 @@ const ROW_CLASSES: Record<DeadlineThreshold, string> = {
 const ICON_CLASSES: Record<DeadlineThreshold, string> = {
   none: "text-text-2",
   "t-30": "text-info",
-  "t-7": "text-warn",
-  "t-1": "text-warn",
+  "t-7": "text-warn-text",
+  "t-1": "text-warn-text",
 };
 
 const CHIP_META: Record<
@@ -42,8 +42,8 @@ const CHIP_META: Record<
   { label: string; className: string }
 > = {
   "t-30": { label: "Due in 30 days", className: "bg-info/[0.12] text-info" },
-  "t-7": { label: "Due in 7 days", className: "bg-warn/[0.12] text-warn" },
-  "t-1": { label: "Due tomorrow", className: "bg-warn/[0.2] text-warn" },
+  "t-7": { label: "Due in 7 days", className: "bg-warn/[0.12] text-warn-text" },
+  "t-1": { label: "Due tomorrow", className: "bg-warn/[0.2] text-warn-text" },
 };
 
 export interface TaxCalendarRowProps {

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -47,7 +47,7 @@ export const Toast: React.FC<ToastProps> = ({
         {children}
       </div>
       {action ? (
-        <div className="shrink-0 text-[13px] font-medium leading-4 text-accent">
+        <div className="shrink-0 text-[13px] font-medium leading-4 text-accent-text">
           {action}
         </div>
       ) : null}

--- a/web/src/components/ui/UploadDropzone.tsx
+++ b/web/src/components/ui/UploadDropzone.tsx
@@ -165,7 +165,7 @@ export const UploadDropzone: React.FC<UploadDropzoneProps> = ({
             type="button"
             disabled={disabled}
             onClick={() => inputRef.current?.click()}
-            className="font-medium text-accent underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            className="font-medium text-accent-text underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           >
             browse
           </button>

--- a/web/src/components/ui/WizardStep.tsx
+++ b/web/src/components/ui/WizardStep.tsx
@@ -31,9 +31,9 @@ const Marker: React.FC<{ state: WizardStepState; index: number }> = ({
       "flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-[11px] font-medium tabular-nums",
       "transition-colors duration-base ease-standard",
       state === "done" && "border-accent bg-accent text-on-accent",
-      state === "current" && "border-accent text-accent",
+      state === "current" && "border-accent text-accent-text",
       state === "todo" && "border-border text-text-2",
-      state === "error" && "border-expense bg-expense/10 text-expense",
+      state === "error" && "border-expense bg-expense/10 text-expense-text",
     )}
   >
     {state === "done" ? (

--- a/web/src/design/tokens.css
+++ b/web/src/design/tokens.css
@@ -24,6 +24,18 @@
   --color-warn: #b26a00; /* anomalies, tax deadlines */
   --color-info: #2456d6; /* AI/insight chips */
 
+  /* ---- AA text variants (design.md §2) ------------------------------
+     Readable text in a hue binds the `-text` variant; fills/borders/
+     icons keep the base hue. Light values darken the base in OKLCH
+     (L only; C/H preserved) until ≥4.5:1 against the hue's worst tinted
+     recipe (chips at /10–/20 over bg-elev) and the plain surfaces; the
+     dark base values already clear AA everywhere, so the dark variants
+     alias them. `info` needs no variant (base clears its /12 chip). */
+  --color-accent-text: #ae4501; /* 4.60 on accent/15 over bg-elev */
+  --color-warn-text: #804c05; /* 4.61 on the T-1 compound warn tint over bg-elev */
+  --color-income-text: #077542; /* 4.64 on income/12 over bg-elev */
+  --color-expense-text: #bc2d34; /* 4.63 on expense/12 over bg-elev */
+
   /* ---- Spacing (4px base grid — no off-scale values) --------------- */
   --space-4: 4px;
   --space-8: 8px;
@@ -78,6 +90,10 @@
   --color-expense: #c6373c;
   --color-warn: #b26a00;
   --color-info: #2456d6;
+  --color-accent-text: #ae4501;
+  --color-warn-text: #804c05;
+  --color-income-text: #077542;
+  --color-expense-text: #bc2d34;
 }
 
 /* Dark theme values (design.md §2, Dark column). */
@@ -94,6 +110,11 @@
   --color-expense: #ff6b6e;
   --color-warn: #ffb020;
   --color-info: #7da2ff;
+  /* AA text variants — dark bases already clear AA; variants alias them */
+  --color-accent-text: #f46a1f;
+  --color-warn-text: #ffb020;
+  --color-income-text: #34c77b;
+  --color-expense-text: #ff6b6e;
 }
 
 /* OS dark preference applies unless a manual light override is set. */
@@ -111,5 +132,9 @@
     --color-expense: #ff6b6e;
     --color-warn: #ffb020;
     --color-info: #7da2ff;
+    --color-accent-text: #f46a1f;
+    --color-warn-text: #ffb020;
+    --color-income-text: #34c77b;
+    --color-expense-text: #ff6b6e;
   }
 }


### PR DESCRIPTION
## What

The `text-X on bg-X/10–20` tinted-chip recipe — and accent/warn as plain text — fails WCAG AA in light theme (2026-07-21 fleet audit, adjudicated canon fix). §2 gains paired `-text` variants — the base hue darkened in OKLCH (L only, C/H preserved) until ≥4.5:1 against the hue's worst tinted recipe over `bg-elev` — and **readable text binds the variant; fills/borders/icons/focus rings keep the base hue**. Dark theme had 0 failing pairs, so the dark variants alias the base values (dark is visually unchanged).

## Token values

| Token | Light | Dark |
|---|---|---|
| `--color-accent-text` | `#AE4501` | `#F46A1F` (base — already AA) |
| `--color-warn-text` | `#804C05` | `#FFB020` (base — already AA) |
| `--color-income-text` | `#077542` | `#34C77B` (base — already AA) |
| `--color-expense-text` | `#BC2D34` | `#FF6B6E` (base — already AA) |

`info` needs no variant (base clears its /12 chip: 5.21/4.89; locked in the e2e).

## Before → after (light theme)

| Pair | Before | After |
|---|---|---|
| accent as text on `bg` (links, actions — the axe ×22/route volume) | **3.03** | **5.75** |
| accent on `accent/10` active-nav tint over `bg-elev` | **2.56** | **4.85** |
| accent on `accent/15` (Avatar initials) over `bg-elev` | **2.43** | **4.60** |
| warn text on `bg-elev` | **3.96** | **6.64** |
| warn on T-1 compound tint (`warn/20` over `warn/12`) over `bg-elev` | **3.05** | **4.61** |
| income on `income/12` chip over `bg-elev` | **4.02** | **4.64** |
| expense on `expense/12` chip over `bg-elev` | **4.11** | **4.63** |

## Code

- Active nav (`AppNav`), `Tag`, `StatCard` delta pills, `AnomalyBadge`, `LinkAccountCard` pills, `TaxCalendarRow` (rows + chips), `StatementView` flags, `RemitToCard` VAT pill, `WizardStep` current/error, `PeriodPicker` selected preset, `EditorialCard` chip + CTA, `Avatar`/`OrgSwitcher` initials, `Banner`/`Toast` actions, marketing links (Trust/SelfHost/Contribute/DeepDives/embeds/footer hover), overview/statement/ratio/taxes copy → `-text` variants
- Kept on base hue deliberately: icons and aria-hidden glyphs (Wordmark, sort chevrons, checkmarks), dots, borders, fills, `on-accent` button fills (fills unchanged per adjudication — the white-on-accent CTA pair is a separate fills decision), plain income/expense amounts (already AA)
- Unit tests asserting the old classes updated to the new contract

## Docs

`docs/design.md` §2 token table gains the `accent-text` and `warn-text/income-text/expense-text` rows.

## Lock

`web/e2e/contrast-tokens.spec.ts`:
1. recomputes every recipe pair from the **served CSS** (both themes, all shipped alphas /8–/20, both surfaces, incl. the T-1 compound tint) asserting ≥4.5:1
2. axe `color-contrast` scoped to the fixed `-text` classes on the transactions ledger → 0 violations (the existing axe gate's "token work tracked separately" note is now this lock)
3. sweeps the rendered overview chips with walk-up backdrop compositing

## Gate

prettier ✓ eslint ✓ boundaries ✓ typecheck ✓ vitest ✓ build ✓ Playwright 75/75 ✓ (PW_PORT=4432)

🤖 Generated with [Claude Code](https://claude.com/claude-code)