### PR TITLE
fix(web): a11y/perf closeout — IDREF, popover trap, table names, skip link, TBT/CLS, P16

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -628,7 +628,10 @@ on it:
    first-run journey runs on the fresh-identity fixture (§6). The interface
    is identical to the future `FirebaseAuthProvider` (X-1 Google-only,
    bearer-token shape preserved — flows/auth.md §2), so backend integration
-   swaps the provider, not the views.
+   swaps the provider, not the views. The test session persists as
+   `expendit.test-session` in **sessionStorage** (JSON user payload) — the
+   fleet key convention (P16): `<product>.test-session`, per-tab, gone on
+   close.
 2. **API client**: the models layer's base URL targets the in-app mock
    server — `/api/mock/v1/*` mirrors the `/api/v1/*` surface path-for-path
    (incl. the `X-Org-Id` context header), so repositories are identical in

--- a/web/e2e/axe-home.spec.ts
+++ b/web/e2e/axe-home.spec.ts
@@ -1,0 +1,52 @@
+// axe gate for the marketing home (2026-07-21 closeout): the A8c tabbed
+// snippet shipped Radix Tabs values carrying the display label — the
+// "Docker Compose" space made aria-controls an invalid IDREF (axe
+// `aria-valid-attr-value` critical). The gate pins the critical class at
+// zero on `/` and locks the ARIA-attribute + name classes specifically,
+// mirroring the transactions gate. (Serious-level light-theme
+// color-contrast is token work tracked separately — not gated here.)
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+// The ARIA classes this gate locks at ANY impact level: broken IDREFs /
+// required attributes (the CodeSnippet regression family) and unnamed
+// buttons (the checkbox/icon-button family, fleet P6).
+const LOCKED_RULES = [
+  "aria-valid-attr-value",
+  "aria-valid-attr",
+  "aria-required-attr",
+  "button-name",
+  "td-has-header",
+  "empty-table-header",
+];
+
+test("home has zero critical axe violations (ARIA IDREF + name lock)", async ({
+  page,
+}) => {
+  await page.goto("/");
+  // Mount the deferred below-fold demo panels (perf pass) so the scan
+  // covers the full page: the IO gates fire on approach, so walk the
+  // sections (an instant jump to the bottom would skip #demo), then
+  // return to the top.
+  await page.locator("#demo").scrollIntoViewIfNeeded();
+  await expect(
+    page.getByRole("table", { name: "Demo transactions" }),
+  ).toBeVisible();
+  await page.locator("#how-it-works").scrollIntoViewIfNeeded();
+  await page.locator("#self-host").scrollIntoViewIfNeeded();
+  await expect(page.getByRole("tab", { name: "Docker Compose" })).toBeVisible();
+  await page.evaluate(() => window.scrollTo(0, 0));
+
+  const results = await new AxeBuilder({ page }).analyze();
+  const critical = results.violations.filter(
+    (violation) => violation.impact === "critical",
+  );
+  expect(
+    critical.map((violation) => `${violation.id} ×${violation.nodes.length}`),
+  ).toEqual([]);
+  expect(
+    results.violations
+      .filter((violation) => LOCKED_RULES.includes(violation.id))
+      .map((violation) => `${violation.id} ×${violation.nodes.length}`),
+  ).toEqual([]);
+});

