### PR TITLE
docs: currency pass — stale claims vs shipped system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Phase 3 collapses into the ratified Mono/Firebase state (no longer
   blocked by D1); `api.md` documents `GET /ai/summary/:userID`;
   `flows/auth.md` future-tenses the credential-system retirement;
-  `design.md` drops stale rename parentheticals.
+  `design.md` drops stale rename parentheticals (#267).
 
 - Session-restore gate hardening (flows/auth.md §2, ratified 2026-07-22):
   `/signin` gains the reverse guard — a signed-in visitor is replaced to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   sign-in/sign-up hooks.
 
 ### Fixed
+- Docs currency pass: `web/README.md`'s test command and app-area list now
+  match the shipped app (Vitest/Playwright, not retired Jest); the
+  `web/src/legacy/` and `mobile/` claims in `web-implementation.md` describe
+  the standing guardrail without asserting trees that aren't there yet;
+  `pages.md`'s A1 nav copy matches `MarketingNav`/`HomeView`; `roadmap.md`'s
+  Phase 3 collapses into the ratified Mono/Firebase state (no longer
+  blocked by D1); `api.md` documents `GET /ai/summary/:userID`;
+  `flows/auth.md` future-tenses the credential-system retirement;
+  `design.md` drops stale rename parentheticals.
+
 - Session-restore gate hardening (flows/auth.md §2, ratified 2026-07-22):
   `/signin` gains the reverse guard — a signed-in visitor is replaced to
   `/dashboard` and never sees the CTA — and a failed session read now reads

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,6 +54,12 @@ removes them from paths. **[Proposed]**)
 | `GET /report/chart/category/:userID` | totals by category |
 | `GET /report/chart/category/expenses/:userID` | expense breakdown by category |
 
