### PR TITLE
chore(web): deferral-register sweep — intent-based rail prefetch, web manifest, SkipLink canon, RatioGauge delta fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- Dashboard rail prefetch is intent-based: a pillar's chunks load on the
+  first hover/focus of its nav item instead of on viewport entry, so a cold
+  dashboard route ships only its own chunk set (~204K vs ~355K settled JS
+  on accounts) with navigation latency unchanged (#262).
+- The skip link converges on the fleet-canonical construction
+  ("Skip to content") (#262).
 - Mock-data module renamed `src/mock/` → `src/mocks/` for tree-shape parity
   with the sibling repos (#256).
 - `/docs/api`'s Scalar reference now loads on user intent instead of shipping
@@ -16,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   (#257).
 
 ### Fixed
+- Ratio gauges format the period delta (2dp ratio convention, or the
+  metric's own style — days stay integer) instead of printing the raw
+  float (#262).
 - Accessibility closeout: valid tab IDREFs in code snippets, date-picker
   popover focus containment, named table headers, a skip-to-content link,
   distinct nav landmark labels, and deferred below-the-fold demo panels
@@ -28,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   (#258).
 
 ### Added
+- Web app manifest at `/manifest.webmanifest`: product identity, token
+  colors and the brand icons; the fleet SEO spec now locks it (#262).
 - Settings goes route-backed tabs: Organization | Members | Data & privacy |
   Notifications, each deep-linkable (#240).
 - Categories gains an Archive tab: routed Active | Archive registry views

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -292,25 +292,31 @@ budget (measured + 20% headroom, CDP-recorded encoded transfer; CI
 prod build only) AND that intent still mounts the full reference with
 the spec fetch intact.
 
-**Dashboard chunk audit (2026-07-21, adjudicated from the fleet perf
-audit P13 — expendit dashboards were the fleet's heaviest at 337–347K
-encoded / 73–92 requests per route).** Findings, network-recorded on
-the TEST_MODE prod build (cold cache per route): the audit's suspects
-do not exist — there is NO charting library (dashboard charts are
-hand-rolled SVG in app code) and NO xlsx dependency (imports parse CSV
-with app code); the dependency graph is radix + lucide + date-fns +
-clsx only. Route-level code splitting is healthy: each pillar view is
-its own small chunk (~5–8K gz) referenced only by its route. The
-uniform ~342K per route decomposes as (a) the framework floor shared
-with every page (react-dom ~70K enc + Next runtime/router ~60K +
-radix/lucide/shared-UI ~40K — /signin measures 237K settled with zero
-dashboard code), and (b) ~100K of Next segment-prefetch freight: the
-nav rail links every pillar, and App Router prefetch pulls sibling
-route chunks, converging every dashboard route to the same union set
-(the 73–92 requests are these many small turbopack chunks). Both are
-by design; no diet applied — disabling rail prefetch or force-splitting
-the shell would trade navigation latency for lab numbers, and the
-interaction-gated candidates are immaterial (CommandPalette ~2K gz).
+**Dashboard bundle truth (perf P13 — audited 2026-07-21, rail
+prefetch revised to intent-based the same day).** Network-recorded on
+the TEST_MODE prod build (CDP encoded transfer, cold cache per route):
+the fleet audit's suspects do not exist — there is NO charting library
+(dashboard charts are hand-rolled SVG in app code) and NO xlsx
+dependency (imports parse CSV with app code); the dependency graph is
+radix + lucide + date-fns + clsx only. Route-level code splitting is
+healthy: each pillar view is its own small chunk (~5–8K gz) referenced
+only by its route. A dashboard route's settled JS is (a) the framework
+floor shared with every page (react-dom ~70K enc + Next runtime/router
+~60K + radix/lucide/shared-UI ~40K — /signin measures 237K settled
+with zero dashboard code) plus (b) the route's own pillar chunk set.
+Rail prefetch is INTENT-BASED: the rail's Links set `prefetch={false}`
+(App Router's viewport pass would otherwise pull every sibling
+pillar's chunks into every dashboard route, converging each to the
+same ~342–359K encoded union set), and the first pointerenter/focus
+on an item fires `router.prefetch(href)` (`useIntentPrefetch` in
+AppNav) — hover leads the click and focus leads the Enter press, so
+the sibling's RSC payload and chunks are in flight before navigation
+commits and nav latency is effectively unchanged. Measured on
+/dashboard/accounts: 204K encoded settled / 14 script requests
+(353–359K / 29–30 with viewport prefetch). The interaction-gated
+candidates are immaterial (CommandPalette ~2K gz).
+
+**Theme contract as-built (2026-07-20, ratified — identical across
 apparule, expendit and upstat).** The preference is tri-state
 light | dark | system: `ThemeProvider` persists it at `expendit.theme`
 ("light"/"dark"/"system" all stored explicitly; KEY ABSENT = dark,

--- a/web/e2e/seo.spec.ts
+++ b/web/e2e/seo.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 
 /**
  * SEO plumbing lock (fleet, 2026-07-21): sitemap + robots + canonical +
- * og/twitter card + product-branded icons.
+ * og/twitter card + product-branded icons + web app manifest.
  *
  * This spec is BYTE-IDENTICAL across apparule/expendit/upstat (tooling
  * canon) — per-product expectations live in the config below keyed by
@@ -151,4 +151,24 @@ test("icons are product-branded and distinct from the sibling products", async (
   const appleRes = await request.get(appleUrl.pathname + appleUrl.search);
   expect(appleRes.status()).toBe(200);
   expect(appleRes.headers()["content-type"]).toContain("image/png");
+});
+
+test("manifest is served with the product identity and resolvable icons", async ({
+  request,
+}) => {
+  const res = await request.get("/manifest.webmanifest");
+  expect(res.status()).toBe(200);
+  const manifest = (await res.json()) as {
+    name?: string;
+    icons?: { src: string }[];
+  };
+  // Identity: the manifest names this product, never a sibling's copy.
+  expect(manifest.name?.toLowerCase()).toContain(pkgName);
+  // Icons: at least one, and every declared asset actually resolves.
+  expect(manifest.icons?.length).toBeGreaterThan(0);
+  for (const icon of manifest.icons ?? []) {
+    const iconUrl = new URL(icon.src, product.base);
+    const iconRes = await request.get(iconUrl.pathname + iconUrl.search);
+    expect(iconRes.status(), `icon ${icon.src} must resolve`).toBe(200);
+  }
 });

--- a/web/e2e/skip-link.spec.ts
+++ b/web/e2e/skip-link.spec.ts
@@ -1,5 +1,5 @@
 // Skip link (fleet canon P15, 2026-07-21 a11y audit): every route's FIRST
-// Tab stop is a visually-hidden-until-focused "Skip to main content" link;
+// Tab stop is a visually-hidden-until-focused "Skip to content" link;
 // activating it moves focus into <main id="main" tabIndex={-1}>, past the
 // navigation chrome. Probe shape: load → Tab → link focused (and visible)
 // → Enter → activeElement is the main landmark.
@@ -18,7 +18,7 @@ const expectSkipLinkFlow = async (page: Page): Promise<void> => {
     window.scrollTo(0, 0);
   });
   await page.keyboard.press("Tab");
-  const link = page.getByRole("link", { name: "Skip to main content" });
+  const link = page.getByRole("link", { name: "Skip to content" });
   await expect(link).toBeFocused();
   await expect(link).toBeVisible();
 

--- a/web/src/app/dashboard/company/ratios/RatiosView.tsx
+++ b/web/src/app/dashboard/company/ratios/RatiosView.tsx
@@ -66,6 +66,31 @@ const displayValue = (result: RatioResult, currency: string): string => {
   }
 };
 
+/**
+ * Delta magnitude in the metric's own display style (the displayValue
+ * table); RatioGauge renders the sign and colors by it, so this is the
+ * magnitude only.
+ */
+const displayDelta = (
+  result: RatioResult,
+  currency: string,
+): string | undefined => {
+  if (result.period_delta === null) return undefined;
+  const magnitude = Math.abs(result.period_delta);
+  switch (result.display) {
+    case "percent":
+      return formatPercent(magnitude);
+    case "currency":
+      return formatMoney(magnitude, currency, { decimals: 0 });
+    case "days":
+      return `${Math.round(magnitude)} days`;
+    case "months":
+      return `${magnitude.toFixed(1)} mo`;
+    default:
+      return formatRatio(magnitude);
+  }
+};
+
 /** Gauge domain from the registry band (healthy range centered). */
 const gaugeDomain = (
   key: string,
@@ -253,6 +278,7 @@ export const RatiosView: React.FC = () => {
                             status={result.status}
                             band={result.status === "na" ? null : domain.band}
                             delta={result.period_delta ?? undefined}
+                            deltaDisplay={displayDelta(result, currency)}
                             // Name the prior period ("vs FY2024"), not a
                             // generic "vs prior period" (B6b frame copy).
                             deltaCaption={

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -52,11 +52,14 @@
   --text-2xl--line-height: 2rem;
   --text-4xl--line-height: 2.5rem;
 
-  /* radii — product radius is 6px (`rounded` → --radius); rounded-lg is
-     the marketing hero device frame; rounded-full for pills/discs/dots. */
+  /* radii — product radius is 6px (`rounded` → --radius); rounded-md is
+     the same 6px under the fleet-shared utility name (byte-identical
+     shared files like SkipLink use it); rounded-lg is the marketing hero
+     device frame; rounded-full for pills/discs/dots. */
   --radius-*: initial;
   --radius: var(--radius);
   --radius-none: 0;
+  --radius-md: var(--radius);
   --radius-lg: 0.5rem;
   --radius-full: 9999px;
 

--- a/web/src/app/manifest.ts
+++ b/web/src/app/manifest.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from "next";
+
+/**
+ * Web app manifest (SEO plumbing, fleet canon): product identity for
+ * installs/add-to-home-screen, served at /manifest.webmanifest. Identity
+ * mirrors the root layout metadata; colors are the design tokens
+ * (design.md §2) — background is the default dark canvas (`--color-bg`,
+ * key-absent theme default), theme the Expendit orange (`--color-accent`).
+ * Icons are the committed brand assets from
+ * scripts/generate-brand-assets.mjs.
+ */
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Expendit",
+    short_name: "Expendit",
+    description: "Expense tracker App",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#0c0c0e",
+    theme_color: "#f46a1f",
+    icons: [
+      {
+        src: "/favicon.ico",
+        sizes: "16x16 32x32 48x48 256x256",
+        type: "image/x-icon",
+      },
+      { src: "/apple-icon.png", sizes: "180x180", type: "image/png" },
+    ],
+  };
+}

--- a/web/src/components/ui/AppNav.test.tsx
+++ b/web/src/components/ui/AppNav.test.tsx
@@ -4,6 +4,11 @@ import userEvent from "@testing-library/user-event";
 import { LayoutDashboard, ArrowLeftRight } from "lucide-react";
 import AppNav, { NavGroupLabel, NavItem } from "./AppNav";
 
+const prefetch = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ prefetch }),
+}));
+
 const nav = (collapsed: boolean, onCollapsedChange = vi.fn()) => (
   <AppNav
     collapsed={collapsed}
@@ -64,5 +69,16 @@ describe("AppNav / NavItem (design.md §8.2b)", () => {
       "href",
       "/dashboard/transactions",
     );
+  });
+
+  it("intent prefetch: first pointerenter fires router.prefetch, once", async () => {
+    prefetch.mockClear();
+    render(nav(false));
+    const link = screen.getByRole("link", { name: /Transactions/ });
+    await userEvent.hover(link);
+    await userEvent.unhover(link);
+    await userEvent.hover(link);
+    expect(prefetch).toHaveBeenCalledTimes(1);
+    expect(prefetch).toHaveBeenCalledWith("/dashboard/transactions");
   });
 });

--- a/web/src/components/ui/AppNav.tsx
+++ b/web/src/components/ui/AppNav.tsx
@@ -6,13 +6,33 @@
  * icon rail · org-switcher slot top.
  */
 
-import React, { createContext, useContext } from "react";
+import React, { createContext, useContext, useRef } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { cn } from "@/lib/cn";
 import Tag from "./Tag";
 
 const NavCollapsedContext = createContext(false);
+
+/**
+ * Intent-based prefetch (perf P13): the rail links every pillar, and App
+ * Router's default viewport prefetch pulled every sibling pillar's chunks
+ * into every dashboard route (the union set). `prefetch={false}` disables
+ * that pass entirely (Next 16 App Router: no hover fallback), so the first
+ * pointerenter/focus on an item calls `router.prefetch(href)` instead —
+ * hover leads the click and focus leads the Enter press, so navigation
+ * latency is unchanged while a cold route ships only its own chunks.
+ */
+const useIntentPrefetch = (href?: string) => {
+  const router = useRouter();
+  const fired = useRef(false);
+  return () => {
+    if (fired.current || !href) return;
+    fired.current = true;
+    router.prefetch(href);
+  };
+};
 
 export interface NavItemProps {
   icon: React.ComponentType<{ className?: string }>;
@@ -33,6 +53,7 @@ export const NavItem: React.FC<NavItemProps> = ({
   onClick,
 }) => {
   const collapsed = useContext(NavCollapsedContext);
+  const prefetchOnIntent = useIntentPrefetch(href);
   const className = cn(
     // text-left: buttons default to centered text, the kit is left-aligned.
     "group/nav-item relative flex w-full items-center gap-2.5 rounded px-2.5 py-1.5 text-left text-[13px] font-medium",
@@ -61,9 +82,12 @@ export const NavItem: React.FC<NavItemProps> = ({
     // identical to the plain anchor the kit was QA'd with.
     <Link
       href={href}
+      prefetch={false}
       aria-current={active ? "page" : undefined}
       aria-label={collapsed ? label : undefined}
       onClick={onClick}
+      onPointerEnter={prefetchOnIntent}
+      onFocus={prefetchOnIntent}
       className={className}
     >
       {content}

--- a/web/src/components/ui/RatioGauge.test.tsx
+++ b/web/src/components/ui/RatioGauge.test.tsx
@@ -97,4 +97,48 @@ describe("RatioGauge (design.md §8.2, MI-8)", () => {
     expect(delta).toHaveTextContent("+0.21 vs Q1");
     expect(delta).toHaveClass("text-income");
   });
+
+  it("formats a computed delta to 2dp — never the raw float — keeping the sign", () => {
+    render(
+      <RatioGauge
+        label="Current ratio"
+        value={3.05}
+        status="healthy"
+        delta={1.2254901960784315}
+        deltaCaption="vs FY2024"
+      />,
+    );
+    expect(screen.getByTestId("gauge-delta")).toHaveTextContent(
+      "+1.23 vs FY2024",
+    );
+
+    render(
+      <RatioGauge
+        label="Quick ratio"
+        value={0.9}
+        status="warning"
+        delta={-0.5}
+        deltaCaption="vs FY2024"
+      />,
+    );
+    const negative = screen.getAllByTestId("gauge-delta")[1];
+    expect(negative).toHaveTextContent("−0.50 vs FY2024");
+    expect(negative).toHaveClass("text-expense");
+  });
+
+  it("deltaDisplay keeps the metric's own style (days stay integer)", () => {
+    render(
+      <RatioGauge
+        label="Receivables days"
+        value={38}
+        status="healthy"
+        delta={-3.2254901960784315}
+        deltaDisplay="3 days"
+        deltaCaption="vs FY2024"
+      />,
+    );
+    expect(screen.getByTestId("gauge-delta")).toHaveTextContent(
+      "−3 days vs FY2024",
+    );
+  });
 });

--- a/web/src/components/ui/RatioGauge.tsx
+++ b/web/src/components/ui/RatioGauge.tsx
@@ -14,6 +14,7 @@
 import React, { useEffect, useState } from "react";
 import type { RatioStatus } from "@/models";
 import { cn } from "@/lib/cn";
+import { formatRatio } from "@/lib/format";
 import { useReducedMotion } from "@/lib/use-reduced-motion";
 import Tooltip from "./Tooltip";
 
@@ -31,6 +32,12 @@ export interface RatioGaugeProps {
   band?: { from: number; to: number } | null;
   /** Delta vs previous period (Figma: "+0.21 vs Q1"). */
   delta?: number;
+  /**
+   * Preformatted delta magnitude in the metric's own display style
+   * (e.g. "3 days", "1.2%"); the sign stays the gauge's. Defaults to
+   * the Figma 2dp ratio convention ("0.21").
+   */
+  deltaDisplay?: string;
   deltaCaption?: string;
   /** Caption line; defaults to the benchmark range when band is on. */
   caption?: string;
@@ -83,6 +90,7 @@ export const RatioGauge: React.FC<RatioGaugeProps> = ({
   status,
   band = null,
   delta,
+  deltaDisplay,
   deltaCaption,
   caption,
   formula,
@@ -192,7 +200,9 @@ export const RatioGauge: React.FC<RatioGaugeProps> = ({
           )}
         >
           {deltaPositive ? "+" : "−"}
-          {Math.abs(delta)}
+          {/* Never the raw float (a computed delta is full-precision —
+              "+1.2254901960784315"); 2dp per the Figma delta line. */}
+          {deltaDisplay ?? formatRatio(Math.abs(delta))}
           {deltaCaption ? ` ${deltaCaption}` : null}
         </div>
       ) : null}

--- a/web/src/components/ui/SkipLink.test.tsx
+++ b/web/src/components/ui/SkipLink.test.tsx
@@ -5,7 +5,7 @@ import SkipLink from "./SkipLink";
 describe("SkipLink (fleet canon P15)", () => {
   it("targets #main and stays visually hidden until focused", () => {
     render(<SkipLink />);
-    const link = screen.getByRole("link", { name: "Skip to main content" });
+    const link = screen.getByRole("link", { name: "Skip to content" });
     expect(link).toHaveAttribute("href", "#main");
     // Hidden-until-focus construction: sr-only with a focus escape hatch.
     expect(link.className).toContain("sr-only");

--- a/web/src/components/ui/SkipLink.tsx
+++ b/web/src/components/ui/SkipLink.tsx
@@ -1,23 +1,16 @@
-/**
- * SkipLink — fleet canon (a11y audit 2026-07-21, P15): the first
- * focusable element on every route; visually hidden until keyboard
- * focus, then a small pill at the top-left. Targets the page's
- * `<main id="main" tabIndex={-1}>` so activation moves focus into the
- * content past the navigation chrome.
- *
- * Construction is shared across the fleet — tokens only, no
- * product-specific classes — so the file stays byte-identical in every
- * product.
- */
-
+// SkipLink — fleet canon (SKILL.md a11y closeout canons, 2026-07-21).
+// First focusable on every route; visually hidden until keyboard focus;
+// the pill appearing on :focus IS the focus indication. Byte-identical
+// across products (shared-files canon) — utility names only, no
+// product-specific tokens.
 import React from "react";
 
-export const SkipLink: React.FC = () => (
+const SkipLink: React.FC = () => (
   <a
     href="#main"
-    className="sr-only focus:not-sr-only focus:fixed focus:left-2 focus:top-2 focus:z-toast focus:rounded focus:border focus:border-border focus:bg-bg focus:px-3 focus:py-2 focus:text-[13px] focus:font-medium focus:text-text focus:outline-none focus:ring-2 focus:ring-accent"
+    className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:block focus:rounded-md focus:border focus:border-border focus:bg-bg-elev focus:px-4 focus:py-2 focus:text-[13px] focus:font-medium focus:text-text"
   >
-    Skip to main content
+    Skip to content
   </a>
 );
 


### PR DESCRIPTION
Closes out expendit's deferred items from the fleet deferral register, plus one adjudicated rendering bug.

## Rail prefetch goes intent-based (revises the P13 as-designed decision)
The nav rail's Links prefetched every pillar on viewport entry, converging every dashboard route to the same ~342–359K encoded union set. The rail now sets `prefetch={false}` and fires `router.prefetch(href)` on the first pointerenter/focus per item (`useIntentPrefetch` in AppNav). Next 16.2.10's `Link` has no native hover-prefetch mode (checked against the installed types: `prefetch?: boolean | 'auto' | null`, and `false` disables the hover pass too), so the manual intent handlers are the mechanism.

Measured (CDP-recorded encoded transfer, TEST_MODE prod build, cold cache, `/dashboard/accounts`):

| | settled JS | script requests | all requests |
|---|---|---|---|
| before | 353–359 KiB | 29–30 | 77–83 |
| after | **204 KiB** | **14** | 22 |

Hover-fire evidence: pointerenter on the rail's "Transactions" item fires 6 RSC payload fetches (`/dashboard/transactions?_rsc=…`) + 2 sibling script chunks (9.0K + 21.1K) — the prefetch is in flight before the click commits. `docs/web-implementation.md`'s bundle-truth paragraph now describes the intent-based system (and restores the theme-contract header line that had been truncated onto the audit paragraph).

## Web app manifest
`app/manifest.ts` — layout-metadata identity (Expendit / "Expense tracker App"), token colors (dark canvas `#0c0c0e` background, accent `#f46a1f` theme), committed brand icons (favicon.ico 16–256, apple-icon.png 180×180). The fleet `seo.spec.ts` gains the generic manifest lock (200 + product name + every declared icon resolves) — coordinated with the upstat lane for byte-parity.

## SkipLink byte-parity
`SkipLink.tsx` replaced with the fleet-canonical file, byte-for-byte (sha256 `907bb788aa625c9963cf26fe8ffe18dcb455c5c09b7a79a4456d32100942a426`). Consumers already used the default export; unit + e2e locks follow the "Skip to content" name. `@theme` gains `--radius-md` (= the 6px product radius) so the canon's `rounded-md` compiles under the pruned radius namespace — all eight `focus:*` utilities verified present in the built CSS.

## RatioGauge delta formatting (scope addition)
The delta line rendered `Math.abs(delta)` unformatted ("+1.2254901960784315 vs FY2024" on the live ratios view). Now defaults to the canonical 2dp (`formatRatio`), sign preserved; new `deltaDisplay` prop lets RatiosView keep each metric's own style via a `displayDelta` mirror of its `displayValue` table (days stay integer). Unit locks added.

## Gates
- lint (prettier + eslint + boundaries): clean
- typecheck: clean
- vitest: 93 files / 480 tests passed
- Playwright, CI mode against the TEST_MODE prod build on port 4444: **89/89 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)