--- a/web/e2e/focus-restore.spec.ts
+++ b/web/e2e/focus-restore.spec.ts
@@ -34,6 +34,46 @@ test("command palette returns focus to the pre-open element on Escape", async ({
   await expect(anchor).toBeFocused();
 });
 
+// DatePicker popover containment (2026-07-21 a11y audit): the open panel
+// held role="dialog" but focus stayed on the trigger and Tab walked out
+// into the page behind (6 of 14 tabs escaped). Probe shape: open → focus
+// moved IN (the grammar input) → Tab cycles stay inside the dialog,
+// wrapping at both edges → Escape closes AND restores the trigger.
+test("date-picker popover moves focus in, contains Tab, and restores on Escape", async ({
+  page,
+}) => {
+  await signIn(page);
+  await page.goto("/dashboard/transactions");
+
+  const trigger = page.getByRole("button", { name: "All dates" });
+  await trigger.click();
+  const popover = page.getByRole("dialog", { name: "Pick range" });
+  await expect(popover).toBeVisible();
+
+  // Focus moved in on open — the grammar input is the first stop.
+  await expect(
+    popover.getByPlaceholder("YYYY-MM-DD..YYYY-MM-DD"),
+  ).toBeFocused();
+
+  // A full lap of Tab presses never leaves the dialog (the old probe saw
+  // Search/Saved views take focus while the popover stayed open).
+  for (let i = 0; i < 14; i += 1) {
+    await page.keyboard.press("Tab");
+    const inside = await popover.evaluate((node) =>
+      node.contains(document.activeElement),
+    );
+    expect(inside, `Tab ${i + 1} stayed inside the popover`).toBe(true);
+  }
+  // Shift+Tab from the first control wraps to the last (Apply).
+  await popover.getByRole("button", { name: "Previous month" }).focus();
+  await page.keyboard.press("Shift+Tab");
+  await expect(popover.getByRole("button", { name: "Apply" })).toBeFocused();
+
+  await page.keyboard.press("Escape");
+  await expect(popover).toBeHidden();
+  await expect(trigger).toBeFocused();
+});
+
 test("merge modal returns focus to its trigger on Escape", async ({ page }) => {
   await signIn(page);
   await page.goto("/dashboard/categories");

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -69,6 +69,8 @@ test.describe("public home `/` (Part A)", () => {
     await page.goto("/");
     // Scope to the A5 section — the A5a thumbs reuse the same demo pool.
     const demo = page.locator("#demo");
+    // The demo panel is IO-deferred (perf pass) — approach it first.
+    await demo.scrollIntoViewIfNeeded();
     // Freelancer boots (Figma A5 strip verbatim).
     await expect(demo.getByText("₦1,480,000.00")).toBeVisible();
     await expect(demo.getByText("MTN — data bundle top-up")).toBeVisible();
@@ -204,6 +206,9 @@ test.describe("public home `/` (Part A)", () => {
   }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto("/");
+    // The demo panel is IO-deferred (perf pass) — mount it before measuring.
+    await page.locator("#demo").scrollIntoViewIfNeeded();
+    await expect(page.getByTestId("demo-table")).toBeVisible();
     // Pillars (A4) and demo stat cards (A5) — 384px cards, 24px gutters.
     const widths = await page.evaluate(() => {
       const rows = [
@@ -233,7 +238,9 @@ test.describe("public home `/` (Part A)", () => {
 
     // Demo table: a real <table> (W3 semantic refactor) whose rows
     // contain only cells / columnheaders — native or ARIA (live QA
-    // 2026-07-19: rows were orphaned, cells bare).
+    // 2026-07-19: rows were orphaned, cells bare). IO-deferred (perf
+    // pass) — approach the section to mount it.
+    await page.locator("#demo").scrollIntoViewIfNeeded();
     const table = page.getByRole("table", { name: "Demo transactions" });
     await expect(table).toBeVisible();
     expect(

--- a/web/e2e/skip-link.spec.ts
+++ b/web/e2e/skip-link.spec.ts
@@ -1,0 +1,61 @@
+// Skip link (fleet canon P15, 2026-07-21 a11y audit): every route's FIRST
+// Tab stop is a visually-hidden-until-focused "Skip to main content" link;
+// activating it moves focus into <main id="main" tabIndex={-1}>, past the
+// navigation chrome. Probe shape: load → Tab → link focused (and visible)
+// → Enter → activeElement is the main landmark.
+import { expect, test, type Page } from "@playwright/test";
+
+const signIn = async (page: Page): Promise<void> => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: "Continue with Google" }).click();
+  await page.waitForURL("**/dashboard", { timeout: 15_000 });
+};
+
+const expectSkipLinkFlow = async (page: Page): Promise<void> => {
+  // Reset the sequential-focus start point to the document top.
+  await page.evaluate(() => {
+    (document.activeElement as HTMLElement | null)?.blur?.();
+    window.scrollTo(0, 0);
+  });
+  await page.keyboard.press("Tab");
+  const link = page.getByRole("link", { name: "Skip to main content" });
+  await expect(link).toBeFocused();
+  await expect(link).toBeVisible();
+
+  await page.keyboard.press("Enter");
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const active = document.activeElement;
+        return active instanceof HTMLElement
+          ? `${active.tagName.toLowerCase()}#${active.id}`
+          : String(active?.tagName ?? "none");
+      }),
+    )
+    .toBe("main#main");
+};
+
+test("home: first Tab is the skip link; activating focuses main", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expectSkipLinkFlow(page);
+});
+
+test("dashboard: first Tab is the skip link; activating focuses main", async ({
+  page,
+}) => {
+  await signIn(page);
+  // Fresh document load: the signin click leaves the browser's
+  // sequential-focus start point on a disconnected node after the
+  // client-side redirect — the skip link contract is about page loads.
+  await page.goto("/dashboard");
+  await expectSkipLinkFlow(page);
+});
+
+test("signin: first Tab is the skip link; activating focuses main", async ({
+  page,
+}) => {
+  await page.goto("/signin");
+  await expectSkipLinkFlow(page);
+});

--- a/web/src/app/dashboard/DashboardShell.tsx
+++ b/web/src/app/dashboard/DashboardShell.tsx
@@ -286,7 +286,11 @@ const ShellChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
               onCreate={() => router.push("/onboarding?create=1")}
               compact={effectiveCollapsed}
             />
-          ) : null
+          ) : (
+            // Pre-org reserve (CLS budget): the switcher's hydrated
+            // height, so the rail list doesn't jump down when orgs land.
+            <div aria-hidden className="h-(--widget-h-org)" />
+          )
         }
         footer={
           <div
@@ -385,7 +389,8 @@ const ShellChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
         </Dialog.Root>
       ) : null}
 
-      <main className="flex-1 overflow-y-auto">
+      {/* id/tabIndex: the SkipLink target (fleet canon P15). */}
+      <main id="main" tabIndex={-1} className="flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-[1440px] px-6 py-6">
           {activeOrg ? children : null}
         </div>

--- a/web/src/app/dashboard/OverviewView.tsx
+++ b/web/src/app/dashboard/OverviewView.tsx
@@ -99,24 +99,56 @@ export const OverviewView: React.FC = () => {
     !loading && latest.length === 0 && (current?.income ?? 0) === 0;
 
   if (loading) {
+    // The loading frame mirrors the loaded frame's geometry (CLS budget,
+    // fleet P14): every slot reserves its hydrated desktop size via the
+    // --widget-h-* tokens so the skeleton → data swap never moves layout
+    // (desktop CLS 0.071 came from the swap; mobile CLS is 0.000 and the
+    // stacked construction sizes differently, so the reserves are
+    // lg-scoped). The period-picker slot reserves too. The plain <div>
+    // root is load-bearing: returned as a bare fragment, index-based
+    // reconciliation MORPHED the loading frame's trailing slot into the
+    // loaded stat grid (a 744px node move Chrome scored as CLS 0.113) —
+    // a different root type forces a clean replace, and since the
+    // reserved geometry matches, the swap moves nothing.
     return (
-      <>
-        <PageHeader title="Overview" />
+      <div>
+        <PageHeader
+          title="Overview"
+          actions={<div aria-hidden className="h-8 w-36" />}
+        />
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {[0, 1, 2, 3].map((i) => (
-            <StatCard key={i} label="" value={0} loading />
+            <StatCard
+              key={i}
+              label=""
+              value={0}
+              loading
+              className="lg:min-h-(--widget-h-stat)"
+            />
           ))}
         </div>
         <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[2fr_1fr]">
-          <ChartLine state="loading" />
-          <ChartDonut state="loading" />
+          <div className="rounded border border-border bg-bg p-4 lg:min-h-(--widget-h-chart-card)">
+            <ChartLine state="loading" />
+          </div>
+          <div className="space-y-4">
+            <div className="rounded border border-border bg-bg p-4 lg:min-h-(--widget-h-donut-card)">
+              <ChartDonut state="loading" />
+            </div>
+            <div
+              aria-hidden
+              className="rounded border border-border bg-bg lg:min-h-(--widget-h-anomaly-card)"
+            />
+          </div>
         </div>
-        <div className="mt-4 space-y-2">
-          {[0, 1, 2, 3].map((i) => (
-            <Skeleton key={i} variant="row" />
-          ))}
+        <div className="mt-4 rounded border border-border bg-bg lg:min-h-(--widget-h-latest-card)">
+          <div className="space-y-0 p-4">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <Skeleton key={i} variant="row" />
+            ))}
+          </div>
         </div>
-      </>
+      </div>
     );
   }
 