+### AI
+
+| Method & path | Purpose |
+| --- | --- |
+| `GET /ai/summary/:userID` | protected; 3-month income/expense narrative summary (AI-generated when a key is configured, else a rule-based fallback) — registered directly in `api/common/cmd/server/main.go`, not a `router/*.go` file |
+
 ## 2. Target surface **[Proposed]** — deltas only, under `/api/v1`
 
 The v1 exercise is mostly *consolidation* (one signup path, JWT-scoped paths

--- a/docs/design.md
+++ b/docs/design.md
@@ -263,7 +263,7 @@ never on screens.
 | CategoryChip | confirmed / AI-suggested (✨) / editing (combobox open) |
 | AnomalyBadge | large_transaction / spending_spike / abnormal_category / duplicate_charge · inline / feed |
 | StatCard | with/without delta chip · with/without sparkline · loading (as built: a single loading variant, delta + sparkline off — 5 of 8 combos, matching row intent) |
-| TxnTableRow | default / hover (actions revealed — cluster docks at the description cell's right edge, MI-6) / selected / editing / staged-duplicate · density ×2 (renamed from `TxnTable row` — §8.1 naming standards) |
+| TxnTableRow | default / hover (actions revealed — cluster docks at the description cell's right edge, MI-6) / selected / editing / staged-duplicate · density ×2 |
 | UploadDropzone | idle / drag-over / per-file progress / AI-sweep / complete / error |
 | LinkAccountCard | pending / active (breathing dot) / reauth_required / degraded / paused |
 | RatioGauge | healthy / warning / critical / n-a ("missing input") · with/without benchmark band (as built: n-a ships band=off only — no benchmark band on missing input) |
@@ -339,7 +339,7 @@ never on screens.
 
 | Component | Variants × states |
 | --- | --- |
-| GoogleAuthButton | **blocking** · default / hover / pressed / loading / disabled · Google mark + "Continue with Google" (the single X-1 auth CTA) · theme ×2 (renamed from `AuthGoogleCTA` — §8.1 naming standards; canonical name in every product) |
+| GoogleAuthButton | **blocking** · default / hover / pressed / loading / disabled · Google mark + "Continue with Google" (the single X-1 auth CTA) · theme ×2 (canonical name in every product) |
 | MappingReviewRow | **blocking** · state: suggested / confirmed / unmapped · source text → mono canonical-key chip + confidence Tag (✨ n% / Confirmed / Unmapped <60%) + tabular amount (in build 2026-07-18 — the B6 mapping-review screen, flows/statement-mapping.md) |
 | MemberRow | **important** · avatar + name + email + role select + remove · default / hover / pending-invite / owner |
 | ImportJobRow | **important** · status: processing / completed / completed-empty / completed-bank / failed · counts + anomalies-found — as built: the source axis folds into status (`completed-bank` = bank_sync; processing/failed render as upload-source) |

--- a/docs/flows/auth.md
+++ b/docs/flows/auth.md
@@ -2,9 +2,10 @@
 
 > Implements decision X-1 as hardened 2026-07-16: **Google sign-in only** —
 > no username/password, product-wide. Firebase Auth on `sandbox-e306a`.
-> Replaces the entire local credential system (signup/signin/forgot/reset/
+> Will retire the entire local credential system (signup/signin/forgot/reset/
 > change-password in `user_controller.go` + their rate limiters and email
-> templates) after the migration window.
+> templates) at the migration window — the Go password system still ships
+> today.
 
 ## 1. Hard rule & enforcement
 

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -17,7 +17,7 @@ setup → Discord + GitHub + preview links → **Try Cloud** / **Self Host** CTA
 
 | # | Section | Content & components | Interactions |
 | --- | --- | --- | --- |
-| A1 | Nav | logo · Product · Solutions (Individuals/SMEs/Companies) · Docs (GitBook) · Community · GitHub badge · Sign in · **Try Cloud** | sticky; dark-on-light after hero scroll |
+| A1 | Nav | logo · Features · Pricing · Docs · GitHub badge (live star count) · ThemeToggle · Sign in · **Try Cloud** | sticky; dark-on-light after hero scroll |
 | A2 | Hero (dark editorial) | display-type H1 "Financial intelligence for modern growth"; sub; dual CTA **Try Cloud** / **Self Host**; hero visual: dashboard in device frame with animated categorization chips | chips animate once; pauses reduced-motion |
 | A3 | Logos/social proof strip | placeholder for case-study logos (PRD §6) | |
 | A4 | Product pillars | 3 editorial cards: **Statements → intelligence** (upload/link), **Company financials** (ratios), **Taxes** (calculate + file) | card hover: 2px lift + accent underline draw |
@@ -44,6 +44,9 @@ Events → Upstat (D2): `page_view`, `try_cloud_click`, `self_host_click`,
 **[Directive 2026-07-18 additions]**.
 
 ## Part B — Dashboard (app)
+
+Section headers below use `/<area>` shorthand for the real
+`/dashboard/<area>` routes (web-implementation.md §4 route map).
 
 Left nav groups **[Proposed]**: Overview · Transactions · Imports · Accounts
 (bank links) · Reports · **Company** (statements, ratios) · **Taxes** ·

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,17 +43,18 @@ met (downloadable summaries + cash movement).
 anomalies visible on the dashboard; categorization measurably improves from
 corrections.
 
-## Phase 3 — Ecosystem + acquisition channels
+## Phase 3 — Bank linking + identity
 
 | Item | Requirement | Notes |
 | --- | --- | --- |
+| Mono (E-1 ratified) link/sync/re-auth flows into the shared staged-review pipeline | BNK-001/002 | NG-first; Plaid layers on later for international (E-1) |
+| Firebase Google-only identity migration | E3-1, X-1 | `account.cuesoft.io` facade is a later cosmetic cutover — **not** blocked by D1 |
 | Upstat events: `upload_success`, `report_generation` | ECO-ANALYTICS | **Blocked by D2**; ship behind the same no-op client wrapper pattern as apparule |
-| `account.cuesoft.io` sign-in + user linking (migration per data-model.md §3) | ECO-AUTH | **Blocked by D1** |
 | Support routing to clients.cuesoft.io | ECO-SUPPORT | Link-outs |
-| Direct bank/SMS ingestion research spike | PRD §5 roadmap | Explicitly post-file-upload; regional aggregator landscape (e.g. Mono/Okra-class providers) is its own investigation |
 
-**Exit criteria:** ecosystem events flowing; central identity live with
-migration path proven; bank-integration decision documented.
+**Exit criteria:** bank linking live end-to-end (Mono connect → sync →
+staged review); identity migration shipped; ecosystem events flowing once
+D2 lands.
 
 ## Dependencies
 
@@ -67,21 +68,14 @@ migration path proven; bank-integration decision documented.
 
 Phases 0–1 close every **Must** with the least engineering (the engine already
 exists) and make the privacy story real before growth work; Phase 2 pays the
-scaling debt in the pipeline the PRD's traffic assumes; Phase 3 waits on
-external contracts (D1/D2) and the deliberately-deferred bank integration.
+scaling debt in the pipeline the PRD's traffic assumes; Phase 3 ships bank
+linking (Mono, E-1 ratified) and the identity migration (X-1) — neither waits
+on D1, and only the ecosystem-events row waits on D2.
 
 ---
 
-## Revision — scope expansion (2026-07-16)
+## Phase 4+ — Company financials, tax, mobile parity
 
-Phases 0–2 stand as written (trust surface → downloadables/rights → pipeline
-hardening). The expansion appends:
-
-- **Phase 3 (revised) — Bank linking + identity**: Mono (E-1 ratified)
-  link/sync/re-auth flows into the shared staged-review pipeline
-  (BNK-001/002); identity = Firebase Google-only migration (E3-1, X-1 — D1
-  does NOT block this; the facade is a later cosmetic cutover). Upstat events
-  move here unchanged.
 - **Phase 4 — Company financials**: org model migration (personal org
   auto-create), statement upload + line-item mapping review, ratio engine +
   trends (CMP-001…003).
@@ -91,5 +85,5 @@ hardening). The expansion appends:
 - **Phase 6 — Mobile parity** (receipt capture first) + Brex-system dashboard
   restyle completes (design.md rolls out progressively from Phase 3).
 
-Gates: aggregator + tax-jurisdiction decisions are Phase 3/5 entry criteria;
-company features require the org migration to ship first.
+Gates: the tax-jurisdiction decision (E-2) is Phase 5 entry criteria; company
+features require the org migration to ship first.

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -54,8 +54,10 @@
   `git mv`-ed into `web/src/legacy/` (structure preserved, excluded from
   build & routing) — live paths carry zero dead code; after the replacement
   passes QA + Playwright, the legacy subtree is deleted in a dedicated
-  `chore(web): retire legacy <area>` PR. No dead code outside `src/legacy/`,
-  ever; `src/legacy/` itself trends to empty. Expendit's application of the
+  `chore(web): retire legacy <area>` PR. No dead code lives outside
+  `src/legacy/`, ever — the eslint `no-restricted-imports` rule and
+  `scripts/check-boundaries.mjs` keep `legacy/` imports banned regardless of
+  whether the tree currently holds anything. Expendit's application of the
   policy: §8.
 - **Mobile responsiveness canon [Directive 2026-07-19]**: the home page and
   every dashboard route are fully responsive at 390 (768 sanity) — the
@@ -758,22 +760,25 @@ release.yml) reuses the same Playwright journeys **[Proposed]**.
 
 ## 8. Legacy quarantine (dead-code policy)
 
-The §1 policy, applied: **live paths carry zero dead code**, and
-`web/src/legacy/` + the boundary gates are the standing mechanism.
-`src/legacy/` is the quarantine tree — excluded from the TS build, lint,
-and both test runners, and unrouted by construction (App Router is
-filesystem-based; nothing under `src/legacy/` is a route). The gates hold
-in CI (`scripts/check-boundaries.mjs` + the eslint
-`no-restricted-imports` rules, both wired into `npm run lint`):
-**styled-kit imports (`@mui/*`, `@emotion/*`) fail repo-wide** — the
-packages left package.json with the MUI retirement — and live code never
-imports from `src/legacy/`. `src/legacy/` is **currently empty** — the
+The §1 policy, applied: **live paths carry zero dead code**.
+`web/src/legacy/` is the reserved quarantine path — excluded from the TS
+build, lint, and both test runners, and unrouted by construction (App
+Router is filesystem-based; nothing under `src/legacy/` would be a route)
+— standing ready for whenever a replacement needs it. The boundary gates
+are the standing mechanism that keep it that way regardless of whether the
+tree currently holds anything: `scripts/check-boundaries.mjs` + the eslint
+`no-restricted-imports` rules (both wired into `npm run lint`) fail
+**styled-kit imports (`@mui/*`, `@emotion/*`) repo-wide** — the packages
+left package.json with the MUI retirement — and ban live code from
+importing `src/legacy/`. The tree does not exist in the current repo — the
 app runs entirely on the token-layer registry (§1), and retired paths 404
 on the branded page rather than carrying redirect stubs forward (§4).
 
-The **mobile app is a later phase** (pages.md Part C): no `mobile/` tree
-exists yet, and that phase gets its own implementation standard —
-including its own application of the quarantine policy — when it opens.
+The **mobile app is a later phase** (pages.md Part C): `mobile/{flutter,
+android,ios}` are placeholder directories only (README.md repository
+structure) — no implementation exists yet, and that phase gets its own
+implementation standard — including its own application of the quarantine
+policy — when it opens.
 
 ## 9. Acceptance
 
@@ -789,7 +794,7 @@ including its own application of the quarantine policy — when it opens.
 - [ ] Views contain no fetch calls (MVC boundary enforced by review + lint
       rule)
 - [x] Styled-kit packages pruned from package.json; imports CI-gated
-      repo-wide; `src/legacy/` stays empty
+      repo-wide; `src/legacy/` does not exist in the current tree
 - [ ] Playwright §8.4 journeys green in CI, incl. the keyboard-first path
       (⌘K + table nav); merge-to-main never deploys (X-6)
 

--- a/web/README.md
+++ b/web/README.md
@@ -1,8 +1,8 @@
 # Expendit Web (`web`)
 
 Next.js 16 (App Router, TypeScript) front-end for the Expendit expense
-tracker: marketing site plus the authenticated app (expenses, income,
-categories, reports, imports, settings).
+tracker: marketing site plus the authenticated app (transactions, imports,
+accounts, reports, company, taxes, categories, settings).
 
 ## Run
 
@@ -21,5 +21,6 @@ npm run dev
 ## Test
 
 ```bash
-npx jest
+npm test
+npm run test:e2e
 ```


### PR DESCRIPTION
## Summary
- `web/README.md`: replaced the retired `npx jest` command with `npm test` (Vitest) + `npm run test:e2e` (Playwright), and corrected the app-area list to the shipped dashboard areas (transactions, imports, accounts, reports, company, taxes, categories, settings).
- `docs/web-implementation.md`: reworded the `web/src/legacy/` quarantine language (§1, §8, §9 acceptance) to describe the standing eslint `no-restricted-imports` + `check-boundaries.mjs` guardrail without asserting a tree that doesn't exist; fixed the false "no `mobile/` tree exists yet" claim — `mobile/{flutter,android,ios}` placeholder dirs exist (reconciled with root README.md's repository-structure phrasing).
- `docs/pages.md`: corrected A1 marketing-nav copy to match `MarketingNav`/`HomeView.tsx` (Features · Pricing · Docs · GitHub + ThemeToggle + Sign in + Try Cloud); added a one-line note at the top of Part B that section headers use `/<area>` shorthand for the real `/dashboard/<area>` routes.
- `docs/roadmap.md`: collapsed the pre-expansion Phase 3 ("Ecosystem + acquisition channels," undecided-aggregator research spike) into the ratified 2026-07-16 state — Mono is ratified (E-1), and ECO-AUTH/identity migration is not blocked by D1 (X-1 Firebase ratified), matching the Dependencies table. Folded the separate "Revision" appendix into the main phase list so Phases 0–6 read as one current plan.
- `docs/api.md`: added the `GET /ai/summary/:userID` row (§1), noting it's registered directly in `api/common/cmd/server/main.go`, not a `router/*.go` file.
- `docs/flows/auth.md`: future-tensed the credential-system retirement ("will retire … at the migration window … the Go password system still ships today") — verified `Signup`/`Login`/`ChangePassword`/`ForgotPassword`/`ResetPassword` still ship in `user_controller.go`.
- `docs/design.md`: dropped the "(renamed from …)" parentheticals for `TxnTableRow` and `GoogleAuthButton`, keeping canonical names only.
- One `CHANGELOG.md` entry under `[Unreleased] / Fixed` (docs currency pass).

## Discrepancies found vs. the adjudicated fix list
- `docs/architecture.md:93` does not reference `web/src/legacy/` at all — that line's "Legacy flat paths" phrase refers to retired **URL routes** (`/expense`, `/income`, …), a different, already-accurate concept (verified: those routes don't exist under `web/src/app`, and `next.config.ts` configures no redirects, so they do 404 as documented). Left unchanged.
- `docs/web-implementation.md:616`'s "Legacy flat paths" is the same URL-route concept, not the `src/legacy/` source tree — left unchanged for the same reason.

## Test plan
- [ ] Docs-only change; no build/test required. Reviewer spot-check: `web/package.json` scripts (`test`, `test:e2e`), `web/src/app/dashboard/*` areas, `api/common/cmd/server/main.go:46`, `docs/decisions.md` E-1/E-2 ratification, `user_controller.go` handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)