### PR TITLE
chore(web): wire eslint-plugin-testing-library per fleet shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   genuine findings it surfaced are fixed (`renderHook` results
   destructured in `use-saved-views.test.ts`, an empty-callback `act()`
   around a clipboard-promise flush replaced with a real fake-timer
-  advance in `CodeSnippet.test.tsx`).
+  advance in `CodeSnippet.test.tsx`) (#271).
 - Fleet-parity wave: mock server routes move under the versioned
   `/api/mock/v1/*` path (client base path, tests, e2e fixtures, and docs
   updated to match); `src/mocks/db.ts` renames to `store.ts`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Web eslint wires `eslint-plugin-testing-library` (flat/react preset)
+  over the co-located tests — it was declared as a dev dep but never
+  configured. `no-container`/`no-node-access` stay off (the
+  component-reuse policy builds visual components bespoke from the token
+  layer, so their tests assert non-semantic structure by design); the
+  genuine findings it surfaced are fixed (`renderHook` results
+  destructured in `use-saved-views.test.ts`, an empty-callback `act()`
+  around a clipboard-promise flush replaced with a real fake-timer
+  advance in `CodeSnippet.test.tsx`).
 - Fleet-parity wave: mock server routes move under the versioned
   `/api/mock/v1/*` path (client base path, tests, e2e fixtures, and docs
   updated to match); `src/mocks/db.ts` renames to `store.ts`;

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import testingLibrary from "eslint-plugin-testing-library";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -48,6 +49,22 @@ const eslintConfig = defineConfig([
           ],
         },
       ],
+    },
+  },
+  // Testing Library lint (org web standard): the flat/react preset, scoped
+  // to the co-located unit/component tests.
+  {
+    files: ["src/**/*.test.{ts,tsx}"],
+    ...testingLibrary.configs["flat/react"],
+    rules: {
+      ...testingLibrary.configs["flat/react"].rules,
+      // The component-reuse policy (web-implementation.md) builds all visual
+      // components bespoke from the token layer — their tests assert
+      // non-semantic structure (SVG geometry, token classes) that has no
+      // role/label to query, so container/node access is the intended
+      // pattern, not a smell.
+      "testing-library/no-container": "off",
+      "testing-library/no-node-access": "off",
     },
   },
 ]);

--- a/web/src/components/ui/CodeSnippet.test.tsx
+++ b/web/src/components/ui/CodeSnippet.test.tsx
@@ -107,8 +107,10 @@ describe("CodeSnippet (design.md §8.2b)", () => {
     const button = screen.getByRole("button", { name: "Copy code" });
     expect(button).toHaveAttribute("data-state", "idle");
     fireEvent.click(button);
+    // flush the clipboard promise (advancing by 0ms still steps through
+    // the pending microtask queue under fake timers).
     await act(async () => {
-      // flush the clipboard promise
+      await vi.advanceTimersByTimeAsync(0);
     });
     expect(writeText).toHaveBeenCalledWith("make run");
     expect(screen.getByRole("button", { name: "Copied" })).toHaveAttribute(

--- a/web/src/controllers/use-saved-views.test.ts
+++ b/web/src/controllers/use-saved-views.test.ts
@@ -25,15 +25,19 @@ describe("useSavedViewsController (B2 saved filter views)", () => {
   });
 
   it("scopes views to the org and removes them", async () => {
-    const first = renderHook(() => useSavedViewsController("org-a"));
+    const { result: first } = renderHook(() =>
+      useSavedViewsController("org-a"),
+    );
     act(() => {
-      first.result.current.save("A view", {});
+      first.current.save("A view", {});
     });
-    const second = renderHook(() => useSavedViewsController("org-b"));
-    await waitFor(() => expect(second.result.current.views).toHaveLength(0));
+    const { result: second } = renderHook(() =>
+      useSavedViewsController("org-b"),
+    );
+    await waitFor(() => expect(second.current.views).toHaveLength(0));
 
-    const id = first.result.current.views[0].id;
-    act(() => first.result.current.remove(id));
-    await waitFor(() => expect(first.result.current.views).toHaveLength(0));
+    const id = first.current.views[0].id;
+    act(() => first.current.remove(id));
+    await waitFor(() => expect(first.current.views).toHaveLength(0));
   });
 });


### PR DESCRIPTION
## Summary
- `eslint-plugin-testing-library` was declared as a web dev dep but never wired into `web/eslint.config.mjs` — adds the flat/react preset scoped to `src/**/*.test.{ts,tsx}`, matching the fleet shape apparule landed on `chore/fleet-parity-wave`.
- `testing-library/no-container` and `testing-library/no-node-access` are disabled with a documenting comment: the component-reuse policy builds visual components bespoke from the token layer, so their tests assert non-semantic structure (SVG geometry, token classes) by design.
- Genuine findings surfaced and fixed properly (no disable-comments needed):
  - `use-saved-views.test.ts`: two un-destructured `renderHook` results (`first`/`second`) renamed via destructuring (`render-result-naming-convention`).
  - `CodeSnippet.test.tsx`: an empty-callback `act()` used only to flush a clipboard promise replaced with a real fake-timer advance (`no-unnecessary-act`).
- `@testing-library/dom` was already present as a dev dep — no dependency changes needed.
- One `CHANGELOG.md` entry under `### Changed`.

## Test plan
- [x] `cd web && npm run lint` — clean (prettier, eslint, check:boundaries)
- [x] `cd web && npm test` — 95 test files / 486 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)