@@ -368,6 +400,8 @@ export const OverviewView: React.FC = () => {
       >
         <Card
           fill
+          // Reserved hydrated size (CLS budget) — mirrors the loading frame.
+          className="lg:min-h-(--widget-h-chart-card)"
           // The monthly series starts at ledger onset (no fabricated
           // pre-onset months) — the title states the span it actually has.
           title={
@@ -456,7 +490,10 @@ export const OverviewView: React.FC = () => {
         </Card>
 
         <div className="space-y-4">
-          <Card title={`Expenses by category — ${donutMonthLabel}`}>
+          <Card
+            title={`Expenses by category — ${donutMonthLabel}`}
+            className="lg:min-h-(--widget-h-donut-card)"
+          >
             {donutSlices.length === 0 ? (
               <p className="text-[13px] text-text-2">
                 No expenses recorded for {donutMonthLabel}.
@@ -521,6 +558,7 @@ export const OverviewView: React.FC = () => {
 
           <Card
             title="Anomalies"
+            className="lg:min-h-(--widget-h-anomaly-card)"
             action={<Tag tint="warn" count={anomalies.length} />}
           >
             {anomalies.length === 0 ? (
@@ -561,7 +599,7 @@ export const OverviewView: React.FC = () => {
 
       <Card
         title="Latest transactions"
-        className="mt-4"
+        className="mt-4 lg:min-h-(--widget-h-latest-card)"
         action={
           <Link
             href="/dashboard/transactions"
@@ -581,6 +619,9 @@ export const OverviewView: React.FC = () => {
               aria-label="Latest transactions"
             >
               <TableHeader
+                // Rows lead with a select cell — the sr-only header keeps
+                // every td under a named th (axe `td-has-header` class).
+                selectHeader="Select"
                 columns={[
                   { id: "date", label: "Date", widthClass: "w-14" },
                   { id: "source", label: "Src", widthClass: "w-8" },

--- a/web/src/app/dashboard/imports/[jobId]/JobDetailView.tsx
+++ b/web/src/app/dashboard/imports/[jobId]/JobDetailView.tsx
@@ -303,6 +303,9 @@ export const JobDetailView: React.FC = () => {
         <table className="w-full border-separate border-spacing-0">
           <TableHeader
             sticky
+            // Rows lead with a select cell — the sr-only header keeps
+            // every td under a named th (axe `td-has-header` class).
+            selectHeader="Select"
             columns={[
               { id: "date", label: "Date", widthClass: "w-14" },
               { id: "source", label: "Src", widthClass: "w-8" },

--- a/web/src/app/dashboard/transactions/TransactionsView.tsx
+++ b/web/src/app/dashboard/transactions/TransactionsView.tsx
@@ -685,7 +685,14 @@ export const TransactionsView: React.FC = () => {
                   sortable: true,
                   widthClass: "w-32",
                 },
-                { id: "actions", label: "", widthClass: "w-20" },
+                // sr-only name (axe `empty-table-header`): the hover
+                // action cluster needs a named column, not a blank th.
+                {
+                  id: "actions",
+                  label: "Actions",
+                  srOnly: true,
+                  widthClass: "w-20",
+                },
               ]}
               sort={sort}
               onSortChange={(columnId, direction) =>

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -371,7 +371,11 @@ export const ComponentGallery: React.FC = () => {
         </button>
       </header>
 
-      <main className="mx-auto max-w-5xl space-y-2 px-6 pb-24">
+      <main
+        id="main"
+        tabIndex={-1}
+        className="mx-auto max-w-5xl space-y-2 px-6 pb-24"
+      >
         <Section title="Button">
           <Variant label="kind × md">
             <Button kind="primary">Primary</Button>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -161,6 +161,26 @@
 }
 
 /*
+ * Widget-frame reserve heights (perf pass 2026-07-21, CLS budget —
+ * fleet P14 pattern from upstat): the B1 overview loading frame reserves
+ * every slot's hydrated size so the skeleton → data swap never moves
+ * layout (desktop CLS 0.071; probe-attributed to the loading → loaded
+ * swap and the rail's org-switcher slot mounting late). Values are the
+ * RENDERED sizes of the seeded widgets (desktop 1440, TEST_MODE) —
+ * re-derive by measuring if a widget's construction changes. Consumed
+ * as `min-h-(--widget-h-*)` / `h-(--widget-h-*)`; no per-page magic
+ * numbers.
+ */
+:root {
+  --widget-h-org: 50px; /* OrgSwitcher trigger (rail slot pre-org reserve) */
+  --widget-h-stat: 170px; /* StatCard: label + 32/38 value + delta/spark */
+  --widget-h-chart-card: 541px; /* B1 cash-flow Card (header + fill plot) */
+  --widget-h-donut-card: 195px; /* donut Card (header + 120 donut + legend) */
+  --widget-h-anomaly-card: 331px; /* anomaly feed Card (3 badges + link) */
+  --widget-h-latest-card: 339px; /* latest-transactions Card (header + 5 rows) */
+}
+
+/*
  * Design-system base resets (QA loop 2026-07-18): UA button chrome
  * centers text, which corrupted left-aligned row/nav buttons. Preflight
  * does not reset text-align, so do it here in the base layer.
@@ -230,7 +250,8 @@
   /* Fix Naira symbol and other currency symbols overlapping with digits under tabular-nums by disabling contextual alternates */
   .tabular-nums {
     font-variant-numeric: tabular-nums;
-    font-feature-settings: "tnum" 1, "calt" 0;
+    font-feature-settings:
+      "tnum" 1,
+      "calt" 0;
   }
 }
-

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import { ThemeProvider, themeInitScript } from "@/design/ThemeProvider";
+import SkipLink from "@/components/ui/SkipLink";
 import "./globals.css";
 
 // Design-system type (design.md §2): Inter for UI/display (Inter Display
@@ -36,6 +37,9 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
       <body className={`${inter.variable} ${jetbrainsMono.variable}`}>
+        {/* First focusable on every route (fleet canon P15) — every
+            page's <main> carries id="main" + tabIndex={-1}. */}
+        <SkipLink />
         <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -9,7 +9,11 @@ import Link from "next/link";
  */
 const NotFound = () => (
   <div data-theme="dark" className="bg-bg-editorial">
-    <main className="mx-auto flex min-h-screen w-full max-w-[1200px] flex-col items-center justify-center px-6 py-16 text-center">
+    <main
+      id="main"
+      tabIndex={-1}
+      className="mx-auto flex min-h-screen w-full max-w-[1200px] flex-col items-center justify-center px-6 py-16 text-center"
+    >
       <p className="font-mono text-[13px] tabular-nums tracking-wide text-text-2">
         404 — page not found
       </p>

--- a/web/src/app/onboarding/OnboardingView.tsx
+++ b/web/src/app/onboarding/OnboardingView.tsx
@@ -45,7 +45,11 @@ export const OnboardingView: React.FC = () => {
   const canSubmit = kind === "personal" || name.trim().length > 0;
 
   return (
-    <main className="flex min-h-screen items-start justify-center bg-bg px-6 py-16">
+    <main
+      id="main"
+      tabIndex={-1}
+      className="flex min-h-screen items-start justify-center bg-bg px-6 py-16"
+    >
       <div className="w-full max-w-lg">
         <Wordmark className="font-display text-2xl font-bold text-text" />
         <h1 className="mt-8 font-display text-xl font-semibold tracking-tight text-text">

--- a/web/src/app/signin/SigninView.tsx
+++ b/web/src/app/signin/SigninView.tsx
@@ -17,7 +17,11 @@ const SigninView: React.FC = () => {
   const { signInWithGoogle, loading, error } = useAuthController();
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-bg px-6">
+    <main
+      id="main"
+      tabIndex={-1}
+      className="flex min-h-screen items-center justify-center bg-bg px-6"
+    >
       <div className="w-full max-w-sm">
         <Link href="/" className="mb-12 block text-center">
           <Wordmark className="font-display text-2xl font-bold text-text" />

--- a/web/src/auth/test-mode-provider.test.ts
+++ b/web/src/auth/test-mode-provider.test.ts
@@ -11,6 +11,18 @@ describe("TestModeAuthProvider (X-1, TEST_MODE)", () => {
     expect(await provider.getIdToken()).toBe("test-mode-token");
   });
 
+  it("persists under `expendit.test-session` in sessionStorage (fleet P16)", async () => {
+    const provider = new TestModeAuthProvider();
+    await provider.signInWithGoogle();
+    // Dictated canon 2026-07-21: `<product>.test-session`, sessionStorage,
+    // JSON user payload — one shape across the fleet's e2e tooling.
+    expect(
+      JSON.parse(window.sessionStorage.getItem("expendit.test-session")!),
+    ).toEqual(TEST_USER);
+    expect(window.localStorage.getItem("expendit.test-session")).toBeNull();
+    await provider.signOut();
+  });
+
   it("sign-out clears both the session and the legacy flag", async () => {
     const provider = new TestModeAuthProvider();
     await provider.signInWithGoogle();

--- a/web/src/auth/test-mode-provider.ts
+++ b/web/src/auth/test-mode-provider.ts
@@ -2,6 +2,10 @@
  * TestModeAuthProvider — NEXT_PUBLIC_TEST_MODE=1: no Firebase, sign-in
  * resolves instantly with the seeded test user and the app goes straight
  * to /dashboard (web standard — TEST_MODE).
+ *
+ * Session key convention (fleet P16, dictated canon 2026-07-21):
+ * `<product>.test-session` in **sessionStorage** — per-tab, gone on
+ * close, one shape across the fleet's e2e tooling.
  */
 
 import type { AuthProvider, AuthUser } from "./types";
@@ -18,7 +22,7 @@ export const TEST_USER: AuthUser = {
 export class TestModeAuthProvider implements AuthProvider {
   currentUser(): AuthUser | null {
     if (typeof window === "undefined") return null;
-    const raw = window.localStorage.getItem(SESSION_KEY);
+    const raw = window.sessionStorage.getItem(SESSION_KEY);
     if (!raw) return null;
     try {
       return JSON.parse(raw) as AuthUser;
@@ -29,14 +33,14 @@ export class TestModeAuthProvider implements AuthProvider {
 
   async signInWithGoogle(): Promise<AuthUser> {
     if (typeof window !== "undefined") {
-      window.localStorage.setItem(SESSION_KEY, JSON.stringify(TEST_USER));
+      window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(TEST_USER));
     }
     return TEST_USER;
   }
 
   async signOut(): Promise<void> {
     if (typeof window !== "undefined") {
-      window.localStorage.removeItem(SESSION_KEY);
+      window.sessionStorage.removeItem(SESSION_KEY);
     }
   }
 

--- a/web/src/components/docs/DocsApiView.tsx
+++ b/web/src/components/docs/DocsApiView.tsx
@@ -63,7 +63,11 @@ export const DocsApiView: React.FC = () => {
           sidebar/mobile bar below the nav and shrinks its viewport math
           to match (one coherent scroll). `isolate` opens a stacking
           context so no Scalar z-index can paint over the nav. */}
-      <main className="isolate flex-1 [--scalar-custom-header-height:56px]">
+      <main
+        id="main"
+        tabIndex={-1}
+        className="isolate flex-1 [--scalar-custom-header-height:56px]"
+      >
         <ScalarApiReferenceLazy />
       </main>
       {/* Minimal footer strip — verbatim legal line only (parity canon). */}

--- a/web/src/components/home/DemoSection.tsx
+++ b/web/src/components/home/DemoSection.tsx
@@ -10,6 +10,7 @@
  */
 
 import React from "react";
+import DeferredPanel from "@/components/ui/DeferredPanel";
 import Tabs, { TabItem, TabPanel } from "@/components/ui/Tabs";
 import Tag from "@/components/ui/Tag";
 import StatCard from "@/components/ui/StatCard";
@@ -48,172 +49,183 @@ export const DemoSection: React.FC = () => {
           </Tag>
         </div>
 
-        <Tabs
-          value={persona}
-          onValueChange={(value) => switchPersona(value as DemoPersona)}
-          kind="pill"
-          aria-label="Demo persona"
-          className="mt-6 flex flex-col items-center"
-          items={DEMO_PERSONAS.map((key) => (
-            <TabItem key={key} value={key} kind="pill">
-              {DEMO_DATASETS[key].label}
-            </TabItem>
-          ))}
-        >
-          {DEMO_PERSONAS.map((key) => (
-            <TabPanel key={key} value={key} className="w-full pt-8">
-              {key !== persona ? null : (
-                <>
-                  {/* 3-up stat row on the 384px-card / 24px-gutter rhythm,
+        {/* Below-the-fold demo chrome (charts + ledger table) mounts on
+            approach — the heading/Tag copy above stays eager (perf pass
+            2026-07-21: home mobile TBT ~310ms, hydration-dominated). The
+            reserve approximates the desktop panel so scroll geometry
+            holds until the IO fires 600px out. */}
+        <DeferredPanel minHeight={880}>
+          <Tabs
+            value={persona}
+            onValueChange={(value) => switchPersona(value as DemoPersona)}
+            kind="pill"
+            aria-label="Demo persona"
+            className="mt-6 flex flex-col items-center"
+            items={DEMO_PERSONAS.map((key) => (
+              <TabItem key={key} value={key} kind="pill">
+                {DEMO_DATASETS[key].label}
+              </TabItem>
+            ))}
+          >
+            {DEMO_PERSONAS.map((key) => (
+              <TabPanel key={key} value={key} className="w-full pt-8">
+                {key !== persona ? null : (
+                  <>
+                    {/* 3-up stat row on the 384px-card / 24px-gutter rhythm,
                       spanning the 1200px container (design.md §2 pin). */}
-                  <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
-                    <StatCard
-                      label={stats.net.label}
-                      value={stats.net.value}
-                      format={(value) => formatMoney(value)}
-                      delta={stats.net.delta}
-                      deltaCaption={dataset.deltaCaption}
-                      sparkline={stats.net.sparkline}
-                    />
-                    <StatCard
-                      label={stats.income.label}
-                      value={stats.income.value}
-                      format={(value) => formatMoney(value)}
-                      delta={stats.income.delta}
-                      deltaCaption={dataset.deltaCaption}
-                      sparkline={stats.income.sparkline}
-                    />
-                    <StatCard
-                      label={stats.expenses.label}
-                      value={stats.expenses.value}
-                      format={(value) => formatMoney(value)}
-                      delta={stats.expenses.delta}
-                      deltaCaption={dataset.deltaCaption}
-                      sparkline={stats.expenses.sparkline}
-                    />
-                  </div>
-
-                  <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[3fr_2fr]">
-                    <div className="rounded border border-border bg-bg p-4">
-                      <div className="mb-3 flex items-center justify-between">
-                        <span className="text-[13px] font-medium text-text">
-                          Cash flow — 12 months
-                        </span>
-                        {/* Chart data-table parity toggle (design.md §5). */}
-                        <button
-                          type="button"
-                          onClick={toggleDataTable}
-                          aria-pressed={showDataTable}
-                          className="rounded border border-border px-2 py-0.5 text-[11px] font-medium text-text-2 transition-colors duration-fast ease-standard hover:bg-bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                        >
-                          Data table
-                        </button>
-                      </div>
-                      {showDataTable ? (
-                        <table className="w-full text-[13px]">
-                          <caption className="sr-only">
-                            Cash flow by month
-                          </caption>
-                          <thead>
-                            <tr className="border-b border-border text-left text-text-2">
-                              <th scope="col" className="py-1 font-medium">
-                                Month
-                              </th>
-                              <th
-                                scope="col"
-                                className="py-1 text-right font-medium"
-                              >
-                                Net cash flow
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {dataset.cashflow.points.map((value, index) => (
-                              // Months run Aug → Jul (trailing 12).
-                              <tr
-                                key={index}
-                                className="border-b border-border last:border-0"
-                              >
-                                <td className="py-1 text-text-2">
-                                  M{index + 1}
-                                </td>
-                                <td className="py-1 text-right tabular-nums text-text">
-                                  {formatMoney(value)}
-                                </td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      ) : (
-                        <ChartLine
-                          series={[
-                            {
-                              id: "cashflow",
-                              label: "Net cash flow",
-                              color: "accent",
-                              points: dataset.cashflow.points,
-                            },
-                          ]}
-                          xLabels={dataset.cashflow.xLabels}
-                          height={200}
-                        />
-                      )}
-                    </div>
-                    <div className="rounded border border-border bg-bg p-4">
-                      <div className="mb-3 text-[13px] font-medium text-text">
-                        Expenses by category
-                      </div>
-                      <div className="flex flex-wrap items-center gap-5">
-                        <ChartDonut
-                          slices={dataset.donut.slices}
-                          centerTotal={dataset.donut.centerTotal}
-                          centerCaption="Expenses"
-                          legend="none"
-                        />
-                        <DonutLegend
-                          slices={dataset.donut.slices}
-                          className="min-w-[220px] flex-1"
-                        />
-                      </div>
-                    </div>
-                  </div>
-
-                  <div
-                    data-testid="demo-table"
-                    className="mt-6 overflow-x-auto rounded border border-border bg-bg"
-                  >
-                    <table
-                      aria-label="Demo transactions"
-                      className="w-full min-w-[720px]"
-                    >
-                      <TableHeader
-                        columns={TXN_COLUMNS}
-                        sort={{ columnId: "date", direction: "desc" }}
+                    <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+                      <StatCard
+                        label={stats.net.label}
+                        value={stats.net.value}
+                        format={(value) => formatMoney(value)}
+                        delta={stats.net.delta}
+                        deltaCaption={dataset.deltaCaption}
+                        sparkline={stats.net.sparkline}
                       />
-                      <tbody className="contents">
-                        {txns.map((txn) => (
-                          <TxnTableRow
-                            key={txn.id}
-                            txn={toTxnEntry(txn)}
-                            category={
-                              dataset.categories.find(
-                                (category) => category.id === txn.categoryId,
-                              ) ?? dataset.categories[0]
-                            }
-                            categoryOptions={dataset.categories}
-                            onCategorySelect={(categoryId) =>
-                              recategorize(txn.id, categoryId)
-                            }
+                      <StatCard
+                        label={stats.income.label}
+                        value={stats.income.value}
+                        format={(value) => formatMoney(value)}
+                        delta={stats.income.delta}
+                        deltaCaption={dataset.deltaCaption}
+                        sparkline={stats.income.sparkline}
+                      />
+                      <StatCard
+                        label={stats.expenses.label}
+                        value={stats.expenses.value}
+                        format={(value) => formatMoney(value)}
+                        delta={stats.expenses.delta}
+                        deltaCaption={dataset.deltaCaption}
+                        sparkline={stats.expenses.sparkline}
+                      />
+                    </div>
+
+                    <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[3fr_2fr]">
+                      <div className="rounded border border-border bg-bg p-4">
+                        <div className="mb-3 flex items-center justify-between">
+                          <span className="text-[13px] font-medium text-text">
+                            Cash flow — 12 months
+                          </span>
+                          {/* Chart data-table parity toggle (design.md §5). */}
+                          <button
+                            type="button"
+                            onClick={toggleDataTable}
+                            aria-pressed={showDataTable}
+                            className="rounded border border-border px-2 py-0.5 text-[11px] font-medium text-text-2 transition-colors duration-fast ease-standard hover:bg-bg-elev hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                          >
+                            Data table
+                          </button>
+                        </div>
+                        {showDataTable ? (
+                          <table className="w-full text-[13px]">
+                            <caption className="sr-only">
+                              Cash flow by month
+                            </caption>
+                            <thead>
+                              <tr className="border-b border-border text-left text-text-2">
+                                <th scope="col" className="py-1 font-medium">
+                                  Month
+                                </th>
+                                <th
+                                  scope="col"
+                                  className="py-1 text-right font-medium"
+                                >
+                                  Net cash flow
+                                </th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {dataset.cashflow.points.map((value, index) => (
+                                // Months run Aug → Jul (trailing 12).
+                                <tr
+                                  key={index}
+                                  className="border-b border-border last:border-0"
+                                >
+                                  <td className="py-1 text-text-2">
+                                    M{index + 1}
+                                  </td>
+                                  <td className="py-1 text-right tabular-nums text-text">
+                                    {formatMoney(value)}
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        ) : (
+                          <ChartLine
+                            series={[
+                              {
+                                id: "cashflow",
+                                label: "Net cash flow",
+                                color: "accent",
+                                points: dataset.cashflow.points,
+                              },
+                            ]}
+                            xLabels={dataset.cashflow.xLabels}
+                            height={200}
                           />
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                </>
-              )}
-            </TabPanel>
-          ))}
-        </Tabs>
+                        )}
+                      </div>
+                      <div className="rounded border border-border bg-bg p-4">
+                        <div className="mb-3 text-[13px] font-medium text-text">
+                          Expenses by category
+                        </div>
+                        <div className="flex flex-wrap items-center gap-5">
+                          <ChartDonut
+                            slices={dataset.donut.slices}
+                            centerTotal={dataset.donut.centerTotal}
+                            centerCaption="Expenses"
+                            legend="none"
+                          />
+                          <DonutLegend
+                            slices={dataset.donut.slices}
+                            className="min-w-[220px] flex-1"
+                          />
+                        </div>
+                      </div>
+                    </div>
+
+                    <div
+                      data-testid="demo-table"
+                      className="mt-6 overflow-x-auto rounded border border-border bg-bg"
+                    >
+                      <table
+                        aria-label="Demo transactions"
+                        className="w-full min-w-[720px]"
+                      >
+                        <TableHeader
+                          columns={TXN_COLUMNS}
+                          // Rows lead with a select cell — the sr-only
+                          // header keeps every td under a named th (axe
+                          // `td-has-header`, 2026-07-21 audit).
+                          selectHeader="Select"
+                          sort={{ columnId: "date", direction: "desc" }}
+                        />
+                        <tbody className="contents">
+                          {txns.map((txn) => (
+                            <TxnTableRow
+                              key={txn.id}
+                              txn={toTxnEntry(txn)}
+                              category={
+                                dataset.categories.find(
+                                  (category) => category.id === txn.categoryId,
+                                ) ?? dataset.categories[0]
+                              }
+                              categoryOptions={dataset.categories}
+                              onCategorySelect={(categoryId) =>
+                                recategorize(txn.id, categoryId)
+                              }
+                            />
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </>
+                )}
+              </TabPanel>
+            ))}
+          </Tabs>
+        </DeferredPanel>
       </SectionInner>
     </section>
   );

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -148,8 +148,9 @@ export const HomeView: React.FC = () => {
         </div>
       ) : null}
 
-      {/* The page's one main landmark — everything but the nav + footer. */}
-      <main>
+      {/* The page's one main landmark — everything but the nav + footer.
+          id/tabIndex: the SkipLink target (fleet canon P15). */}
+      <main id="main" tabIndex={-1}>
         <div ref={heroRef}>
           <HeroSection
             nav={<MarketingNav variant="on-dark" {...navProps} />}

--- a/web/src/components/home/HowItWorksSection.tsx
+++ b/web/src/components/home/HowItWorksSection.tsx
@@ -8,6 +8,7 @@
  */
 
 import React from "react";
+import DeferredPanel from "@/components/ui/DeferredPanel";
 import { useAnalyticsController } from "@/controllers/use-analytics";
 import { SectionHeading, SectionInner } from "./Section";
 import ScaledEmbed from "./ScaledEmbed";
@@ -92,9 +93,15 @@ export const HowItWorksSection: React.FC = () => {
                 data-testid="how-thumb"
                 className="relative aspect-[384/190] overflow-hidden rounded border border-border bg-bg transition-transform duration-base ease-standard hover:-translate-y-0.5 motion-reduce:hover:translate-y-0"
               >
-                <div inert className="pointer-events-none select-none">
-                  {step.thumb}
-                </div>
+                {/* The three thumbs are full dashboard compositions —
+                    below-the-fold, they mount on approach (perf pass
+                    2026-07-21). The aspect box above reserves the
+                    geometry, so the placeholder just fills it. */}
+                <DeferredPanel minHeight="100%" className="h-full">
+                  <div inert className="pointer-events-none select-none">
+                    {step.thumb}
+                  </div>
+                </DeferredPanel>
                 <a
                   href={`#${ANCHORS.demo}`}
                   onClick={scrollToDemo}

--- a/web/src/components/home/embeds.tsx
+++ b/web/src/components/home/embeds.tsx
@@ -331,6 +331,9 @@ export const DashboardEmbed: React.FC = () => {
             <TableHeader
               columns={TXN_COLUMNS}
               density="compact"
+              // Rows lead with a select cell — the sr-only header keeps
+              // every td under a named th (axe `td-has-header`).
+              selectHeader="Select"
               sort={{ columnId: "date", direction: "desc" }}
             />
             <tbody className="contents">
@@ -373,6 +376,8 @@ export const ImportReviewEmbed: React.FC = () => {
             <TableHeader
               columns={TXN_COLUMNS}
               density="compact"
+              // Same select-cell alignment as the hero embed's table.
+              selectHeader="Select"
               sort={{ columnId: "date", direction: "desc" }}
             />
             <tbody className="contents">

--- a/web/src/components/ui/CodeSnippet.test.tsx
+++ b/web/src/components/ui/CodeSnippet.test.tsx
@@ -72,6 +72,23 @@ describe("CodeSnippet (design.md §8.2b)", () => {
     ).toBeInTheDocument();
   });
 
+  it("tabbed mode: multi-word labels produce valid IDREFs (slugified values)", () => {
+    // 2026-07-21 a11y audit: `value={tab.label}` put the "Docker Compose"
+    // space into Radix's trigger/panel ids — aria-controls became an
+    // invalid IDREF (axe `aria-valid-attr-value` critical on home).
+    render(<CodeSnippet tabs={TABS} />);
+    for (const tab of screen.getAllByRole("tab")) {
+      const controls = tab.getAttribute("aria-controls");
+      expect(controls).toBeTruthy();
+      // A single valid IDREF: no whitespace anywhere in the id.
+      expect(controls).not.toMatch(/\s/);
+      expect(tab.id).not.toMatch(/\s/);
+    }
+    const panel = screen.getByRole("tabpanel");
+    expect(panel.id).not.toMatch(/\s/);
+    expect(panel.getAttribute("aria-labelledby")).not.toMatch(/\s/);
+  });
+
   it("tabbed mode: arrow keys rove focus across the tablist (Radix)", async () => {
     render(<CodeSnippet tabs={TABS} />);
     const docker = screen.getByRole("tab", { name: "Docker Compose" });

--- a/web/src/components/ui/CodeSnippet.tsx
+++ b/web/src/components/ui/CodeSnippet.tsx
@@ -22,6 +22,19 @@ export interface CodeSnippetTab {
   code: string;
 }
 
+/**
+ * Stable Tabs `value` for a tab label. Radix builds trigger/panel ids
+ * (and the aria-controls IDREF between them) from the value — a display
+ * label like "Docker Compose" put a space into the IDREF, an axe
+ * `aria-valid-attr-value` critical (2026-07-21 audit). Slugified values
+ * keep the ids valid while the label stays free-form for display.
+ */
+const tabValue = (label: string): string =>
+  label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+
 export interface CodeSnippetProps {
   /** Single-block mode. */
   code?: string;
@@ -42,7 +55,9 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({
   className,
 }) => {
   const [copied, setCopied] = useState(false);
-  const [activeLabel, setActiveLabel] = useState(tabs?.[0]?.label ?? "");
+  const [activeValue, setActiveValue] = useState(
+    tabs?.[0] ? tabValue(tabs[0].label) : "",
+  );
 
   useEffect(() => {
     if (!copied) return;
@@ -51,7 +66,7 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({
   }, [copied]);
 
   const activeCode = tabs?.length
-    ? (tabs.find((tab) => tab.label === activeLabel) ?? tabs[0]).code
+    ? (tabs.find((tab) => tabValue(tab.label) === activeValue) ?? tabs[0]).code
     : (code ?? "");
 
   const onCopy = async () => {
@@ -73,9 +88,9 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({
         )}
       >
         <RadixTabs.Root
-          value={activeLabel}
+          value={activeValue}
           onValueChange={(value) => {
-            setActiveLabel(value);
+            setActiveValue(value);
             setCopied(false);
           }}
         >
@@ -87,7 +102,7 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({
               {tabs.map((tab) => (
                 <RadixTabs.Trigger
                   key={tab.label}
-                  value={tab.label}
+                  value={tabValue(tab.label)}
                   className={cn(
                     "group flex flex-col gap-1 text-[13px] font-medium",
                     "text-text-2 transition-colors duration-fast ease-standard",
@@ -124,7 +139,7 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({
           {tabs.map((tab) => (
             <RadixTabs.Content
               key={tab.label}
-              value={tab.label}
+              value={tabValue(tab.label)}
               className="focus:outline-none"
             >
               <pre

--- a/web/src/components/ui/DeferredPanel.test.tsx
+++ b/web/src/components/ui/DeferredPanel.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import DeferredPanel from "./DeferredPanel";
+
+/** Controllable IntersectionObserver stub (jsdom has none). */
+class ObserverStub {
+  static instances: ObserverStub[] = [];
+  callback: IntersectionObserverCallback;
+  observed: Element[] = [];
+  constructor(cb: IntersectionObserverCallback) {
+    this.callback = cb;
+    ObserverStub.instances.push(this);
+  }
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+  disconnect() {}
+  intersect() {
+    this.callback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+afterEach(() => {
+  ObserverStub.instances = [];
+  vi.unstubAllGlobals();
+});
+
+describe("DeferredPanel (perf pass 2026-07-21)", () => {
+  it("reserves min-height and defers children until intersection", () => {
+    vi.stubGlobal("IntersectionObserver", ObserverStub);
+    const { container } = render(
+      <DeferredPanel minHeight={220}>
+        <p>demo panel</p>
+      </DeferredPanel>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper).toHaveAttribute("data-deferred", "pending");
+    expect(wrapper.style.minHeight).toBe("220px");
+    expect(screen.queryByText("demo panel")).toBeNull();
+
+    act(() => ObserverStub.instances[0].intersect());
+    expect(screen.getByText("demo panel")).toBeInTheDocument();
+    expect(wrapper).toHaveAttribute("data-deferred", "mounted");
+    // the reserve hands over to the real content's own height
+    expect(wrapper.style.minHeight).toBe("");
+  });
+
+  it("mounts immediately where IntersectionObserver is unavailable", () => {
+    render(
+      <DeferredPanel minHeight={100}>
+        <p>fallback content</p>
+      </DeferredPanel>,
+    );
+    expect(screen.getByText("fallback content")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ui/DeferredPanel.tsx
+++ b/web/src/components/ui/DeferredPanel.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * DeferredPanel — visibility-gated mount for below-the-fold demo panels
+ * (perf pass 2026-07-21, fleet pattern from upstat). The home page
+ * hydrated every demo panel eagerly — the A5 persona demo (charts +
+ * ledger table) and the three A5a screen-thumb compositions executed
+ * inside the load window (live mobile TBT ~310ms). Prerender and first
+ * client render emit only a height-reserving placeholder; the real
+ * subtree mounts when it approaches the viewport. Environments without
+ * IntersectionObserver mount immediately.
+ *
+ * Marketing-copy sections stay OUTSIDE these wrappers — deferral is for
+ * illustrative panels whose markup carries no SEO weight. Above-the-fold
+ * panels (the A2 hero embed) stay eager.
+ */
+
+import React, { startTransition, useEffect, useRef, useState } from "react";
+
+export interface DeferredPanelProps {
+  /**
+   * Reserved footprint until the panel mounts (number = px). Mounting
+   * happens `rootMargin` before the panel scrolls into view, so the
+   * reserve only needs to hold the page's scroll geometry — off-viewport
+   * swaps contribute nothing to CLS.
+   */
+  minHeight: number | string;
+  /** How far outside the viewport to start mounting. */
+  rootMargin?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const DeferredPanel: React.FC<DeferredPanelProps> = ({
+  minHeight,
+  rootMargin = "600px 0px",
+  children,
+  className,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    if (mounted) return;
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === "undefined") {
+      setMounted(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          // transition: a fast scroll can trip several observers at once —
+          // the heavy subtree mounts must stay interruptible so they never
+          // starve a router navigation (the home CTA handoff).
+          startTransition(() => setMounted(true));
+        }
+      },
+      { rootMargin },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [mounted, rootMargin]);
+
+  return (
+    <div
+      ref={ref}
+      data-deferred={mounted ? "mounted" : "pending"}
+      className={className}
+      style={mounted ? undefined : { minHeight }}
+    >
+      {mounted ? children : null}
+    </div>
+  );
+};
+
+export default DeferredPanel;

--- a/web/src/components/ui/PeriodPicker.tsx
+++ b/web/src/components/ui/PeriodPicker.tsx
@@ -180,6 +180,7 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   // Master collision contract (467:11039): flip above when room below
   // runs out (never cover the field), cap + scroll when neither side
   // fits, keep right-anchored triggers right-anchored (the Overview
@@ -220,6 +221,51 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
       document.removeEventListener("keydown", onKeyDown);
     };
   }, [open]);
+
+  // Focus moves INTO the panel on open (org overlay contract — dialog
+  // canon: focus in, contain Tab, Escape restores). The grammar input is
+  // the first stop (the typing path). A plain autoFocus can't do this:
+  // the panel mounts visibility:hidden for the placement measure and
+  // focus() on a hidden element is a no-op — so focus lands once the
+  // placement paints. The contains() guard keeps resize re-measures from
+  // re-stealing focus the user has since moved within the panel.
+  useEffect(() => {
+    if (!open || placement === null) return;
+    if (panelRef.current?.contains(document.activeElement)) return;
+    inputRef.current?.focus();
+  }, [open, placement]);
+
+  /**
+   * Tab containment (org overlay contract): while open, the popover is a
+   * focus boundary — Tab from the last control wraps to the first and
+   * Shift+Tab mirrors it, never walking out into the page behind (a11y
+   * audit: 6 of 14 tabs escaped the open panel). The roving day grid
+   * keeps its single tab stop via the tabIndex filter.
+   */
+  const onPanelKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key !== "Tab") return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const focusables = Array.from(
+      panel.querySelectorAll<HTMLElement>(
+        "button:not([disabled]), input:not([disabled]), [tabindex]",
+      ),
+    ).filter((el) => el.tabIndex >= 0);
+    if (focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+    if (event.shiftKey && (active === first || !panel.contains(active))) {
+      event.preventDefault();
+      last.focus();
+    } else if (
+      !event.shiftKey &&
+      (active === last || !panel.contains(active))
+    ) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
 
   const commit = (next: string) => {
     if (!isValidPeriod(mode, next)) {
@@ -304,6 +350,7 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
           ref={panelRef}
           role="dialog"
           aria-label={`Pick ${mode}`}
+          onKeyDown={onPanelKeyDown}
           style={{
             // Cap + internal scroll when neither side fits the panel —
             // it must never exceed the viewport or grow the document.
@@ -373,7 +420,7 @@ export const PeriodPicker: React.FC<PeriodPickerProps> = ({
           <label className="mt-2.5 block border-t border-border pt-2 text-[11px] font-medium uppercase tracking-wide text-text-2">
             {mode}
             <input
-              autoFocus
+              ref={inputRef}
               value={draft}
               onChange={(event) => setDraft(event.target.value)}
               onKeyDown={(event) => {

--- a/web/src/components/ui/SkipLink.test.tsx
+++ b/web/src/components/ui/SkipLink.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SkipLink from "./SkipLink";
+
+describe("SkipLink (fleet canon P15)", () => {
+  it("targets #main and stays visually hidden until focused", () => {
+    render(<SkipLink />);
+    const link = screen.getByRole("link", { name: "Skip to main content" });
+    expect(link).toHaveAttribute("href", "#main");
+    // Hidden-until-focus construction: sr-only with a focus escape hatch.
+    expect(link.className).toContain("sr-only");
+    expect(link.className).toContain("focus:not-sr-only");
+  });
+});

--- a/web/src/components/ui/SkipLink.tsx
+++ b/web/src/components/ui/SkipLink.tsx
@@ -1,0 +1,24 @@
+/**
+ * SkipLink — fleet canon (a11y audit 2026-07-21, P15): the first
+ * focusable element on every route; visually hidden until keyboard
+ * focus, then a small pill at the top-left. Targets the page's
+ * `<main id="main" tabIndex={-1}>` so activation moves focus into the
+ * content past the navigation chrome.
+ *
+ * Construction is shared across the fleet — tokens only, no
+ * product-specific classes — so the file stays byte-identical in every
+ * product.
+ */
+
+import React from "react";
+
+export const SkipLink: React.FC = () => (
+  <a
+    href="#main"
+    className="sr-only focus:not-sr-only focus:fixed focus:left-2 focus:top-2 focus:z-toast focus:rounded focus:border focus:border-border focus:bg-bg focus:px-3 focus:py-2 focus:text-[13px] focus:font-medium focus:text-text focus:outline-none focus:ring-2 focus:ring-accent"
+  >
+    Skip to main content
+  </a>
+);
+
+export default SkipLink;

--- a/web/src/components/ui/TableHeader.test.tsx
+++ b/web/src/components/ui/TableHeader.test.tsx
@@ -83,5 +83,32 @@ describe("TableHeader (design.md §8.2b)", () => {
     expect(box).toHaveAttribute("aria-checked", "mixed");
     await userEvent.click(box);
     expect(onCheckedChange).toHaveBeenCalled();
+    // The th itself carries the name too (axe `empty-table-header`:
+    // the checkbox's aria-label doesn't name the cell). Regex: the
+    // cell's name concatenates the sr-only text with the checkbox's.
+    expect(
+      screen.getByRole("columnheader", { name: /Select all transactions/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("selectHeader renders an sr-only named th for select-cell rows", () => {
+    // axe `td-has-header` class (2026-07-21 audit): demo/read-only tables
+    // pair TxnTableRow select cells with a header that had no matching th.
+    render(<TableHeader columns={columns} selectHeader="Select" />);
+    const th = screen.getByRole("columnheader", { name: "Select" });
+    expect(th).toHaveClass("w-4");
+  });
+
+  it("srOnly columns name the th without visible text (actions column)", () => {
+    render(
+      <TableHeader
+        columns={[
+          ...columns,
+          { id: "actions", label: "Actions", srOnly: true },
+        ]}
+      />,
+    );
+    const th = screen.getByRole("columnheader", { name: "Actions" });
+    expect(th.querySelector("span")).toHaveClass("sr-only");
   });
 });

--- a/web/src/components/ui/TableHeader.tsx
+++ b/web/src/components/ui/TableHeader.tsx
@@ -21,6 +21,12 @@ export interface TableColumn {
   sortable?: boolean;
   /** Fixed width class, e.g. "w-32". */
   widthClass?: string;
+  /**
+   * Visually hidden label (a11y audit: the actions column shipped an
+   * empty `<th>` — axe `empty-table-header`). The column keeps its
+   * width; the name reads to AT only.
+   */
+  srOnly?: boolean;
 }
 
 export interface TableHeaderProps {
@@ -35,6 +41,14 @@ export interface TableHeaderProps {
     onCheckedChange: (checked: boolean | "indeterminate") => void;
     label: string;
   };
+  /**
+   * Presentational select-column header (sr-only name, checkbox-width
+   * spacer) for tables whose rows carry select cells but no select-all
+   * control — the demo/read-only TxnTableRow surfaces. Without it the
+   * leading checkbox cell shifts every row one column past the header
+   * (axe `td-has-header` on the home demo table, 2026-07-21 audit).
+   */
+  selectHeader?: string;
   sticky?: boolean;
   className?: string;
 }
@@ -48,6 +62,7 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
   sort = null,
   onSortChange,
   selectAll,
+  selectHeader,
   sticky = false,
   className,
 }) => (
@@ -66,11 +81,20 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
     >
       {selectAll ? (
         <th scope="col" className="flex shrink-0 items-center">
+          {/* sr-only text names the th itself (axe `empty-table-header`:
+              the checkbox's aria-label doesn't reach the cell). */}
+          <span className="sr-only">{selectAll.label}</span>
           <Checkbox
             aria-label={selectAll.label}
             checked={selectAll.checked}
             onCheckedChange={selectAll.onCheckedChange}
           />
+        </th>
+      ) : selectHeader ? (
+        // Checkbox-width spacer (h-4/w-4 Checkbox root) keeps the header
+        // grid aligned with the rows' leading select cells.
+        <th scope="col" className="flex w-4 shrink-0 items-center">
+          <span className="sr-only">{selectHeader}</span>
         </th>
       ) : null}
       {columns.map((column) => {
@@ -79,7 +103,9 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
         const label = (
           <span
             className={cn(
-              "text-[11px] font-medium uppercase tracking-wide text-text-2",
+              column.srOnly
+                ? "sr-only"
+                : "text-[11px] font-medium uppercase tracking-wide text-text-2",
               column.numeric && "tabular-nums",
             )}
           >


### PR DESCRIPTION
Closes the expendit gaps on the 2026-07-21 a11y/perf audit ledger (web program closeout).

## Ledger items

| # | Item | Status |
|---|---|---|
| 1 | AXE CRITICAL — CodeSnippet Radix Tabs invalid IDREF (`aria-valid-attr-value`) | Fixed — slugified stable tab values, label stays display-only; unit lock + new `axe-home` e2e gate (zero criticals + ARIA/name/table rule lock) |
| 2 | MAJOR — DatePicker popover focus containment | Fixed — focus moves in on open (grammar input; `autoFocus` was a no-op against the visibility-hidden placement measure), Tab contained with wrap both ways, Escape still closes + restores trigger; probe-shape e2e lock |
| 3 | `td-has-header` — demo/embed txn tables | Fixed — `TableHeader` `selectHeader` slot: checkbox-width sr-only `<th scope="col">` aligns the rows' leading select cells (wired: home demo, hero + import embeds, overview latest, import job detail) |
| 4 | `empty-table-header` ×2 — select-all + actions `<th>` | Fixed — sr-only text names the select-all th; `srOnly` column renders a named, visually hidden Actions th |
| 5 | Unnamed demo-mock icon buttons on home | Verified clean — the checkbox family got names in the earlier Checkbox-API pass and the hero/thumb embeds are `inert`; axe `button-name` = 0 on home (locked by the new gate) |
| 6 | Home mobile TBT ~310ms | Fixed — `DeferredPanel` port (IO-gated mount 600px out, `startTransition`, height-reserving placeholder): A5 persona demo + 3 A5a screen thumbs defer; copy/headings and the A2 hero embed stay eager |
| 7 | Overview desktop CLS 0.071 | Fixed — measured `--widget-h-*` reserve tokens (lg-scoped) + loading frame mirrors the loaded frame slot-for-slot; the loading return gets a `<div>` root because bare-fragment index reconciliation morphed its trailing slot into the loaded stat grid (a 744px node move Chrome scored as CLS 0.113); rail org-switcher slot reserved pre-org. Probe (1440, TEST_MODE prod): **0.0704 → 0.0004** |
| 8 | P15 skip link (fleet canon) | Fixed — `ui/SkipLink.tsx` (minimal, tokens only, byte-identical construction for sibling lanes), first focusable in the root layout, every route `<main id="main" tabIndex={-1}>`; e2e: first Tab lands on it on `/`, `/signin`, `/dashboard`; Enter focuses `main#main` |
| 9 | P16 TEST_MODE key convergence | Fixed — `expendit.test-session` moves localStorage → **sessionStorage** (value semantics unchanged); no e2e helper read the key directly; unit lock + web-implementation.md §5 note |
| 10 | Serif font subset | Moot — no serif family exists in the `next/font` config (Inter + JetBrains Mono only, both already latin-subset); the ledger nit doesn't apply at current main |

## axe before/after (1440, TEST_MODE, default theme)

| Surface | Before (origin/main) | After |
|---|---|---|
| `/` (home, deferred panels mounted) | **critical `aria-valid-attr-value` ×1**, moderate `landmark-unique` ×1, serious `color-contrast` ×4 | moderate `landmark-unique` ×1, serious `color-contrast` ×4 |
| `/dashboard/transactions` | minor `empty-table-header` ×1, serious `color-contrast` ×1 | serious `color-contrast` ×1 |

Remaining `color-contrast` (serious) + `landmark-unique` (moderate) are pre-existing and outside this closeout's items (contrast is the token workstream; nav-label dedupe is the ledger's separate minor finding).

## Perf evidence

- Overview CLS probe (layout-shift observer, 1440×900, TEST_MODE prod build, ×3 runs): before 0.0704 / 0.0704 / 0.0708 → after 0.0000 / 0.0004 / 0.0004 (residual = 3px scrollbar-appearance shift).
- Home: A5 demo + A5a thumbs now mount on approach (`data-deferred` gates); prerender keeps headings/copy for SEO.

## Gates

prettier ✓ · eslint ✓ · boundaries ✓ (342 files) · typecheck ✓ · vitest 477/477 ✓ · `next build` ✓ · Playwright 87 passed, 1 skipped (pre-existing) on PW_PORT=4441 ✓ — branch rebased on origin/main (post #259).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
