### PR TITLE
fix(web): session-restore gate — /signin reverse guard + failed-restore net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   as signed out instead of stranding the auth guards at their loading
   state; the provider contract (return `null`, never throw) is documented
   on `AuthProvider.currentUser()`, and the e2e cold-start pair locks both
-  directions.
+  directions (#266).
 - Demo embeds highlight the surface they depict in the nav rail (Overview /
   Imports / Tax center) instead of always marking Overview active — canvas
   parity for the hero and walkthrough thumbs (#265).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   sign-in/sign-up hooks.
 
 ### Fixed
+- Session-restore gate hardening (flows/auth.md §2, ratified 2026-07-22):
+  `/signin` gains the reverse guard — a signed-in visitor is replaced to
+  `/dashboard` and never sees the CTA — and a failed session read now reads
+  as signed out instead of stranding the auth guards at their loading
+  state; the provider contract (return `null`, never throw) is documented
+  on `AuthProvider.currentUser()`, and the e2e cold-start pair locks both
+  directions.
 - Demo embeds highlight the surface they depict in the nav rail (Overview /
   Imports / Tax center) instead of always marking Overview active — canvas
   parity for the hero and walkthrough thumbs (#265).

--- a/docs/flows/auth.md
+++ b/docs/flows/auth.md
@@ -25,6 +25,15 @@ tokens (both cataloged in engineering.md §1). Upsert `USER` by
 throttling replaces the Redis auth rate limiters; Redis limits remain for
 non-auth routes.
 
+**Session restore [Decided 2026-07-22, platform-neutral]**: restore
+resolves **before either surface routes** — the web resolves the
+provider's restored session before dashboard routes render (the
+`DashboardShell` gate), and the mobile app, when its phase opens, runs
+the same silent restore behind its boot gate. A failed restore reads as
+**signed out** (never an error interstitial) — providers resolve `null`
+and never throw past the seam; a signed-in user never sees the auth
+screen (`/signin` carries the reverse guard).
+
 ## 3. Migration of legacy password users
 
 ```mermaid

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -621,6 +621,18 @@ stubs — they 404 on the branded page (route canon, above): the only
 routes are `/`, `/signin`, `/onboarding`, and `/dashboard/<area>`
 (X-1, flows/auth.md §1).
 
+**Session gate (flows/auth.md §2, ratified 2026-07-22).** Restore
+resolves before either surface routes: `DashboardShell` holds rendering
+behind `useRequireAuth` (nothing dashboard-side paints until the session
+read settles; signed-out visitors replace to `/signin`), and `/signin`
+carries the reverse guard — `SignInGate` wraps the screen content
+(`useRedirectAuthed`; the page stays a server component with its
+metadata) so a signed-in visitor is replaced to `/dashboard` and never
+sees the CTA, with an aria-busy hold while the read is in flight. A
+failed restore reads as signed out: providers return `null`, never throw
+(the `AuthProvider.currentUser()` contract), and the controllers catch
+as a second net. Locked by the e2e cold-start pair in `signin.spec.ts`.
+
 ## 5. TEST_MODE contract
 
 `NEXT_PUBLIC_TEST_MODE=1` (build-time inlined, like all `NEXT_PUBLIC_*` —

--- a/web/e2e/signin.spec.ts
+++ b/web/e2e/signin.spec.ts
@@ -39,6 +39,40 @@ test("TEST_MODE: Continue with Google goes straight to /dashboard", async ({
   await expect(page).toHaveURL(/\/dashboard$/);
 });
 
+/**
+ * Cold-start matrix (flows/auth.md §2, ratified 2026-07-22): restore
+ * resolves before either surface routes, and each surface guards its
+ * wrong-state visitor.
+ */
+test("cold start signed out: /dashboard replaces to /signin with no dashboard paint", async ({
+  page,
+}) => {
+  await page.goto("/dashboard");
+  await page.waitForURL("**/signin");
+  await expect(
+    page.getByRole("button", { name: "Continue with Google" }),
+  ).toBeVisible();
+  // The dashboard never painted content for the signed-out visitor.
+  await expect(page.getByTestId("overview-mid-band")).toHaveCount(0);
+});
+
+test("reverse guard: a signed-in visit to /signin is replaced to /dashboard", async ({
+  page,
+}) => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: "Continue with Google" }).click();
+  await page.waitForURL("**/dashboard", { timeout: 15_000 });
+
+  // Same tab (the TEST_MODE session is sessionStorage-held, per-tab):
+  // /signin is not a reachable surface while signed in — the SignInGate
+  // replaces to the app and the CTA never paints.
+  await page.goto("/signin");
+  await page.waitForURL("**/dashboard");
+  await expect(
+    page.getByRole("button", { name: "Continue with Google" }),
+  ).toHaveCount(0);
+});
+
 test("retired password routes 404 on the branded page", async ({ page }) => {
   for (const path of ["/signup", "/forgot-password", "/change-password"]) {
     const response = await page.goto(path);

--- a/web/src/app/signin/SignInGate.test.tsx
+++ b/web/src/app/signin/SignInGate.test.tsx
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import SignInGate from "./SignInGate";
+import { TEST_USER } from "@/auth";
+
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push: vi.fn(), prefetch: vi.fn() }),
+}));
+
+describe("SignInGate (flows/auth.md §2 — the /signin reverse guard)", () => {
+  beforeEach(() => {
+    replace.mockClear();
+    window.sessionStorage.clear();
+  });
+
+  it("holds an aria-busy gate on first paint while the session read is in flight", () => {
+    render(
+      <SignInGate>
+        <p>cta</p>
+      </SignInGate>,
+    );
+    // Synchronous first paint — the read microtask hasn't resolved yet:
+    // never the CTA.
+    expect(screen.getByTestId("signin-gate")).toBeInTheDocument();
+    expect(screen.queryByText("cta")).not.toBeInTheDocument();
+  });
+
+  it("renders the screen for a signed-out visitor", async () => {
+    render(
+      <SignInGate>
+        <p>cta</p>
+      </SignInGate>,
+    );
+    expect(await screen.findByText("cta")).toBeInTheDocument();
+    expect(screen.queryByTestId("signin-gate")).not.toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("replaces a signed-in visitor to /dashboard without ever painting the CTA", async () => {
+    window.sessionStorage.setItem(
+      "expendit.test-session",
+      JSON.stringify(TEST_USER),
+    );
+    render(
+      <SignInGate>
+        <p>cta</p>
+      </SignInGate>,
+    );
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/dashboard"));
+    expect(screen.queryByText("cta")).not.toBeInTheDocument();
+    expect(screen.getByTestId("signin-gate")).toBeInTheDocument();
+  });
+});

--- a/web/src/app/signin/SignInGate.tsx
+++ b/web/src/app/signin/SignInGate.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+/**
+ * SignInGate — the /signin reverse guard (flows/auth.md §2, ratified
+ * 2026-07-22: restore resolves before either surface routes; a signed-in
+ * user never sees the auth screen). Wraps the screen content so the page
+ * stays a server component (metadata intact): signed in → replace to
+ * /dashboard (useRedirectAuthed), session read in flight → an aria-busy
+ * hold (per-tab sessionStorage, one microtask — a negligible beat); only
+ * signed out renders the CTA. DashboardShell holds the mirror-image gate
+ * (useRequireAuth).
+ */
+
+import React from "react";
+import { useRedirectAuthed } from "@/controllers/use-auth";
+
+const SignInGate: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user, checked } = useRedirectAuthed();
+
+  if (!checked || user) {
+    // Covers both the in-flight read and the signed-in replace-in-progress.
+    return (
+      <div
+        aria-busy="true"
+        data-testid="signin-gate"
+        className="flex min-h-screen items-center justify-center bg-bg"
+      >
+        <span className="sr-only">Loading…</span>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+};
+
+export default SignInGate;

--- a/web/src/app/signin/page.tsx
+++ b/web/src/app/signin/page.tsx
@@ -1,14 +1,22 @@
 import React from "react";
+import SignInGate from "./SignInGate";
 import SigninView from "./SigninView";
 
-// X-1: the single auth screen — Google-only (flows/auth.md §1).
+// X-1: the single auth screen — Google-only (flows/auth.md §1). SignInGate
+// is the flows/auth.md §2 reverse guard: a signed-in visitor is replaced
+// to /dashboard and never sees this screen; the page stays a server
+// component (metadata intact).
 export const metadata = {
   title: "Sign in — Expendit",
   description: "Sign in to Expendit with Google",
 };
 
 const SignIn = () => {
-  return <SigninView />;
+  return (
+    <SignInGate>
+      <SigninView />
+    </SignInGate>
+  );
 };
 
 export default SignIn;

--- a/web/src/auth/test-mode-provider.test.ts
+++ b/web/src/auth/test-mode-provider.test.ts
@@ -23,6 +23,13 @@ describe("TestModeAuthProvider (X-1, TEST_MODE)", () => {
     await provider.signOut();
   });
 
+  it("reads a corrupted session as signed out (flows/auth.md §2: null, never throw)", () => {
+    window.sessionStorage.setItem("expendit.test-session", "{not json");
+    const provider = new TestModeAuthProvider();
+    expect(provider.currentUser()).toBeNull();
+    window.sessionStorage.removeItem("expendit.test-session");
+  });
+
   it("sign-out clears both the session and the legacy flag", async () => {
     const provider = new TestModeAuthProvider();
     await provider.signInWithGoogle();

--- a/web/src/auth/types.ts
+++ b/web/src/auth/types.ts
@@ -13,7 +13,14 @@ export interface AuthUser {
 }
 
 export interface AuthProvider {
-  /** Synchronous snapshot of the current session (null = signed out). */
+  /**
+   * Synchronous snapshot of the current session (null = signed out).
+   * Contract (flows/auth.md §2, ratified 2026-07-22): a failed session
+   * read reads as **signed out** — implementations return `null` on any
+   * failure and MUST NOT throw; the controllers still catch as a second
+   * net so a misbehaving provider can never strand a guard at its
+   * loading state.
+   */
   currentUser(): AuthUser | null;
   /** The single X-1 sign-in path. Resolves with the signed-in user. */
   signInWithGoogle(): Promise<AuthUser>;

--- a/web/src/controllers/index.ts
+++ b/web/src/controllers/index.ts
@@ -1,4 +1,8 @@
-export { useAuthController, useRequireAuth } from "./use-auth";
+export {
+  useAuthController,
+  useRedirectAuthed,
+  useRequireAuth,
+} from "./use-auth";
 export { useOrgController } from "./use-org";
 export { OrgProvider, useOrg } from "./org-context";
 export { useOverviewController } from "./use-overview";

--- a/web/src/controllers/use-auth.test.tsx
+++ b/web/src/controllers/use-auth.test.tsx
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import type { AuthUser } from "@/auth/types";
+import { useRedirectAuthed, useRequireAuth } from "./use-auth";
+
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push: vi.fn(), prefetch: vi.fn() }),
+}));
+
+// A provider that violates its own contract (auth/types.ts: return null,
+// never throw) — the controllers' second net must map it to signed out
+// (flows/auth.md §2), never a stranded loading state.
+vi.mock("@/auth", () => ({
+  getAuthProvider: () => {
+    throw new Error("restore exploded");
+  },
+  resetAuthProvider: vi.fn(),
+}));
+
+describe("session-read failure net (flows/auth.md §2)", () => {
+  beforeEach(() => {
+    replace.mockClear();
+  });
+
+  it("useRequireAuth: a throwing provider reads as signed out → /signin", async () => {
+    let state: { user: AuthUser | null; checked: boolean } = {
+      user: null,
+      checked: false,
+    };
+    const Probe = () => {
+      state = useRequireAuth();
+      return null;
+    };
+    render(<Probe />);
+    await waitFor(() => expect(state.checked).toBe(true));
+    expect(state.user).toBeNull();
+    expect(replace).toHaveBeenCalledWith("/signin");
+  });
+
+  it("useRedirectAuthed: a throwing provider reads as signed out → the CTA renders", async () => {
+    let state: { user: AuthUser | null; checked: boolean } = {
+      user: null,
+      checked: false,
+    };
+    const Probe = () => {
+      state = useRedirectAuthed();
+      return null;
+    };
+    render(<Probe />);
+    await waitFor(() => expect(state.checked).toBe(true));
+    expect(state.user).toBeNull();
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/controllers/use-auth.ts
+++ b/web/src/controllers/use-auth.ts
@@ -20,6 +20,20 @@ export interface AuthController {
   signOut: () => Promise<void>;
 }
 
+/**
+ * Session read with the flows/auth.md §2 failure net: a failed restore
+ * reads as **signed out** — a throwing provider can never strand a guard
+ * at its loading state. Providers already contract to return null
+ * (auth/types.ts); this is the second net.
+ */
+const readSession = (): AuthUser | null => {
+  try {
+    return getAuthProvider().currentUser();
+  } catch {
+    return null;
+  }
+};
+
 export const useAuthController = (): AuthController => {
   const router = useRouter();
   const [user, setUser] = useState<AuthUser | null>(null);
@@ -31,7 +45,7 @@ export const useAuthController = (): AuthController => {
     // (react-hooks/set-state-in-effect) and off the hydration pass.
     let cancelled = false;
     queueMicrotask(() => {
-      if (!cancelled) setUser(getAuthProvider().currentUser());
+      if (!cancelled) setUser(readSession());
     });
     return () => {
       cancelled = true;
@@ -77,10 +91,43 @@ export const useRequireAuth = (): {
     let cancelled = false;
     queueMicrotask(() => {
       if (cancelled) return;
-      const current = getAuthProvider().currentUser();
+      const current = readSession();
       setUser(current);
       setChecked(true);
       if (!current) router.replace("/signin");
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  return { user, checked };
+};
+
+/**
+ * Reverse guard for /signin (flows/auth.md §2, ratified 2026-07-22): a
+ * signed-in user never sees the auth screen — the gate replaces to
+ * /dashboard. `checked` distinguishes "still reading the session" from
+ * "signed out" so the view (SignInGate) can hold its loading state; a
+ * failed read is signed out (readSession), which lands on the sign-in
+ * screen itself.
+ */
+export const useRedirectAuthed = (): {
+  user: AuthUser | null;
+  checked: boolean;
+} => {
+  const router = useRouter();
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      const current = readSession();
+      setUser(current);
+      setChecked(true);
+      if (current) router.replace("/dashboard");
     });
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Summary

Canon sweep from apparule (org parity canon #4 + flows/auth.md §2, ratified 2026-07-22): tri-state session restore resolves **before either surface routes**; a failed restore reads as **signed out**; a signed-in user never sees the auth screen.

**Audit found**
- `/signin` had **no reverse guard** — a signed-in visitor saw the CTA.
- `useRequireAuth`/`useAuthController` had **no failure net**: a throwing `currentUser()` stranded the dashboard gate at `checked=false` (permanent blank), and the provider contract was undocumented.
- The dashboard-side gate itself was present and correct (`DashboardShell` → `useRequireAuth`).

**Fixes**
- `SignInGate` client wrapper on `/signin` (page stays a server component, metadata intact): signed in → `router.replace("/dashboard")` via the new `useRedirectAuthed` controller; read-in-flight → aria-busy hold; signed out → the CTA.
- `readSession` try/catch second net on every controller session read; contract documented on `AuthProvider.currentUser()` (return `null`, never throw).
- e2e cold-start pair locks both directions (signed-out `/dashboard` → `/signin` with no dashboard paint; signed-in `/signin` → `/dashboard`); unit locks for the gate, the net, and the corrupted-session read.
- Docs: flows/auth.md §2 platform-neutral ruling; web-implementation.md §4 session-gate note; CHANGELOG (Fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)