### PR TITLE
docs: closeout currency — changelog catch-up + voice strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Mock-data module renamed `src/mock/` → `src/mocks/` for tree-shape parity
+  with the sibling repos (#256).
+- `/docs/api`'s Scalar reference now loads on user intent instead of shipping
+  eagerly with the route; a dashboard bundle audit found every route's
+  shared weight is the framework + prefetch floor, with nothing safe to cut
+  (#257).
+
+### Fixed
+- Contrast-token canon: AA-compliant `-text` variants for the tinted-chip
+  recipe so tinted text clears 4.5:1 in both themes (#254).
+- Signin's legal links now point at the canonical Cuesoft policies, and the
+  onboarding AI-consent sheet's "privacy hub" mention is now a real link
+  (#258).
+
 ### Added
 - Settings goes route-backed tabs: Organization | Members | Data & privacy |
   Notifications, each deep-linkable (#240).

--- a/docs/design.md
+++ b/docs/design.md
@@ -46,9 +46,8 @@
 
 - Display (marketing + dashboard page titles): **Inter Display** committed for
   v1 [Decided — no commercial-font procurement now]; revisit at brand pass. Hero sizes 56–88px,
-  tight leading (Brex scale). The documented style ramp previously stopped at
-  Hero/56; **Hero/88 Bold** (the A2 hero headline) is added to complete the
-  56–88 scale [Decided 2026-07-16]. Inter Display remains unavailable in
+  tight leading (Brex scale), spanning Hero/56 through **Hero/88 Bold** (the
+  A2 hero headline) [Decided 2026-07-16]. Inter Display remains unavailable in
   Figma — the Inter Bold tight-tracked fallback stands until the brand pass.
 - UI/data: `Inter`; base 14, tables 13; **tabular figures always on for
   numeric columns**; money format `₦1,240,300.50` / `$…` with currency from
@@ -65,8 +64,8 @@
   the Figma `A — Home` frame was normalized to this rule on 2026-07-19 — the
   pillar row, all five feature deep-dive splits, the demo stats/charts/table,
   the how-it-works steps, the security columns, and the contribute dev-row
-  previously implied phantom containers (872–1128px wide); 3-up card rows now
-  share one 384px-card / 24px-gutter rhythm.
+  all align to the single centered container; 3-up card rows share one
+  384px-card / 24px-gutter rhythm.
 - Dashboard: left nav 240px (collapsible to 64px icon rail) · content
   max 1440px · right inspector panel (400px) slides in for detail views —
   tables never navigate away for a single record. **[Proposed]**

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -345,8 +345,8 @@ adjudicated audit ledger):**
   amber outside, hidden when a side is absent).
 - **Purge model converged** (MI-15, one construction): typed confirm is
   the ORG NAME, the 5s danger-armed CTA stays, and an "Export first"
-  secondary kicks off the USR-001 export from the modal; grace states as
-  previously built.
+  secondary kicks off the USR-001 export from the modal; the 7-day grace
+  banner and cancel remain intact.
 - **Ratio gauges carry real deltas**: the mock engine computes the prior
   same-kind period per metric and attaches `period_delta` (skipped for
   growth metrics and when either side is n/a); `previousPeriod` lives in
@@ -478,8 +478,8 @@ prompts are decorative (select-none) and stay out of the payload. The
 shared muted caption renders once under the block — "Compose ships
 MongoDB + Redis — the Helm chart expects reachable instances
 (MONGODB_URL, REDIS_URL)." — visible in both tab states, so switching
-never shifts layout. The section eyebrow drops "· docker" (now
-method-neutral "self-host"). Unit: `CodeSnippet.test.tsx` tabbed cases
+never shifts layout. The section eyebrow reads method-neutral "self-host".
+Unit: `CodeSnippet.test.tsx` tabbed cases
 (tab state, per-tab copy payload, Radix roving focus, copied-morph
 reset); e2e: `home.spec.ts` pins helm-tab copy → the clipboard payload,
 caption persistence and the 1440/390 container fit.
@@ -525,9 +525,9 @@ hardened at the shared layer:
 - **Overlays return focus to their opener.** `Modal` and `CommandPalette`
   own the focus contract (fleet P4): the opener is captured on open
   (before autofocus moves into the overlay) and refocused on close —
-  Radix's default targets a null trigger on controlled dialogs and the
-  palette opens programmatically via ⌘K, so both previously dropped focus
-  on `<body>`. `Modal` is also announced `aria-modal`. e2e:
+  necessary because Radix's default targets a null trigger on controlled
+  dialogs, and the palette opens programmatically via ⌘K, so neither has a
+  natural focus-return target. `Modal` is also announced `aria-modal`. e2e:
   `focus-restore.spec.ts` (open → Tab inside → Escape → trigger
   refocused) for the palette and the merge modal.
 
@@ -787,9 +787,9 @@ products; per-product values only):
   canonical URL.
 - **og/twitter card** — `src/app/opengraph-image.png` (1200×630, App Router
   file convention): the "expendit·" wordmark + tagline on the editorial
-  token canvas — replaces the 1500×371 `/logo.png` wordmark (wrong aspect
-  for 1.91:1 cards); `twitter:card = summary_large_image`. `/signin` title
-  standardized to "Sign in — Expendit" (fleet separator).
+  token canvas, sized to the 1.91:1 card aspect ratio; `twitter:card =
+  summary_large_image`. `/signin` title standardized to "Sign in —
+  Expendit" (fleet separator).
 - **Icons** — `src/app/favicon.ico` (16/32/48/256 PNG-in-ICO — was 16×16
   only) and `src/app/apple-icon.png` (180×180): the "e·" mark on the
   editorial tile.


### PR DESCRIPTION
## Summary
- CHANGELOG: adds the four PRs the 2026-07-21 catch-up missed — #254 (contrast-token canon), #256 (src/mock→src/mocks tree parity), #257 (Scalar first-load diet + dashboard chunk audit), #258 (signin legal links + onboarding privacy-hub link).
- docs/design.md + docs/web-implementation.md: strips changelog-archaeology clauses (docs-current-system voice — describe the present state, not what it replaced/previously did).

## Test plan
- Docs-only change; no code touched. Diff reviewed for accuracy against `gh pr view` titles/bodies for #254/#256/#257/#258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)