### PR TITLE
chore(web): closeout final — unique nav landmarks + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   (#257).
 
 ### Fixed
+- Accessibility closeout: valid tab IDREFs in code snippets, date-picker
+  popover focus containment, named table headers, a skip-to-content link,
+  distinct nav landmark labels, and deferred below-the-fold demo panels
+  cutting home mobile blocking time; overview layout shift drops to ~0
+  (#260).
 - Contrast-token canon: AA-compliant `-text` variants for the tinted-chip
   recipe so tinted text clears 4.5:1 in both themes (#254).
 - Signin's legal links now point at the canonical Cuesoft policies, and the

--- a/web/e2e/axe-home.spec.ts
+++ b/web/e2e/axe-home.spec.ts
@@ -18,6 +18,7 @@ const LOCKED_RULES = [
   "button-name",
   "td-has-header",
   "empty-table-header",
+  "landmark-unique",
 ];
 
 test("home has zero critical axe violations (ARIA IDREF + name lock)", async ({

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -144,7 +144,11 @@ export const HomeView: React.FC = () => {
       {/* Sticky dark-on-light nav appears once the hero is scrolled. */}
       {pastHero ? (
         <div className="fixed inset-x-0 top-0 z-sticky animate-fade-in motion-reduce:animate-none">
-          <MarketingNav variant="dark-on-light" {...navProps} />
+          <MarketingNav
+            variant="dark-on-light"
+            ariaLabel="Marketing, sticky"
+            {...navProps}
+          />
         </div>
       ) : null}
 

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -32,6 +32,9 @@ export interface MarketingNavLink {
 export interface MarketingNavProps {
   /** on-dark: over the hero; dark-on-light: post-hero sticky scroll. */
   variant?: "on-dark" | "dark-on-light";
+  /** Landmark label — must be unique when two navs coexist in the DOM
+      (the sticky post-hero copy shares the page with the hero nav). */
+  ariaLabel?: string;
   /** The 4 canonical links (GitHub carries `star: true`). */
   links?: MarketingNavLink[];
   /** Trailing slot before the CTAs (the theme toggle). */
@@ -63,6 +66,7 @@ const GitHubMark: React.FC<{ className?: string }> = ({ className }) => (
 
 export const MarketingNav: React.FC<MarketingNavProps> = ({
   variant = "on-dark",
+  ariaLabel = "Marketing",
   links = [],
   trailing,
   starCount = null,
@@ -157,7 +161,7 @@ export const MarketingNav: React.FC<MarketingNavProps> = ({
 
   return (
     <nav
-      aria-label="Marketing"
+      aria-label={ariaLabel}
       data-variant={variant}
       // on-dark: dark token mode scoped to the nav subtree (both themes).
       data-theme={onDark ? "dark" : undefined}


### PR DESCRIPTION
Closes the last expendit ledger residue: HomeView's two MarketingNavs (hero + sticky) shared the "Marketing" landmark label — the sticky copy is now "Marketing, sticky" via a new ariaLabel prop, and the axe-home gate locks landmark-unique. Changelog gains the #260 closeout entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)