### PR TITLE
fix(web): signin legal links wired to the canonical Cuesoft policies

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -588,7 +588,7 @@ the ⌘K palette (MI-1) is a global overlay, not a route.
 | pages.md | Route | Screen |
 | --- | --- | --- |
 | Part A (A1–A11 + A4a/A5a/A8a/A10a/A10b) | `/` | Public home page (Brex-editorial) |
-| flows/auth.md §1 | `/signin` | Single auth screen — GoogleAuthButton + legal links (the one X-1 auth screen; Stage-4 `signin` template) |
+| flows/auth.md §1 | `/signin` | Single auth screen — GoogleAuthButton + legal links (Terms/Privacy open the canonical https://terms.cuesoft.io / https://privacy.cuesoft.io in a new tab; the one X-1 auth screen; Stage-4 `signin` template) |
 | X-2 | `/docs/api` | Public API reference — Scalar embed rendering `docs/api/openapi.yaml` (served at `/docs/api/openapi.yaml`); marketing nav chrome, minimal legal strip **[Ratified 2026-07-20]** |
 | B0 | `/onboarding` | First-run: org create (personal/company kind picker) + AI-consent sheet |
 | B1 | `/dashboard` | Overview (StatCards, cash-flow chart, category donut, anomaly feed, latest txns) |

--- a/web/e2e/signin.spec.ts
+++ b/web/e2e/signin.spec.ts
@@ -17,6 +17,19 @@ test("signin page shows the single Google CTA and no password fields", async ({
   await expect(page.locator('input[type="email"]')).toHaveCount(0);
 });
 
+test("legal links point at the canonical Cuesoft policies", async ({
+  page,
+}) => {
+  await page.goto("/signin");
+  await expect(page.getByRole("link", { name: "Terms" })).toHaveAttribute(
+    "href",
+    "https://terms.cuesoft.io",
+  );
+  await expect(
+    page.getByRole("link", { name: "Privacy Policy" }),
+  ).toHaveAttribute("href", "https://privacy.cuesoft.io");
+});
+
 test("TEST_MODE: Continue with Google goes straight to /dashboard", async ({
   page,
 }) => {

--- a/web/src/app/onboarding/OnboardingView.tsx
+++ b/web/src/app/onboarding/OnboardingView.tsx
@@ -12,6 +12,7 @@ import React, { useState } from "react";
 import { Sparkles } from "lucide-react";
 import { useOnboardingController, useRequireAuth } from "@/controllers";
 import type { OrgKind } from "@/models";
+import { PRIVACY_HUB_URL } from "@/components/home/links";
 import Button from "@/components/ui/Button";
 import FormRow from "@/components/ui/FormRow";
 import Input from "@/components/ui/Input";
@@ -180,9 +181,17 @@ export const OnboardingView: React.FC = () => {
               className="mt-0.5 h-4 w-4 shrink-0 text-info"
             />
             <span>
-              Imported statements and receipts are categorized by an AI provider
-              (disclosed in the privacy hub). Only transaction rows are sent —
-              never your credentials.
+              Imported statements and receipts are categorized by an AI
+              provider (disclosed in the{" "}
+              <a
+                href={PRIVACY_HUB_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="underline hover:text-text"
+              >
+                privacy hub
+              </a>
+              ). Only transaction rows are sent — never your credentials.
             </span>
           </p>
           <p>

--- a/web/src/app/onboarding/OnboardingView.tsx
+++ b/web/src/app/onboarding/OnboardingView.tsx
@@ -181,8 +181,8 @@ export const OnboardingView: React.FC = () => {
               className="mt-0.5 h-4 w-4 shrink-0 text-info"
             />
             <span>
-              Imported statements and receipts are categorized by an AI
-              provider (disclosed in the{" "}
+              Imported statements and receipts are categorized by an AI provider
+              (disclosed in the{" "}
               <a
                 href={PRIVACY_HUB_URL}
                 target="_blank"

--- a/web/src/app/signin/SigninView.tsx
+++ b/web/src/app/signin/SigninView.tsx
@@ -9,6 +9,7 @@
 import React from "react";
 import Link from "next/link";
 import { useAuthController } from "@/controllers/use-auth";
+import { PRIVACY_HUB_URL, TERMS_URL } from "@/components/home/links";
 import GoogleAuthButton from "@/components/ui/GoogleAuthButton";
 import Wordmark from "@/components/ui/Wordmark";
 
@@ -42,13 +43,23 @@ const SigninView: React.FC = () => {
         <p className="mt-6 text-center text-xs leading-relaxed text-text-2">
           Google is the only sign-in method — no passwords, ever. By continuing
           you agree to the{" "}
-          <Link href="/" className="underline hover:text-text">
+          <a
+            href={TERMS_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="underline hover:text-text"
+          >
             Terms
-          </Link>{" "}
+          </a>{" "}
           and{" "}
-          <Link href="/" className="underline hover:text-text">
+          <a
+            href={PRIVACY_HUB_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="underline hover:text-text"
+          >
             Privacy Policy
-          </Link>
+          </a>
           .
         </p>
       </div>


### PR DESCRIPTION
## Summary
- `/signin`'s Terms / Privacy Policy links were `next/link` placeholders pointing at `/`; they are now external `<a>` links to `TERMS_URL` / `PRIVACY_HUB_URL` from the canonical link register (`@/components/home/links`), opening in a new tab (`target="_blank" rel="noreferrer"` — the repo's external-link idiom).
- Sweep fix: the B0 AI-consent sheet (`OnboardingView`) said providers are "disclosed in the privacy hub" without linking it — "privacy hub" now links `PRIVACY_HUB_URL` with the same idiom.
- LOCK: `web/e2e/signin.spec.ts` now asserts both legal links exist with exactly the canonical hrefs.
- Docs: `/signin` route-map row in `docs/web-implementation.md` notes the canonical targets (current-system voice).

## Test plan
- CI e2e: new "legal links point at the canonical Cuesoft policies" assertion in the signin spec.
- Grep sweep: no remaining legal-link placeholders in `web/src` (dev component gallery's all-placeholder footer demo intentionally untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)