### PR TITLE
fix(web): demo embeds highlight their own surface in the nav rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   sign-in/sign-up hooks.
 
 ### Fixed
+- Demo embeds highlight the surface they depict in the nav rail (Overview /
+  Imports / Tax center) instead of always marking Overview active — canvas
+  parity for the hero and walkthrough thumbs (#265).
 
 - Ratio gauges format the period delta (2dp ratio convention, or the
   metric's own style — days stay integer) instead of printing the raw

--- a/web/src/components/home/embeds.tsx
+++ b/web/src/components/home/embeds.tsx
@@ -91,20 +91,22 @@ const TXN_COLUMNS = [
 
 export { TXN_COLUMNS };
 
-const NAV = (
+// Each embed depicts a different surface, so its rail highlights that
+// surface (canvas parity — the A5a thumbs highlight per-surface nav).
+const navFor = (active: string) => (
   <AppNav
     orgSwitcher={<OrgSwitcher orgs={EMBED_ORGS} currentOrgId="org-cuesoft" />}
   >
-    <NavItem icon={LayoutDashboard} label="Overview" active />
+    <NavItem icon={LayoutDashboard} label="Overview" active={active === "Overview"} />
     <NavItem icon={ArrowLeftRight} label="Transactions" />
-    <NavItem icon={Upload} label="Imports" />
+    <NavItem icon={Upload} label="Imports" active={active === "Imports"} />
     <NavItem icon={Landmark} label="Accounts" />
     <NavItem icon={FileText} label="Reports" />
     <NavGroupLabel>Company</NavGroupLabel>
     <NavItem icon={FileSpreadsheet} label="Statements" />
     <NavItem icon={Gauge} label="Ratios" badgeCount={3} />
     <NavGroupLabel>Taxes</NavGroupLabel>
-    <NavItem icon={Calculator} label="Tax center" />
+    <NavItem icon={Calculator} label="Tax center" active={active === "Tax center"} />
     <NavItem icon={TagIcon} label="Categories" />
     <NavItem icon={Settings} label="Settings" />
   </AppNav>
@@ -199,7 +201,7 @@ export const DashboardEmbed: React.FC = () => {
       className="flex h-full w-full overflow-hidden bg-bg text-left"
       style={{ width: DASHBOARD_EMBED_WIDTH, height: DASHBOARD_EMBED_HEIGHT }}
     >
-      {NAV}
+      {navFor("Overview")}
       <div className="min-w-0 flex-1 space-y-4 overflow-hidden p-5">
         <div className="flex items-center justify-between gap-4">
           <h3 className="text-lg font-semibold tracking-tight text-text">
@@ -368,7 +370,7 @@ export const ImportReviewEmbed: React.FC = () => {
       className="flex h-full w-full overflow-hidden bg-bg text-left"
       style={{ width: IMPORT_EMBED_WIDTH, height: IMPORT_EMBED_HEIGHT }}
     >
-      {NAV}
+      {navFor("Imports")}
       <div className="min-w-0 flex-1 space-y-3 overflow-hidden p-5">
         <StagedReviewHeader importCount={209} duplicateCount={5} />
         <div>
@@ -421,7 +423,7 @@ export const TaxCenterEmbed: React.FC = () => (
     className="flex h-full w-full overflow-hidden bg-bg text-left"
     style={{ width: TAX_EMBED_WIDTH, height: TAX_EMBED_HEIGHT }}
   >
-    {NAV}
+    {navFor("Tax center")}
     <div className="min-w-0 flex-1 space-y-4 overflow-hidden p-5">
       <div className="flex items-center justify-between gap-4">
         <h3 className="text-lg font-semibold tracking-tight text-text">

--- a/web/src/components/home/embeds.tsx
+++ b/web/src/components/home/embeds.tsx
@@ -97,7 +97,11 @@ const navFor = (active: string) => (
   <AppNav
     orgSwitcher={<OrgSwitcher orgs={EMBED_ORGS} currentOrgId="org-cuesoft" />}
   >
-    <NavItem icon={LayoutDashboard} label="Overview" active={active === "Overview"} />
+    <NavItem
+      icon={LayoutDashboard}
+      label="Overview"
+      active={active === "Overview"}
+    />
     <NavItem icon={ArrowLeftRight} label="Transactions" />
     <NavItem icon={Upload} label="Imports" active={active === "Imports"} />
     <NavItem icon={Landmark} label="Accounts" />
@@ -106,7 +110,11 @@ const navFor = (active: string) => (
     <NavItem icon={FileSpreadsheet} label="Statements" />
     <NavItem icon={Gauge} label="Ratios" badgeCount={3} />
     <NavGroupLabel>Taxes</NavGroupLabel>
-    <NavItem icon={Calculator} label="Tax center" active={active === "Tax center"} />
+    <NavItem
+      icon={Calculator}
+      label="Tax center"
+      active={active === "Tax center"}
+    />
     <NavItem icon={TagIcon} label="Categories" />
     <NavItem icon={Settings} label="Settings" />
   </AppNav>


### PR DESCRIPTION
embeds.tsx marked Overview active in all three demo embeds; each embed now highlights the surface it depicts (Overview / Imports / Tax center) — canvas is design truth here (the A5a thumbs highlight per-surface nav). Found during the hero-embed narrative sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)